### PR TITLE
Added asset data to rpc call return data and fix unit tests

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -1621,6 +1621,50 @@ bool GetAssetFromCoin(const Coin& coin, std::string& strName, CAmount& nAmount)
     return false;
 }
 
+void GetAssetData(const CScript& script, CAssetOutputEntry& data)
+{
+    // Placeholder strings that will get set if you successfully get the transfer or asset from the script
+    std::string address = "";
+    std::string assetName = "";
+
+    // Get the New Asset or Transfer Asset from the scriptPubKey
+    if (script.IsNewAsset()) {
+        CNewAsset asset;
+        if (AssetFromScript(script, asset, address)) {
+            assetName = asset.strName;
+            data.type = ASSET_NEW_STRING;
+            data.amount = asset.nAmount;
+            data.destination = DecodeDestination(address);
+            data.assetName = asset.strName;
+        }
+    } else if (script.IsTransferAsset()) {
+        CAssetTransfer transfer;
+        if (TransferAssetFromScript(script, transfer, address)) {
+            assetName = transfer.strName;
+            data.type = ASSET_TRANSFER_STRING;
+            data.amount = transfer.nAmount;
+            data.destination = DecodeDestination(address);
+            data.assetName = transfer.strName;
+        }
+    } else if (script.IsOwnerAsset()) {
+        if (OwnerAssetFromScript(script, assetName, address)) {
+            data.type = ASSET_NEW_STRING;
+            data.amount = OWNER_ASSET_AMOUNT;
+            data.destination = DecodeDestination(address);
+            data.assetName = assetName;
+        }
+    } else if (script.IsReissueAsset()) {
+        CReissueAsset reissue;
+        if (ReissueAssetFromScript(script, reissue, address)) {
+            assetName = reissue.strName;
+            data.type = ASSET_REISSUE_STRING;
+            data.amount = reissue.nAmount;
+            data.destination = DecodeDestination(address);
+            data.assetName = reissue.strName;
+        }
+    }
+}
+
 bool CheckAssetOwner(const std::string& assetName)
 {
     if (passets->mapMyUnspentAssets.count(assetName + OWNER)) {

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -31,11 +31,17 @@
 #define MAX_ASSET_LENGTH 31
 #define OWNER_ASSET_AMOUNT 1 * COIN
 
+#define ASSET_TRANSFER_STRING "transfer_asset"
+#define ASSET_NEW_STRING "new_asset"
+#define ASSET_REISSUE_STRING "reissue_asset"
+
+
 class CScript;
 class CDataStream;
 class CTransaction;
 class CTxOut;
 class Coin;
+struct CAssetOutputEntry;
 
 // 50000 * 82 Bytes == 4.1 Mb
 #define MAX_CACHE_ASSETS_SIZE 50000
@@ -322,4 +328,6 @@ bool CheckAssetOwner(const std::string& assetName);
 void UpdatePossibleAssets();
 
 bool GetAssetFromCoin(const Coin& coin, std::string& strName, CAmount& nAmount);
+
+void GetAssetData(const CScript& script, CAssetOutputEntry& data);
 #endif //RAVENCOIN_ASSET_PROTOCOL_H

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -5,6 +5,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <assets/assets.h>
+#include <wallet/wallet.h>
+#include <base58.h>
 #include "script.h"
 
 #include "tinyformat.h"
@@ -214,6 +216,7 @@ bool CScript::IsPayToScriptHash() const
             (*this)[22] == OP_EQUAL);
 }
 
+/** RVN START */
 bool CScript::IsNewAsset() const
 {
     // Extra-fast test for new-asset CScripts:
@@ -257,6 +260,11 @@ bool CScript::IsTransferAsset() const
             (*this)[29] == RVN_N &&
             (*this)[30] == RVN_T);
 }
+
+bool CScript::IsAsset() const {
+    return IsTransferAsset() || IsReissueAsset() || IsOwnerAsset() || IsNewAsset();
+}
+/** RVN END */
 
 bool CScript::IsPayToWitnessScriptHash() const
 {

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -654,6 +654,7 @@ public:
     bool IsOwnerAsset() const;
     bool IsReissueAsset() const;
     bool IsTransferAsset() const;
+    bool IsAsset() const;
     /** RVN END */
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -5,6 +5,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <base58.h>
+#include <assets/assets.h>
 #include "script/standard.h"
 
 #include "pubkey.h"
@@ -34,9 +35,9 @@ const char* GetTxnOutputType(txnouttype t)
     case TX_WITNESS_UNKNOWN: return "witness_unknown";
 
     /** RVN START */
-    case TX_NEW_ASSET: return "new_asset";
-    case TX_TRANSFER_ASSET: return "transfer_asset";
-    case TX_REISSUE_ASSET: return "reissue_asset";
+    case TX_NEW_ASSET: return ASSET_NEW_STRING;
+    case TX_TRANSFER_ASSET: return ASSET_TRANSFER_STRING;
+    case TX_REISSUE_ASSET: return ASSET_REISSUE_STRING;
     /** RVN END */
     }
     return nullptr;
@@ -259,7 +260,7 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
         addressRet = unk;
         return true;
     /** RVN START */
-    } else if (whichType == TX_NEW_ASSET || TX_REISSUE_ASSET || TX_TRANSFER_ASSET) {
+    } else if (whichType == TX_NEW_ASSET || whichType == TX_REISSUE_ASSET || whichType == TX_TRANSFER_ASSET) {
         addressRet = CKeyID(uint160(vSolutions[0]));
         return true;
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1520,14 +1520,17 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
  * @param  ret        The UniValue into which the result is stored.
  * @param  filter     The "is mine" filter bool.
  */
-void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter)
+void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::string& strAccount, int nMinDepth, bool fLong, UniValue& ret, UniValue& retAssets, const isminefilter& filter)
 {
     CAmount nFee;
     std::string strSentAccount;
     std::list<COutputEntry> listReceived;
     std::list<COutputEntry> listSent;
 
-    wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount, filter);
+    std::list<CAssetOutputEntry> listAssetsReceived;
+    std::list<CAssetOutputEntry> listAssetsSent;
+
+    wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount, filter, listAssetsReceived, listAssetsSent);
 
     bool fAllAccounts = (strAccount == std::string("*"));
     bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
