### PR TITLE
Fixing Boost library link error when building with --enable-debug fla…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -439,7 +439,7 @@ case $host in
        esac
      fi
 
-     AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"])
+     AX_CHECK_LINK_FLAG([[-lboost_system -Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -lboost_system -Wl,-headerpad_max_install_names"])
      CPPFLAGS="$CPPFLAGS -DMAC_OSX"
      OBJCXXFLAGS="$CXXFLAGS"
      ;;


### PR DESCRIPTION
Recent changes caused link errors when compiling on OS-X using the --enable-debug configure parameter.  This commit resolves that link error by adding the -lboost_system LDFLAG to the default configure as recommended by the Boost library developer guide.