### PR TITLE
Fix asset regex names (fixes build errors from #125)

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -43,15 +43,15 @@ static const std::regex UNIQUE_INDICATOR("^[^#]+#[^#]+$");
 static const std::regex CHANNEL_INDICATOR("^[^~]+~[^~]+$");
 static const std::regex OWNER_INDICATOR("^[^!]+!$");
 
+static const std::regex RAVEN_NAMES("^RVN$|^RAVEN$|^RAVENCOIN$|^RAVEN.COIN$|^RAVEN_COIN$");
+
 bool IsRootNameValid(const std::string& name)
 {
     return std::regex_match(name, ROOT_NAME_CHARACTERS)
         && !std::regex_match(name, DOUBLE_PUNCTUATION)
         && !std::regex_match(name, LEADING_PUNCTUATION)
         && !std::regex_match(name, TRAILING_PUNCTUATION)
-        && !std::regex_match(name, "^RVN$")
-        && !std::regex_match(name, "^RAVEN$")
-        && !std::regex_match(name, "^RAVENCOIN$");
+        && !std::regex_match(name, RAVEN_NAMES);
 }
 
 bool IsSubNameValid(const std::string& name)

--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -202,7 +202,7 @@ UniValue issue(const JSONRPCRequest& request)
     return result;
 }
 
