### PR TITLE
Asset name validation changes for ownership '!'

### DIFF
--- a/src/test/assets/asset_tests.cpp
+++ b/src/test/assets/asset_tests.cpp
@@ -22,7 +22,8 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
     BOOST_AUTO_TEST_CASE(name_validation_tests) {
         // regular
         BOOST_CHECK(IsAssetNameValid("MIN"));
-        BOOST_CHECK(IsAssetNameValid("MAX_ASSET_IS_31_CHARACTERS_LONG"));
+        BOOST_CHECK(IsAssetNameValid("MAX_ASSET_IS_30_CHARACTERS_LNG"));
+        BOOST_CHECK(!IsAssetNameValid("MAX_ASSET_IS_31_CHARACTERS_LONG"));
         BOOST_CHECK(IsAssetNameValid("A_BCDEFGHIJKLMNOPQRSTUVWXY.Z"));
         BOOST_CHECK(IsAssetNameValid("0_12345678.9"));
 
@@ -30,7 +31,6 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
         BOOST_CHECK(!IsAssetNameValid("nolower"));
         BOOST_CHECK(!IsAssetNameValid("NO SPACE"));
         BOOST_CHECK(!IsAssetNameValid("(#&$(&*^%$))"));
-        BOOST_CHECK(!IsAssetNameValid("MAX_ASSET_IS_31_CHARACTERS_LONG_DOH"));
 
         BOOST_CHECK(!IsAssetNameValid("_RVN"));
         BOOST_CHECK(!IsAssetNameValid("_RVN"));
@@ -46,7 +46,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
         BOOST_CHECK(IsAssetNameValid("RVN/A"));
         BOOST_CHECK(IsAssetNameValid("RVN/A/1"));
         BOOST_CHECK(IsAssetNameValid("RVN/A_1/1.A"));
-        BOOST_CHECK(IsAssetNameValid("RVN/AB/XYZ/STILL/MAX/31/OVERALL"));
+        BOOST_CHECK(IsAssetNameValid("RVN/AB/XYZ/STILL/MAX/30/123456"));
 
         BOOST_CHECK(!IsAssetNameValid("RVN//MIN_1"));
         BOOST_CHECK(!IsAssetNameValid("RVN/"));
@@ -62,12 +62,13 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
         BOOST_CHECK(!IsAssetNameValid("RVN/nolower"));
         BOOST_CHECK(!IsAssetNameValid("RVN/NO SPACE"));
         BOOST_CHECK(!IsAssetNameValid("RVN/(*#^&$%)"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/AB/XYZ/STILL/MAX/31/OVERALL/SORRY"));
+        BOOST_CHECK(!IsAssetNameValid("RVN/AB/XYZ/STILL/MAX/30/OVERALL/1234"));
 
         // unique
         BOOST_CHECK(IsAssetNameValid("RVN#AZaz09"));
-        BOOST_CHECK(IsAssetNameValid("RVN#!@$%&*()[]{}<>-_.;?\\:"));
-        BOOST_CHECK(IsAssetNameValid("RVN/THING#_STILL_31_MAX-------_"));
+        BOOST_CHECK(IsAssetNameValid("RVN#@$%&*()[]{}<>-_.;?\\:"));
+        BOOST_CHECK(!IsAssetNameValid("RVN#no!bangs"));
+        BOOST_CHECK(IsAssetNameValid("RVN/THING#_STILL_30_MAX------_"));
 
         BOOST_CHECK(!IsAssetNameValid("MIN#"));
         BOOST_CHECK(!IsAssetNameValid("RVN#NO#HASH"));
@@ -78,7 +79,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
 
         // channel
         BOOST_CHECK(IsAssetNameValid("RVN~1"));
-        BOOST_CHECK(IsAssetNameValid("RVN~STILL_MAX_OF_31.CHARS_12345"));
+        BOOST_CHECK(IsAssetNameValid("RVN~STILL_MAX_OF_30.CHARS_1234"));
 
         BOOST_CHECK(!IsAssetNameValid("MIN~"));
         BOOST_CHECK(!IsAssetNameValid("RVN~NO~TILDE"));
@@ -92,8 +93,17 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
         BOOST_CHECK(!IsAssetNameValid("RVN~X..X"));
         BOOST_CHECK(!IsAssetNameValid("RVN~nolower"));
 
+        // owner
         BOOST_CHECK(IsAssetNameAnOwner("RVN!"));
         BOOST_CHECK(!IsAssetNameAnOwner("RVN"));
+        BOOST_CHECK(!IsAssetNameAnOwner("RVN!COIN"));
+        BOOST_CHECK(IsAssetNameAnOwner("MAX_ASSET_IS_30_CHARACTERS_LNG!"));
+        BOOST_CHECK(!IsAssetNameAnOwner("MAX_ASSET_IS_31_CHARACTERS_LONG!"));
+        BOOST_CHECK(IsAssetNameAnOwner("RVN/A!"));
+        BOOST_CHECK(IsAssetNameAnOwner("RVN/A/1!"));
+        BOOST_CHECK(IsAssetNameValid("RVN#AZaz09"));
+
+
     }
 
     BOOST_AUTO_TEST_CASE(transfer_asset_coin_check) {


### PR DESCRIPTION
30 max characters (excluding '!' for ownership)
unique asset tag can't contain '!'