@@ -1598,6 +1601,47 @@ void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::s
             }
         }
     }
+
+    /** RVN START */
+    if (listAssetsReceived.size() > 0 && wtx.GetDepthInMainChain() >= nMinDepth)
+    {
+        for (const CAssetOutputEntry& data : listAssetsReceived) {
+            UniValue entry(UniValue::VOBJ);
+
+            entry.push_back(Pair("asset_type", data.type));
+            entry.push_back(Pair("asset_name", data.assetName));
+            entry.push_back(Pair("amount", ValueFromAmount(data.amount)));
+            entry.push_back(Pair("destination", EncodeDestination(data.destination)));
+            entry.push_back(Pair("vout", data.vout));
+            entry.push_back(Pair("category", "receive"));
+            retAssets.push_back(entry);
+        }
+    }
+
+
+    if ((!listAssetsSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))
+    {
+        for (const CAssetOutputEntry& data : listAssetsSent) {
+            UniValue entry(UniValue::VOBJ);
+
+            entry.push_back(Pair("asset_type", data.type));
+            entry.push_back(Pair("asset_name", data.assetName));
+            entry.push_back(Pair("amount", ValueFromAmount(data.amount)));
+            entry.push_back(Pair("destination", EncodeDestination(data.destination)));
+            entry.push_back(Pair("vout", data.vout));
+            entry.push_back(Pair("category", "send"));
+            retAssets.push_back(entry);
+        }
+    }
+
+    /** RVN END */
+}
+
+void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter)
+{
+    UniValue assetDetails(UniValue::VARR);
+
+    ListTransactions(pwallet, wtx, strAccount, nMinDepth, fLong, ret, assetDetails, filter);
 }
 
 void AcentryToJSON(const CAccountingEntry& acentry, const std::string& strAccount, UniValue& ret)
@@ -2010,6 +2054,18 @@ UniValue gettransaction(const JSONRPCRequest& request)
             "    }\n"
             "    ,...\n"
             "  ],\n"
+            "  \"asset_details\" : [\n"
+            "    {\n"
+            "      \"asset_type\" : \"new_asset|transfer_asset|reissue_asset\", (string) The type of asset transaction\n"
+            "      \"asset_name\" : \"asset_name\",          (string) The name of the asset\n"
+            "      \"amount\" : x.xxx,                 (numeric) The amount in " + CURRENCY_UNIT + "\n"
+            "      \"address\" : \"address\",          (string) The raven address involved in the transaction\n"
+            "      \"vout\" : n,                       (numeric) the vout value\n"
+            "      \"category\" : \"send|receive\",    (string) The category, either 'send' or 'receive'\n"
+            "    }\n"
+            "    ,...\n"
+            "  ],\n"
+
             "  \"hex\" : \"data\"         (string) Raw data for transaction\n"
             "}\n"
 
@@ -2049,8 +2105,10 @@ UniValue gettransaction(const JSONRPCRequest& request)
     WalletTxToJSON(wtx, entry);
 
     UniValue details(UniValue::VARR);
-    ListTransactions(pwallet, wtx, "*", 0, false, details, filter);
+    UniValue assetDetails(UniValue::VARR);
+    ListTransactions(pwallet, wtx, "*", 0, false, details, assetDetails, filter);
     entry.push_back(Pair("details", details));
+    entry.push_back(Pair("asset_details", assetDetails));
 
     std::string strHex = EncodeHexTx(static_cast<CTransaction>(wtx), RPCSerializationFlags());
     entry.push_back(Pair("hex", strHex));

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -187,6 +187,17 @@ struct COutputEntry
     int vout;
 };
 
+/** RVN START */
+struct CAssetOutputEntry
+{
+    std::string type;
+    std::string assetName;
+    CTxDestination destination;
+    CAmount amount;
+    int vout;
+};
+/** RVN END */
+
 /** A transaction with a merkle branch linking it to the block chain. */
 class CMerkleTx
 {
@@ -458,6 +469,9 @@ public:
 
     void GetAmounts(std::list<COutputEntry>& listReceived,
                     std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const;
+
+    void GetAmounts(std::list<COutputEntry>& listReceived,
+                    std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter, std::list<CAssetOutputEntry>& assetsReceived, std::list<CAssetOutputEntry>& assetsSent) const;
 
     bool IsFromMe(const isminefilter& filter) const
     {


### PR DESCRIPTION
Added the ability to see the asset data when calling the following rpc calls. 
Here are some examples of the results

### **gettransaction - (With a new asset transaction)**
![screen shot 2018-06-18 at 2 04 08 pm](https://user-images.githubusercontent.com/8285518/41560239-baba2d2a-7303-11e8-96ab-c08b3347a793.png)

### **gettransaction - (With a reissue asset transaction)**
![screen shot 2018-06-18 at 2 00 41 pm](https://user-images.githubusercontent.com/8285518/41560188-93299390-7303-11e8-841b-1d6b28a49936.png)

### **decodescript - (With a new asset script)**
![screen shot 2018-06-18 at 2 22 14 pm](https://user-images.githubusercontent.com/8285518/41560280-db5db24a-7303-11e8-88be-a132c36383ac.png)



