### PR TITLE
Add consensus rules for asset inputs and outputs values must match

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -25,6 +25,7 @@ GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.r
 # test_raven binary #
 RAVEN_TESTS =\
   test/assets/asset_tests.cpp \
+  test/assets/asset_tx_tests.cpp \
   test/assets/cache_tests.cpp \
   test/arith_uint256_tests.cpp \
   test/scriptnum10.h \

--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -612,7 +612,7 @@ bool CAssetsCache::UndoAssetCoin(const Coin& coin, const COutPoint& out)
         if (!OwnerAssetFromScript(coin.out.scriptPubKey, ownerName, strAddress))
             return error("%s : Failed to get owner asset from script while trying to unso asset spend. OutPoint : %s", __func__, out.ToString());
         assetName = ownerName;
-        nAmount = 1 * COIN;
+        nAmount = OWNER_ASSET_AMOUNT;
     }
 
     if (assetName == "" || strAddress == "" || nAmount == 0)
@@ -759,7 +759,7 @@ bool CAssetsCache::AddOwnerAsset(const std::string& assetsName, const std::strin
     }
 
     // Insert the asset into the assests address amount map
-    mapAssetsAddressAmount[std::make_pair(assetsName, address)] = 1 * COIN;
+    mapAssetsAddressAmount[std::make_pair(assetsName, address)] = OWNER_ASSET_AMOUNT;
 
 
     // Update the cache
@@ -887,7 +887,7 @@ bool CAssetsCache::Flush(bool fSoftCopy, bool fFlushDB)
             for (auto ownerAsset : setNewOwnerAssetsToAdd) {
 
                 if (!passetsdb->WriteAssetAddressQuantity(ownerAsset.assetName, ownerAsset.address,
-                                                          1 * COIN)) {
+                                                          OWNER_ASSET_AMOUNT)) {
                     dirty = true;
                     message = "_Failed Writing Owner Address Balance to database";
                 }
@@ -1235,7 +1235,7 @@ bool GetAssetFromCoin(const Coin& coin, std::string& strName, CAmount& nAmount)
         if (!OwnerAssetFromScript(coin.out.scriptPubKey, name, address))
             return false;
         strName = name;
-        nAmount = 1 * COIN;
+        nAmount = OWNER_ASSET_AMOUNT;
         return true;
     }
 

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -268,4 +268,6 @@ bool IsScriptTransferAsset(const CScript& scriptPubKey);
 bool IsNewOwnerTxValid(const CTransaction& tx, const std::string& assetName, const std::string& address, std::string& errorMsg);
 
 void UpdatePossibleAssets();
+
+bool GetAssetFromCoin(const Coin& coin, std::string& strName, CAmount& nAmount);
 #endif //RAVENCOIN_ASSET_PROTOCOL_H

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -29,6 +29,7 @@
 #define OWNER_LENGTH 1
 #define MIN_ASSET_LENGTH 3
 #define MAX_ASSET_LENGTH 31
