### PR TITLE
Update asset cacheing

### DIFF
--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -43,9 +43,12 @@ class Coin;
 class CAssets {
 public:
     std::map<std::string, std::set<COutPoint> > mapMyUnspentAssets; // Asset Name -> COutPoint
+
+
     std::map<std::string, std::set<std::string> > mapAssetsAddresses; // Asset Name -> set <Addresses>
     std::map<std::pair<std::string, std::string>, CAmount> mapAssetsAddressAmount; // pair < Asset Name , Address > -> Quantity of tokens in the address
 
+    // Dirty, Gets wiped once flushed to database
     std::map<std::string, CNewAsset> mapReissuedAssetData; // Asset Name -> New Asset Data
 
     CAssets(const CAssets& assets) {
@@ -267,6 +270,7 @@ public :
         setChangeOwnedOutPoints.clear();
 
         mapReissuedAssetData.clear();
+        mapAssetsAddressAmount.clear();
 
         // Copy sets of possibilymine
         setPossiblyMineAdd.clear();
@@ -322,4 +326,6 @@ bool CheckAssetOwner(const std::string& assetName);
 void UpdatePossibleAssets();
 
 bool GetAssetFromCoin(const Coin& coin, std::string& strName, CAmount& nAmount);
+
+bool GetBestAssetAddressAmount(CAssetsCache& cache, const std::string& assetName, const std::string& address);
 #endif //RAVENCOIN_ASSET_PROTOCOL_H

--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -273,7 +273,7 @@ UniValue getassetdata(const JSONRPCRequest& request)
 
         UniValue value(UniValue::VOBJ);
         value.push_back(Pair("name: ", asset.strName));
-        value.push_back(Pair("amount: ", asset.nAmount));
+        value.push_back(Pair("amount: ", ValueFromAmount(asset.nAmount)));
         value.push_back(Pair("units: ", asset.units));
         value.push_back(Pair("reissuable: ", asset.nReissuable));
         value.push_back(Pair("has_ipfs: ", asset.nHasIPFS));
@@ -372,11 +372,9 @@ UniValue getassetaddresses(const JSONRPCRequest& request)
     auto setAddresses = passets->mapAssetsAddresses.at(asset_name);
     for (auto it : setAddresses) {
         auto pair = std::make_pair(asset_name, it);
-        if (passets->mapAssetsAddressAmount.count(pair)) {
+
+        if (GetBestAssetAddressAmount(*passets, asset_name, it))
             addresses.push_back(Pair(it, ValueFromAmount(passets->mapAssetsAddressAmount.at(pair))));
-        } else {
-            addresses.push_back(Pair(it, 0));
-        }
     }
 
     return addresses;


### PR DESCRIPTION
Currently we have a map of assets address and there balances, that never clears. Once users are using assets more this map would grow in size and require a large of memory that could crash some systems running the wallet. 

This change will make it so that the map is more of a cache, and only contains items that where changed since the last blockchain saved state. If will clear up the memory and make it so that the wallet can be run easily and not require more memory. 