### PR TITLE
Dev mailing list doesn't exist (yet?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ regularly to indicate new official, stable release versions of Raven Core.
 
 The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-The developer [mailing list](https://lists.linuxfoundation.org/mailman/listinfo/raven-dev)
-should be used to discuss complicated or controversial changes before working
-on a patch set.
-
 Developer IRC can be found on Freenode at #raven-core-dev.
 
 Testing


### PR DESCRIPTION
When I click on the link it gives me an error that the mailing list doesn't exist.