### PR TITLE
Fixes asset_tests failure on unique due to dash in regex

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -28,7 +28,7 @@ static const auto MAX_NAME_LENGTH = 30;
 // min lengths are expressed by quantifiers
 static const std::regex ROOT_NAME_CHARACTERS("^[A-Z0-9._]{3,}$");
 static const std::regex SUB_NAME_CHARACTERS("^[A-Z0-9._]+$");
-static const std::regex UNIQUE_TAG_CHARACTERS("^[A-Za-z0-9@$%&*()[\\]{}<>\\-_.;?\\\\:]+$");
+static const std::regex UNIQUE_TAG_CHARACTERS("^[-A-Za-z0-9@$%&*()[\\]{}<>_.;?\\\\:]+$");
 static const std::regex CHANNEL_TAG_CHARACTERS("^[A-Z0-9._]+$");
 
 static const std::regex DOUBLE_PUNCTUATION("^.*[._]{2,}.*$");


### PR DESCRIPTION
asset_test was failing a few of the unique asset name tests on Linux due to a strange difference in how Linux handles the dash "-" character in RegEx.  It took me too long to find the simple solution - move the dash to the beginning of the RegEx definition instead of in the middle using an escape.