### PR TITLE
Disable the miner in the wallet by default

### DIFF
--- a/src/rpc/mining.h
+++ b/src/rpc/mining.h
@@ -10,7 +10,7 @@
 
 #include <univalue.h>
 
-static const bool DEFAULT_GENERATE = true;
+static const bool DEFAULT_GENERATE = false;
 static const int DEFAULT_GENERATE_THREADS = 1;
 
 /** Generate blocks (mine) */


### PR DESCRIPTION
Disables the miner(by default, it still can be enabled), as CPU mining is no longer profitable.