### PR TITLE
MNEY - change reserved raven names

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -48,7 +48,7 @@ static const std::regex UNIQUE_INDICATOR("^[^#]+#[^#]+$");
 static const std::regex CHANNEL_INDICATOR("^[^~]+~[^~]+$");
 static const std::regex OWNER_INDICATOR("^[^!]+!$");
 
-static const std::regex RAVEN_NAMES("^RVN$|^RAVEN$|^RAVENCOIN$|^RAVEN.COIN$|^RAVEN_COIN$");
+static const std::regex RAVEN_NAMES("^RVN|^RAVEN|^RAVENCOIN|^RAVENC0IN|^RAVENCO1N|^RAVENC01N");
 
 bool IsRootNameValid(const std::string& name)
 {

--- a/src/test/assets/asset_tests.cpp
+++ b/src/test/assets/asset_tests.cpp
@@ -42,11 +42,23 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
         BOOST_CHECK(!IsAssetNameValid("A._BC"));
         BOOST_CHECK(!IsAssetNameValid("AB_.C"));
 
+        //- Versions of RAVENCOIN NOT allowed
         BOOST_CHECK(!IsAssetNameValid("RVN"));
         BOOST_CHECK(!IsAssetNameValid("RAVEN"));
         BOOST_CHECK(!IsAssetNameValid("RAVENCOIN"));
-        BOOST_CHECK(!IsAssetNameValid("RAVEN.COIN"));
-        BOOST_CHECK(!IsAssetNameValid("RAVEN_COIN"));
+        BOOST_CHECK(!IsAssetNameValid("RAVENC0IN"));
+        BOOST_CHECK(!IsAssetNameValid("RAVENCO1N"));
+        BOOST_CHECK(!IsAssetNameValid("RAVENC01N"));
+
+        //- Versions of RAVENCOIN ALLOWED
+        BOOST_CHECK(IsAssetNameValid("RAVEN.COIN"));
+        BOOST_CHECK(IsAssetNameValid("RAVEN_COIN"));
+        BOOST_CHECK(IsAssetNameValid("RVNSPYDER"));
+        BOOST_CHECK(IsAssetNameValid("SPYDERRVN"));
+        BOOST_CHECK(IsAssetNameValid("RAVENSPYDER"));
+        BOOST_CHECK(IsAssetNameValid("SPYDERAVEN"));
+        BOOST_CHECK(IsAssetNameValid("BLACK_RAVENS"));
+        BOOST_CHECK(IsAssetNameValid("SERVNOT"));
 
         // subs
         BOOST_CHECK(IsAssetNameValid("ABC/A"));


### PR DESCRIPTION
Modified reserved (disallowed) raven names: RVN, RAVEN, RAVENCOIN, RAVENC0IN, RAVENCO1N, and RAVENC01N.  These words can be inside or at the end a name (i.e. SERVNOT, SPYDER_RAVEN.)