-UniValue listassetbalancesbyaddress(const JSONRPCRequest &request)
+UniValue listassetbalancesbyaddress(const JSONRPCRequest& request)
 {
     if (request.fHelp || !AreAssetsDeployed() || request.params.size() < 1)
         throw std::runtime_error(
@@ -634,7 +634,7 @@ UniValue reissue(const JSONRPCRequest& request)
 {
     if (request.fHelp || !AreAssetsDeployed() || request.params.size() > 5 || request.params.size() < 3)
         throw std::runtime_error(
-                "reissue \"asset_name\" qty \"to_address\" reissuable \"new_ipfs\" \n"
+                "reissue \"asset_name\" qty \"to_address\" ( reissuable ) \"( new_ipfs )\" \n"
                 + AssetActivationWarning() +
                 "\nReissues a quantity of an asset to an owned address if you own the Owner Token"
                 "\nCan change the reissuable flag during reissuance"

--- a/src/test/assets/asset_tests.cpp
+++ b/src/test/assets/asset_tests.cpp
@@ -32,76 +32,82 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
         BOOST_CHECK(!IsAssetNameValid("NO SPACE"));
         BOOST_CHECK(!IsAssetNameValid("(#&$(&*^%$))"));
 
-        BOOST_CHECK(!IsAssetNameValid("_RVN"));
-        BOOST_CHECK(!IsAssetNameValid("_RVN"));
-        BOOST_CHECK(!IsAssetNameValid("RVN_"));
-        BOOST_CHECK(!IsAssetNameValid(".RVN"));
-        BOOST_CHECK(!IsAssetNameValid("RVN."));
-        BOOST_CHECK(!IsAssetNameValid("RV..N"));
-        BOOST_CHECK(!IsAssetNameValid("R__VN"));
-        BOOST_CHECK(!IsAssetNameValid("R._VN"));
-        BOOST_CHECK(!IsAssetNameValid("RV_.N"));
+        BOOST_CHECK(!IsAssetNameValid("_ABC"));
+        BOOST_CHECK(!IsAssetNameValid("_ABC"));
+        BOOST_CHECK(!IsAssetNameValid("ABC_"));
+        BOOST_CHECK(!IsAssetNameValid(".ABC"));
+        BOOST_CHECK(!IsAssetNameValid("ABC."));
+        BOOST_CHECK(!IsAssetNameValid("AB..C"));
+        BOOST_CHECK(!IsAssetNameValid("A__BC"));
+        BOOST_CHECK(!IsAssetNameValid("A._BC"));
+        BOOST_CHECK(!IsAssetNameValid("AB_.C"));
+
+        BOOST_CHECK(!IsAssetNameValid("RVN"));
+        BOOST_CHECK(!IsAssetNameValid("RAVEN"));
+        BOOST_CHECK(!IsAssetNameValid("RAVENCOIN"));
+        BOOST_CHECK(!IsAssetNameValid("RAVEN.COIN"));
+        BOOST_CHECK(!IsAssetNameValid("RAVEN_COIN"));
 
         // subs
-        BOOST_CHECK(IsAssetNameValid("RVN/A"));
-        BOOST_CHECK(IsAssetNameValid("RVN/A/1"));
-        BOOST_CHECK(IsAssetNameValid("RVN/A_1/1.A"));
-        BOOST_CHECK(IsAssetNameValid("RVN/AB/XYZ/STILL/MAX/30/123456"));
+        BOOST_CHECK(IsAssetNameValid("ABC/A"));
+        BOOST_CHECK(IsAssetNameValid("ABC/A/1"));
+        BOOST_CHECK(IsAssetNameValid("ABC/A_1/1.A"));
+        BOOST_CHECK(IsAssetNameValid("ABC/AB/XYZ/STILL/MAX/30/123456"));
 
-        BOOST_CHECK(!IsAssetNameValid("RVN//MIN_1"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/NOTRAIL/"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/_X"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/X_"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/.X"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/X."));
-        BOOST_CHECK(!IsAssetNameValid("RVN/X__X"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/X..X"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/X_.X"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/X._X"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/nolower"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/NO SPACE"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/(*#^&$%)"));
-        BOOST_CHECK(!IsAssetNameValid("RVN/AB/XYZ/STILL/MAX/30/OVERALL/1234"));
+        BOOST_CHECK(!IsAssetNameValid("ABC//MIN_1"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/NOTRAIL/"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/_X"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/X_"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/.X"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/X."));
+        BOOST_CHECK(!IsAssetNameValid("ABC/X__X"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/X..X"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/X_.X"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/X._X"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/nolower"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/NO SPACE"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/(*#^&$%)"));
+        BOOST_CHECK(!IsAssetNameValid("ABC/AB/XYZ/STILL/MAX/30/OVERALL/1234"));
 
         // unique
-        BOOST_CHECK(IsAssetNameValid("RVN#AZaz09"));
-        BOOST_CHECK(IsAssetNameValid("RVN#@$%&*()[]{}<>-_.;?\\:"));
-        BOOST_CHECK(!IsAssetNameValid("RVN#no!bangs"));
-        BOOST_CHECK(IsAssetNameValid("RVN/THING#_STILL_30_MAX------_"));
+        BOOST_CHECK(IsAssetNameValid("ABC#AZaz09"));
+        BOOST_CHECK(IsAssetNameValid("ABC#@$%&*()[]{}<>-_.;?\\:"));
+        BOOST_CHECK(!IsAssetNameValid("ABC#no!bangs"));
+        BOOST_CHECK(IsAssetNameValid("ABC/THING#_STILL_30_MAX------_"));
 
         BOOST_CHECK(!IsAssetNameValid("MIN#"));
-        BOOST_CHECK(!IsAssetNameValid("RVN#NO#HASH"));
-        BOOST_CHECK(!IsAssetNameValid("RVN#NO SPACE"));
-        BOOST_CHECK(!IsAssetNameValid("RVN#RESERVED/"));
-        BOOST_CHECK(!IsAssetNameValid("RVN#RESERVED~"));
-        BOOST_CHECK(!IsAssetNameValid("RVN#RESERVED^"));
+        BOOST_CHECK(!IsAssetNameValid("ABC#NO#HASH"));
+        BOOST_CHECK(!IsAssetNameValid("ABC#NO SPACE"));
+        BOOST_CHECK(!IsAssetNameValid("ABC#RESERVED/"));
+        BOOST_CHECK(!IsAssetNameValid("ABC#RESERVED~"));
+        BOOST_CHECK(!IsAssetNameValid("ABC#RESERVED^"));
 
         // channel
-        BOOST_CHECK(IsAssetNameValid("RVN~1"));
-        BOOST_CHECK(IsAssetNameValid("RVN~STILL_MAX_OF_30.CHARS_1234"));
+        BOOST_CHECK(IsAssetNameValid("ABC~1"));
+        BOOST_CHECK(IsAssetNameValid("ABC~STILL_MAX_OF_30.CHARS_1234"));
 
         BOOST_CHECK(!IsAssetNameValid("MIN~"));
-        BOOST_CHECK(!IsAssetNameValid("RVN~NO~TILDE"));
-        BOOST_CHECK(!IsAssetNameValid("RVN~_ANN"));
-        BOOST_CHECK(!IsAssetNameValid("RVN~ANN_"));
-        BOOST_CHECK(!IsAssetNameValid("RVN~.ANN"));
-        BOOST_CHECK(!IsAssetNameValid("RVN~ANN."));
-        BOOST_CHECK(!IsAssetNameValid("RVN~X__X"));
-        BOOST_CHECK(!IsAssetNameValid("RVN~X._X"));
-        BOOST_CHECK(!IsAssetNameValid("RVN~X_.X"));
-        BOOST_CHECK(!IsAssetNameValid("RVN~X..X"));
-        BOOST_CHECK(!IsAssetNameValid("RVN~nolower"));
+        BOOST_CHECK(!IsAssetNameValid("ABC~NO~TILDE"));
+        BOOST_CHECK(!IsAssetNameValid("ABC~_ANN"));
+        BOOST_CHECK(!IsAssetNameValid("ABC~ANN_"));
+        BOOST_CHECK(!IsAssetNameValid("ABC~.ANN"));
+        BOOST_CHECK(!IsAssetNameValid("ABC~ANN."));
+        BOOST_CHECK(!IsAssetNameValid("ABC~X__X"));
+        BOOST_CHECK(!IsAssetNameValid("ABC~X._X"));
+        BOOST_CHECK(!IsAssetNameValid("ABC~X_.X"));
+        BOOST_CHECK(!IsAssetNameValid("ABC~X..X"));
+        BOOST_CHECK(!IsAssetNameValid("ABC~nolower"));
 
         // owner
-        BOOST_CHECK(IsAssetNameAnOwner("RVN!"));
-        BOOST_CHECK(!IsAssetNameAnOwner("RVN"));
-        BOOST_CHECK(!IsAssetNameAnOwner("RVN!COIN"));
+        BOOST_CHECK(IsAssetNameAnOwner("ABC!"));
+        BOOST_CHECK(!IsAssetNameAnOwner("ABC"));
+        BOOST_CHECK(!IsAssetNameAnOwner("ABC!COIN"));
         BOOST_CHECK(IsAssetNameAnOwner("MAX_ASSET_IS_30_CHARACTERS_LNG!"));
         BOOST_CHECK(!IsAssetNameAnOwner("MAX_ASSET_IS_31_CHARACTERS_LONG!"));
-        BOOST_CHECK(IsAssetNameAnOwner("RVN/A!"));
-        BOOST_CHECK(IsAssetNameAnOwner("RVN/A/1!"));
-        BOOST_CHECK(IsAssetNameValid("RVN#AZaz09"));
+        BOOST_CHECK(IsAssetNameAnOwner("ABC/A!"));
+        BOOST_CHECK(IsAssetNameAnOwner("ABC/A/1!"));
+        BOOST_CHECK(IsAssetNameValid("ABC#AZaz09"));
 
 
     }

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -162,7 +162,6 @@ BOOST_AUTO_TEST_CASE(rpc_createraw_assets)
     BOOST_CHECK_NO_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"rNNjqrDbSHxJZNfC54WsF8dxqbcue9SoiB\":20000}"));
     BOOST_CHECK_NO_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"rNNjqrDbSHxJZNfC54WsF8dxqbcue9SoiB\":{\"transfer\":{\"RAVEN_ASSET\":20000}}}"));
     BOOST_CHECK_NO_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"rNNjqrDbSHxJZNfC54WsF8dxqbcue9SoiB\":{\"issue\":{\"name_length\":1,\"asset_name\":\"RAVEN_ASSET\",\"asset_quantity\":20000,\"units\":0,\"reissuable\":1,\"has_ipfs\":0}}}"));
-    BOOST_CHECK_NO_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"rNNjqrDbSHxJZNfC54WsF8dxqbcue9SoiB\":{\"reissue\":{\"name_length\":1,\"asset_name\":\"RAVEN_ASSET\",\"asset_quantity\":10000,\"units\":0,\"reissuable\":0,\"has_ipfs\":0}}}"));
 
     // one address multiple asset outs
     BOOST_CHECK_NO_THROW(CallRPC("createrawtransaction [{\"txid\":\"a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed\",\"vout\":0}] {\"rNNjqrDbSHxJZNfC54WsF8dxqbcue9SoiB\":{\"transfer\":{\"RAVEN_ASSET\":20000,\"RAVEN_ASSET_2\":20000}}}"));


### PR DESCRIPTION
Fixes raven asset names RegEx that causes build errors introduced in  #125.  Remove the reissue test from rpc_tests since it cannot be called without owner token. Fix help string that was missing optional parameter indication using ().  Add tests for invalid (reserved) raven names - RVN, RAVEN, RAVENCOIN, RAVEN.COIN, RAVEN_COIN.