+#define OWNER_ASSET_AMOUNT 1 * COIN
 
 class CScript;
 class CDataStream;

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -197,9 +197,9 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, CAssetsCa
 
                 // If we aren't reindexing
                 if (!fReindex) {
-                    // If the transfer is an ownership asset. Check to make sure that it is 1 * COIN
+                    // If the transfer is an ownership asset. Check to make sure that it is OWNER_ASSET_AMOUNT
                     if (IsAssetNameAnOwner(transfer.strName)) {
-                        if (transfer.nAmount != 1 * COIN)
+                        if (transfer.nAmount != OWNER_ASSET_AMOUNT)
                             return state.DoS(100, false, REJECT_INVALID, "bad-txns-transfer-owner-amount-wasn't-1");
                     } else {
                         // For all other types of assets, make sure they are sending the right type of units

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -30,6 +30,10 @@ namespace Consensus {
  * Preconditions: tx.IsCoinBase() is false.
  */
 bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee);
+
+/** RVN START */
+bool CheckTxAssets(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs);
+/** RVN END */
 } // namespace Consensus
 
 /** Auxiliary functions for transaction validation (ideally should not be exposed) */

--- a/src/test/assets/asset_tests.cpp
+++ b/src/test/assets/asset_tests.cpp
@@ -9,6 +9,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include <amount.h>
+#include <base58.h>
+#include <chainparams.h>
 
 BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
 
@@ -92,6 +94,43 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
 
         BOOST_CHECK(IsAssetNameAnOwner("RVN!"));
         BOOST_CHECK(!IsAssetNameAnOwner("RVN"));
+    }
+
+    BOOST_AUTO_TEST_CASE(transfer_asset_coin_check) {
+
+        SelectParams(CBaseChainParams::MAIN);
+
+        // Create the asset scriptPubKey
+        CAssetTransfer asset("RAVEN", 1000);
+        CScript scriptPubKey = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+        asset.ConstructTransaction(scriptPubKey);
+
+        CTxOut txOut;
+        txOut.nValue = 0;
+        txOut.scriptPubKey = scriptPubKey;
+
+
+        Coin coin(txOut, 0, 0);
+
+        BOOST_CHECK_MESSAGE(coin.IsAsset(), "Transfer Asset Coin isn't as asset");
+    }
+
+    BOOST_AUTO_TEST_CASE(new_asset_coin_check) {
+
+        SelectParams(CBaseChainParams::MAIN);
+
+        // Create the asset scriptPubKey
+        CNewAsset asset("RAVEN", 1000, 8, 1, 0, "");
+        CScript scriptPubKey = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+        asset.ConstructTransaction(scriptPubKey);
+
+        CTxOut txOut;
+        txOut.nValue = 0;
+        txOut.scriptPubKey = scriptPubKey;
+
+        Coin coin(txOut, 0, 0);
+
+        BOOST_CHECK_MESSAGE(coin.IsAsset(), "New Asset Coin isn't as asset");
     }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/assets/asset_tx_tests.cpp
