### PR TITLE
Update Mac instructions to use correct directory name.

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -32,7 +32,7 @@ Build Raven Core
 1. Clone the raven source code and cd into `raven`
 
         git clone https://github.com/RavenProject/Ravencoin
-        cd raven
+        cd Ravencoin
 
 2.  Build raven-core:
 


### PR DESCRIPTION
Trivial: Update Mac instructions to use correct directory name.

closes #9 