+++ b/src/test/assets/asset_tx_tests.cpp
@@ -1,0 +1,395 @@
+// Copyright (c) 2017 The Raven Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <assets/assets.h>
+
+#include <test/test_raven.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <amount.h>
+#include <script/standard.h>
+#include <base58.h>
+#include <consensus/validation.h>
+#include <consensus/tx_verify.h>
+
+BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
+
+
+    BOOST_AUTO_TEST_CASE(asset_tx_valid) {
+
+        SelectParams(CBaseChainParams::MAIN);
+
+        // Create the asset scriptPubKey
+        CAssetTransfer asset("RAVEN", 1000);
+        CScript scriptPubKey = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+        asset.ConstructTransaction(scriptPubKey);
+
+        CCoinsView view;
+        CCoinsViewCache coins(&view);
+
+        // Create CTxOut and add it to a coin
+        CTxOut txOut;
+        txOut.nValue = 0;
+        txOut.scriptPubKey = scriptPubKey;
+
+        // Create a random hash
+        uint256 hash = uint256S("BF50CB9A63BE0019171456252989A459A7D0A5F494735278290079D22AB704A2");
+
+        // Add the coin to the cache
+        COutPoint outpoint(hash, 1);
+        coins.AddCoin(outpoint, Coin(txOut, 10, 0), true);
+
+        // Create transaction and input for the outpoint of the coin we just created
+        CMutableTransaction mutTx;
+
+        CTxIn in;
+        in.prevout = outpoint;
+
+        // Add the input, and an output into the transaction
+        mutTx.vin.emplace_back(in);
+        mutTx.vout.emplace_back(txOut);
+
+        CTransaction tx(mutTx);
+        CValidationState state;
+
+        // The inputs are spending 1000 Assets
+        // The outputs are assigning a destination to 1000 Assets
+        // This test should pass because all assets are assigned a destination
+        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins), "CheckTxAssets Failed");
+    }
+
+    BOOST_AUTO_TEST_CASE(asset_tx_not_valid) {
+
+        SelectParams(CBaseChainParams::MAIN);
+
+        // Create the asset scriptPubKey
+        CAssetTransfer asset("RAVEN", 1000);
+        CScript scriptPubKey = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+        asset.ConstructTransaction(scriptPubKey);
+
+        CCoinsView view;
+        CCoinsViewCache coins(&view);
+
+        // Create CTxOut and add it to a coin
+        CTxOut txOut;
+        txOut.nValue = 0;
+        txOut.scriptPubKey = scriptPubKey;
+
+        // Create a random hash
+        uint256 hash = uint256S("BF50CB9A63BE0019171456252989A459A7D0A5F494735278290079D22AB704A2");
+
+        // Add the coin to the cache
+        COutPoint outpoint(hash, 1);
+        coins.AddCoin(outpoint, Coin(txOut, 10, 0), true);
+
+        // Create transaction and input for the outpoint of the coin we just created
+        CMutableTransaction mutTx;
+
+        CTxIn in;
+        in.prevout = outpoint;
+
+        // Create CTxOut that will only send 100 of the asset
+        // This should fail because 900 RAVEN doesn't have a destination
+        CAssetTransfer assetTransfer("RAVEN", 100);
+        CScript scriptLess = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+        assetTransfer.ConstructTransaction(scriptLess);
+
+        CTxOut txOut2;
+        txOut2.nValue = 0;
+        txOut2.scriptPubKey = scriptLess;
+
+        // Add the input, and an output into the transaction
+        mutTx.vin.emplace_back(in);
+        mutTx.vout.emplace_back(txOut2);
+
+        CTransaction tx(mutTx);
+        CValidationState state;
+
+        // The inputs of this transaction are spending 1000 Assets
+        // The outputs are assigning a destination to only 100 Assets
+        // This should fail because 900 Assets aren't being assigned a destination (Trying to burn 900 Assets)
+        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx, state, coins), "CheckTxAssets should of failed");
+    }
+
+    BOOST_AUTO_TEST_CASE(asset_tx_valid_multiple_outs) {
+
+        SelectParams(CBaseChainParams::MAIN);
+
+        // Create the asset scriptPubKey
+        CAssetTransfer asset("RAVEN", 1000);
+        CScript scriptPubKey = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+        asset.ConstructTransaction(scriptPubKey);
+
+        CCoinsView view;
+        CCoinsViewCache coins(&view);
+
+        // Create CTxOut and add it to a coin
+        CTxOut txOut;
+        txOut.nValue = 0;
+        txOut.scriptPubKey = scriptPubKey;
+
+        // Create a random hash
+        uint256 hash = uint256S("BF50CB9A63BE0019171456252989A459A7D0A5F494735278290079D22AB704A2");
+
+        // Add the coin to the cache
+        COutPoint outpoint(hash, 1);
+        coins.AddCoin(outpoint, Coin(txOut, 10, 0), true);
+
+        // Create transaction and input for the outpoint of the coin we just created
+        CMutableTransaction mutTx;
+
+        CTxIn in;
+        in.prevout = outpoint;
+
+        // Create CTxOut that will only send 100 of the asset 10 times total = 1000
+        for (int i = 0; i < 10; i++) {
+            CAssetTransfer asset2("RAVEN", 100);
+            CScript scriptPubKey2 = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+            asset2.ConstructTransaction(scriptPubKey2);
+
+            CTxOut txOut2;
+            txOut2.nValue = 0;
+            txOut2.scriptPubKey = scriptPubKey2;
+
+            // Add the output into the transaction
+            mutTx.vout.emplace_back(txOut2);
+        }
+
+        // Add the input, and an output into the transaction
+        mutTx.vin.emplace_back(in);
+
+        CTransaction tx(mutTx);
+        CValidationState state;
+
+        // The inputs are spending 1000 Assets
+        // The outputs are assigned 100 Assets to 10 destinations (10 * 100) = 1000
+        // This test should pass all assets that are being spent are assigned to a destination
+        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins), "CheckTxAssets failed");
+    }
+
+    BOOST_AUTO_TEST_CASE(asset_tx_multiple_outs_invalid) {
+
+        SelectParams(CBaseChainParams::MAIN);
+
+        // Create the asset scriptPubKey
+        CAssetTransfer asset("RAVEN", 1000);
+        CScript scriptPubKey = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+        asset.ConstructTransaction(scriptPubKey);
+
+        CCoinsView view;
+        CCoinsViewCache coins(&view);
+
+        // Create CTxOut and add it to a coin
+        CTxOut txOut;
+        txOut.nValue = 0;
+        txOut.scriptPubKey = scriptPubKey;
+
+        // Create a random hash
+        uint256 hash = uint256S("BF50CB9A63BE0019171456252989A459A7D0A5F494735278290079D22AB704A2");
+
+        // Add the coin to the cache
+        COutPoint outpoint(hash, 1);
+        coins.AddCoin(outpoint, Coin(txOut, 10, 0), true);
+
+        // Create transaction and input for the outpoint of the coin we just created
+        CMutableTransaction mutTx;
+
+        CTxIn in;
+        in.prevout = outpoint;
+
+        // Create CTxOut that will only send 100 of the asset 12 times, total = 1200
+        for (int i = 0; i < 12; i++) {
+            CAssetTransfer asset2("RAVEN", 100);
+            CScript scriptPubKey2 = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+            asset2.ConstructTransaction(scriptPubKey2);
+
+            CTxOut txOut2;
+            txOut2.nValue = 0;
+            txOut2.scriptPubKey = scriptPubKey2;
+
+            // Add the output into the transaction
+            mutTx.vout.emplace_back(txOut2);
+        }
+
+        // Add the input, and an output into the transaction
+        mutTx.vin.emplace_back(in);
+
+        CTransaction tx(mutTx);
+        CValidationState state;
+
+        // The inputs are spending 1000 Assets
+        // The outputs are assigning 100 Assets to 12 destinations (12 * 100 = 1200)
+        // This test should fail because the Outputs are greater than the inputs
+        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx, state, coins), "CheckTxAssets passed when it should of failed");
+    }
+
+    BOOST_AUTO_TEST_CASE(asset_tx_multiple_assets) {
+
+        SelectParams(CBaseChainParams::MAIN);
+
+        // Create the asset scriptPubKeys
+        CAssetTransfer asset("RAVEN", 1000);
+        CScript scriptPubKey = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+        asset.ConstructTransaction(scriptPubKey);
+
+        CAssetTransfer asset2("RAVENTEST", 1000);
+        CScript scriptPubKey2 = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+        asset2.ConstructTransaction(scriptPubKey2);
+
+        CAssetTransfer asset3("RAVENTESTTEST", 1000);
+        CScript scriptPubKey3 = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+        asset3.ConstructTransaction(scriptPubKey3);
+
+        CCoinsView view;
+        CCoinsViewCache coins(&view);
+
+        // Create CTxOuts
+        CTxOut txOut;
+        txOut.nValue = 0;
+        txOut.scriptPubKey = scriptPubKey;
+
+        CTxOut txOut2;
+        txOut2.nValue = 0;
+        txOut2.scriptPubKey = scriptPubKey2;
+
+        CTxOut txOut3;
+        txOut3.nValue = 0;
+        txOut3.scriptPubKey = scriptPubKey3;
+
+        // Create a random hash
+        uint256 hash = uint256S("BF50CB9A63BE0019171456252989A459A7D0A5F494735278290079D22AB704A2");
+        uint256 hash2 = uint256S("BF50CB9A63BE0019171456252989A459A7D0A5F494735278290079D22AB704A3");
+        uint256 hash3 = uint256S("BF50CB9A63BE0019171456252989A459A7D0A5F494735278290079D22AB704A4");
+
+        // Add the coins to the cache
+        COutPoint outpoint(hash, 1);
+        coins.AddCoin(outpoint, Coin(txOut, 10, 0), true);
+
+        COutPoint outpoint2(hash2, 1);
+        coins.AddCoin(outpoint2, Coin(txOut2, 10, 0), true);
+
+        COutPoint outpoint3(hash3, 1);
+        coins.AddCoin(outpoint3, Coin(txOut3, 10, 0), true);
+
+        Coin coinTemp;
+        BOOST_CHECK_MESSAGE(coins.GetCoin(outpoint, coinTemp), "Failed to get coin 1");
+        BOOST_CHECK_MESSAGE(coins.GetCoin(outpoint2, coinTemp), "Failed to get coin 2");
+        BOOST_CHECK_MESSAGE(coins.GetCoin(outpoint3, coinTemp), "Failed to get coin 3");
+
+        // Create transaction and input for the outpoint of the coin we just created
+        CMutableTransaction mutTx;
+
+        CTxIn in;
+        in.prevout = outpoint;
+
+        CTxIn in2;
+        in2.prevout = outpoint2;
+
+        CTxIn in3;
+        in3.prevout = outpoint3;
+
+        // Create CTxOut for each asset that spends 100 assets 10 time = 1000 asset in total
+        for (int i = 0; i < 10; i++) {
+            // Add the first asset
+            CAssetTransfer outAsset("RAVEN", 100);
+            CScript outScript = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+            outAsset.ConstructTransaction(outScript);
+
+            CTxOut txOutNew;
+            txOutNew.nValue = 0;
+            txOutNew.scriptPubKey = outScript;
+
+            mutTx.vout.emplace_back(txOutNew);
+
+            // Add the second asset
+            CAssetTransfer outAsset2("RAVENTEST", 100);
+            CScript outScript2 = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+            outAsset2.ConstructTransaction(outScript2);
+
+            CTxOut txOutNew2;
+            txOutNew2.nValue = 0;
+            txOutNew2.scriptPubKey = outScript2;
+
+            mutTx.vout.emplace_back(txOutNew2);
+
+            // Add the third asset
+            CAssetTransfer outAsset3("RAVENTESTTEST", 100);
+            CScript outScript3 = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+            outAsset3.ConstructTransaction(outScript3);
+
+            CTxOut txOutNew3;
+            txOutNew3.nValue = 0;
+            txOutNew3.scriptPubKey = outScript3;
+
+            mutTx.vout.emplace_back(txOutNew3);
+        }
+
+        // Add the inputs
+        mutTx.vin.emplace_back(in);
+        mutTx.vin.emplace_back(in2);
+        mutTx.vin.emplace_back(in3);
+
+        CTransaction tx(mutTx);
+        CValidationState state;
+
+        // The inputs are spending 3000 Assets (1000 of each RAVEN, RAVENTEST, RAVENTESTTEST)
+        // The outputs are spending 100 Assets to 10 destinations (10 * 100 = 1000) (of each RAVEN, RAVENTEST, RAVENTESTTEST)
+        // This test should pass because for each asset that is spent. It is assigned a destination
+        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins), "CheckTxAssets Failed");
+
+
+        // Try it not but only spend 900 of each asset instead of 1000
+        CMutableTransaction mutTx2;
+
+        // Create CTxOut for each asset that spends 100 assets 9 time = 900 asset in total
+        for (int i = 0; i < 9; i++) {
+            // Add the first asset
+            CAssetTransfer outAsset("RAVEN", 100);
+            CScript outScript = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+            outAsset.ConstructTransaction(outScript);
+
+            CTxOut txOutNew;
+            txOutNew.nValue = 0;
+            txOutNew.scriptPubKey = outScript;
+
+            mutTx2.vout.emplace_back(txOutNew);
+
+            // Add the second asset
+            CAssetTransfer outAsset2("RAVENTEST", 100);
+            CScript outScript2 = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+            outAsset2.ConstructTransaction(outScript2);
+
+            CTxOut txOutNew2;
+            txOutNew2.nValue = 0;
+            txOutNew2.scriptPubKey = outScript2;
+
+            mutTx2.vout.emplace_back(txOutNew2);
+
+            // Add the third asset
+            CAssetTransfer outAsset3("RAVENTESTTEST", 100);
+            CScript outScript3 = GetScriptForDestination(DecodeDestination(Params().GlobalBurnAddress()));
+            outAsset3.ConstructTransaction(outScript3);
+
+            CTxOut txOutNew3;
+            txOutNew3.nValue = 0;
+            txOutNew3.scriptPubKey = outScript3;
+
+            mutTx2.vout.emplace_back(txOutNew3);
+        }
+
+        // Add the inputs
+        mutTx2.vin.emplace_back(in);
+        mutTx2.vin.emplace_back(in2);
+        mutTx2.vin.emplace_back(in3);
+
+        CTransaction tx2(mutTx2);
+
+        // Check the transaction that contains inputs that are spending 1000 Assets for 3 different assets
+        // While only outputs only contain 900 Assets being sent to a destination
+        // This should fail because 100 of each Asset isn't being sent to a destination (Trying to burn 100 Assets each)
+        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx2, state, coins), "CheckTxAssets should of failed");
+    }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -613,8 +613,10 @@ static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& m
     CValidationState state;
     CAmount txfee = 0;
     bool fCheckResult = tx.IsCoinBase() || Consensus::CheckTxInputs(tx, state, mempoolDuplicate, spendheight, txfee);
+    /** RVN START */
     bool fCheckAssets = Consensus::CheckTxAssets(tx, state, mempoolDuplicate);
     assert(fCheckResult && fCheckAssets);
+    /** RVN END */
     UpdateCoins(tx, mempoolDuplicate, 1000000);
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -613,7 +613,8 @@ static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& m
     CValidationState state;
     CAmount txfee = 0;
     bool fCheckResult = tx.IsCoinBase() || Consensus::CheckTxInputs(tx, state, mempoolDuplicate, spendheight, txfee);
-    assert(fCheckResult);
+    bool fCheckAssets = Consensus::CheckTxAssets(tx, state, mempoolDuplicate);
+    assert(fCheckResult && fCheckAssets);
     UpdateCoins(tx, mempoolDuplicate, 1000000);
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -593,6 +593,11 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             return error("%s: Consensus::CheckTxInputs: %s, %s", __func__, tx.GetHash().ToString(), FormatStateMessage(state));
         }
 
+        /** RVN START */
+        if (!Consensus::CheckTxAssets(tx, state, view))
+            return error("%s: Consensus::CheckTxAssets: %s, %s", __func__, tx.GetHash().ToString(), FormatStateMessage(state));
+        /** RVN END */
+
         // Check for non-standard pay-to-script-hash in inputs
         if (fRequireStandard && !AreInputsStandard(tx, view))
             return state.Invalid(false, REJECT_NONSTANDARD, "bad-txns-nonstandard-inputs");
@@ -1875,6 +1880,12 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
                 return state.DoS(100, error("%s: accumulated fee in the block out of range.", __func__),
                                  REJECT_INVALID, "bad-txns-accumulated-fee-outofrange");
             }
+
+            /** RVN START */
+            if (!Consensus::CheckTxAssets(tx, state, view)) {
+                return error("%s: Consensus::CheckTxAssets: %s, %s", __func__, tx.GetHash().ToString(), FormatStateMessage(state));
+            }
+            /** RVN END */
 
             // Check that transaction is BIP68 final
             // BIP68 lock checks (as opposed to nLockTime checks) must

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2247,7 +2247,7 @@ void CWallet::AvailableCoinsAll(std::vector<COutput>& vCoins, std::map<std::stri
                                              : mapAssetTotals[strAssetName] += assetTransfer.nAmount;
 
                         if (fWasOwnerAssetOutPoint)
-                            mapAssetTotals[strAssetName] = 1 * COIN;
+                            mapAssetTotals[strAssetName] = OWNER_ASSET_AMOUNT;
                     }
 
                     // Checks the sum amount of all UTXO's, and adds to the set of assets that we found the max for
@@ -2696,7 +2696,7 @@ bool CWallet::SelectAssets(const std::map<std::string, std::vector<COutput> >& m
                 std::string address;
                 if (!OwnerAssetFromScript(out.tx->tx->vout[out.i].scriptPubKey, ownerName, address))
                     continue;
-                mapValueRet.at(ownerName) = 1 * COIN;
+                mapValueRet.at(ownerName) = OWNER_ASSET_AMOUNT;
             } else {
                 continue;
             }


### PR DESCRIPTION
Because assets behave differently from RVN. Consensus rules must be added to prevent transactions that burn assets. This means that for every asset that is spent, the same amount of assets must be sent to an address. 

To compensate for the ability to not burn assets. There is a globally know burn address were you can send assets. Nothing in this address will be spendable because of the ability to not generate the private key for it. 