### PR TITLE
Fix ability to be able to send assets to same address they are being …

### DIFF
--- a/src/assets/assettypes.h
+++ b/src/assets/assettypes.h
@@ -243,11 +243,13 @@ struct CAssetCacheSpendAsset
 {
     std::string assetName;
     std::string address;
+    CAmount nAmount;
 
-    CAssetCacheSpendAsset(const std::string& assetName, const std::string& address)
+    CAssetCacheSpendAsset(const std::string& assetName, const std::string& address, const CAmount& nAmount)
     {
         this->assetName = assetName;
         this->address = address;
+        this->nAmount = nAmount;
     }
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -51,6 +51,7 @@
 #include "wallet/init.h"
 #endif
 #include "warnings.h"
+#include "tinyformat.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <memory>
@@ -1454,10 +1455,8 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     strLoadError = _("Failed to load Assets Database");
                     break;
                 }
-                std::cout << std::endl << "Loaded Assets without error" << std::endl << "Cache of assets size: "
-                          << passetsCache->Size() << std::endl << "number of assets I have: "
-                          << passets->mapMyUnspentAssets.size() << std::endl;
 
+                LogPrintf("Loaded Assets from database without error\nCache of assets size: %d\nNumber of assets I have: %d\n", passetsCache->Size(), passets->mapMyUnspentAssets.size());
 
                 if (fReset) {
                     pblocktree->WriteReindexing(true);

--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -364,7 +364,7 @@ UniValue listmyassets(const JSONRPCRequest &request)
     std::map<std::string, CAmount> balances;
     if (filter == "*") {
         if (!GetMyAssetBalances(*passets, balances))
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't get asset balances.");
+            throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't get asset balances. For all assets");
     }
     else if (filter.back() == '*') {
         std::vector<std::string> assetNames;
@@ -378,8 +378,9 @@ UniValue listmyassets(const JSONRPCRequest &request)
         if (!IsAssetNameValid(filter))
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid asset name.");
         CAmount balance;
-        if (!GetMyAssetBalance(*passets, filter, balance))
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't get asset balances.");
+        if (!GetMyAssetBalance(*passets, filter, balance)) {
+            throw JSONRPCError(RPC_INTERNAL_ERROR, std::string("Couldn't get asset balances. For asset : ") + filter);
+        }
         balances[filter] = balance;
     }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -632,7 +632,7 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
                         throw JSONRPCError(RPC_INVALID_PARAMETER, strError);
 
 
-                    // Create the scripts for the change of the ownership toekn
+                    // Create the scripts for the change of the ownership token
                     CScript scriptTransferOwnerAsset = GetScriptForDestination(destination);
                     CAssetTransfer assetTransfer(asset_name.get_str() + OWNER_TAG, OWNER_ASSET_AMOUNT);
                     assetTransfer.ConstructTransaction(scriptTransferOwnerAsset);

--- a/src/rpc/test.json
+++ b/src/rpc/test.json
@@ -19,20 +19,22 @@
 
 ./src/raven-cli -regtest createrawtransaction "[{\"txid\":\"5a92ae8358840c2c8bba4419ec279409419a61ad552bc84ee51e5fea8b6ad712\",\"vout\":1}]" "{\"mssiSaYW18h3vj8LpqdNjjNjYsAPvg7sWB\": 500, \"n3C2qrCma88RRQ39fQPumLBaFSuwUePcVc\": 98499.988, \"mhEx3bc43oBWUsh5EjQ7Az6FT735cD6yF4\": {\"issue\": {\"name_length\": 8, \"asset_name\": \"ravenasset\", \"asset_quantity\": 20, \"units\": 1, \"reissuable\": 1, \"has_ipfs\": 1, \"ipfs_hash\" : \"43f81c6f2c0593bde5a85e09ae662816eca80797\"}}}"
 
-"[{\"txid\":\"de5dfcf2e4372e341adb8cca743517f766dc421f75e052e66f1235a3636a1f91\",\"vout\":0}]" "{\"mssiSaYW18h3vj8LpqdNjjNjYsAPvg7sWB\": 500, \"n31k7MYxWTevfdioKC2gNTJTPQkmmtkUYe\": 749.988, \"muX3sYGaRuDi59TQwyMus6r5d4Fxoafc2a\": {\"issue\": {\"name_length\": 3, \"asset_name\": \"RAVEN\", \"asset_quantity\": 20, \"units\": 1, \"reissuable\": 0, \"has_ipfs\": 1, \"ipfs_hash\" : \"43f81c6f2c0593bde5a85e09ae662816eca80797\"}}}"
+
+issue example
+"[{\"txid\":\"ff0d72d6fc16ed5d5630e235ea6cfd57b45159c18b94d20a99daf254c20ec9d9\",\"vout\":0}]" "{\"n1issueAssetXXXXXXXXXXXXXXXXWdnemQ\": 500, \"mzJMKpMZr53d32NuxmfiGaYBm4NNQ2nN3N\": 4499.988, \"mgkyuZB13r6qUEnh7Us7vPDameuYZToTG8\": {\"issue\": {\"asset_name\": \"RAW_TEST\", \"asset_quantity\": 100, \"units\": 8, \"reissuable\": 1, \"has_ipfs\": 0}}}"
 
 
 
 
 transfer example
-"[{\"txid\":\"35d945c10a6114aba1097a0d679378f64080d5aa108aee97ba6d10b2aff18bf3\",\"vout\":0}, {\"txid\":\"11a79e8928e3901526aa7ac177faccd0e3bc98917ae4193f04d1cf2330d645eb\",\"vout\":3}]" "{\"n2NKWBsA2wFqK7yBuazviueHGT7GXu7KtS\": 4999.998, \"mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp\": {\"transfer\": {\"ASSET\": 400}}, \"modMde4DCEBfiQhz6fxQWAKkCS2ifeJgYK\": {\"transfer\": {\"ASSET\": 600}}}"
+"[{\"txid\":\"ef12a4803c051ac72c4d858a17a07eab6b2d2409fa4b3783c83312a63a45f8d4\",\"vout\":0}, {\"txid\":\"dbab7439c67cbd9ac82ede1dd4a2fd604e1a709f5905550112fe744494ad343b\",\"vout\":3}]" "{\"n2NKWBsA2wFqK7yBuazviueHGT7GXu7KtS\": 4999.998, \"mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp\": {\"transfer\": {\"RAW_TEST\": 40}}, \"mun1hF7VM3iWqWKV8EH7AsKWfu7Nfa7pyg\": {\"transfer\": {\"RAW_TEST\": 60}}}"
 
 
 "[{\"txid\":\"5c6dc6c2942d01d0b181a69616284514085b01d200be94865b19ec1bdd59dcac\",\"vout\":1}]" "{\"n3C2qrCma88RRQ39fQPumLBaFSuwUePcVc\":98999.998}"
 
 
 reissue example
-"[{\"txid\":\"3f3c22a0544369698d3428ba11a29bbbfe8508938f9a0974b0eff086be24a02e\",\"vout\":0}, {\"txid\":\"f0028b85cc2ca694d2fd0f96c65b4312fb67cc32e056069da3462bf6d32400fc\",\"vout\":2}]" "{\"n2NKWBsA2wFqK7yBuazviueHGT7GXu7KtS\": 4899.988, \"n1ReissueAssetXXXXXXXXXXXXXXWG9NLd\": 100.00, \"mwfL6voyJhhPngjQG2HvaL9Kero4jwmxeZ\": {\"reissue\": {\"asset_name\": \"TEST\", \"asset_quantity\": 25, \"reissuable\": 1, \"ipfs_hash\" : \"43f81c6f2c0593bde5a85e09ae662816eca80797\"}}}"
+"[{\"txid\":\"4ff504098847a27f1754f124b3a17daa6a824ad142c5d52d69e633d686b21500\",\"vout\":0}, {\"txid\":\"21c96247f9989920c3b3ac09e7db2429e2aa23c37c48d614d777840496ca4ff4\",\"vout\":2}]" "{\"n2NKWBsA2wFqK7yBuazviueHGT7GXu7KtS\": 2399.988, \"n1ReissueAssetXXXXXXXXXXXXXXWG9NLd\": 100.00, \"mxdGKGNNiaUgJZYuvvVEomPamvxEP2yzyz\": {\"reissue\": {\"asset_name\": \"TEST_ASSET\", \"asset_quantity\": 1000, \"reissuable\": 1}}}"
 
 "[{\"txid\":\"3f3c22a0544369698d3428ba11a29bbbfe8508938f9a0974b0eff086be24a02e\",\"vout\":0}, {\"txid\":\"f0028b85cc2ca694d2fd0f96c65b4312fb67cc32e056069da3462bf6d32400fc\",\"vout\":2}]" "{\"n2NKWBsA2wFqK7yBuazviueHGT7GXu7KtS\": 4899.988, \"n1ReissueAssetXXXXXXXXXXXXXXWG9NLd\": 100.00, \"mwfL6voyJhhPngjQG2HvaL9Kero4jwmxeZ\": {\"reissue\": {\"asset_name\": \"TEST\", \"asset_quantity\": 25, \"reissuable\": 5}}}"
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1685,7 +1685,7 @@ static DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* 
                     CNewAsset asset;
                     std::string strAddress;
                     if (!AssetFromTransaction(tx, asset, strAddress)) {
-                        error("%s : Failed to get asset from transaction. TXID : ", __func__, tx.GetHash().GetHex());
+                        error("%s : Failed to get asset from transaction. TXID : %s", __func__, tx.GetHash().GetHex());
                         return DISCONNECT_FAILED;
                     }
                     if (assetsCache->ContainsAsset(asset)) {
@@ -1699,12 +1699,12 @@ static DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* 
                     std::string ownerName;
                     std::string ownerAddress;
                     if (!OwnerFromTransaction(tx, ownerName, ownerAddress)) {
-                        error("%s : Failed to get owner from transaction. TXID : ", __func__, tx.GetHash().GetHex());
+                        error("%s : Failed to get owner from transaction. TXID : %s", __func__, tx.GetHash().GetHex());
                         return DISCONNECT_FAILED;
                     }
 
                     if (!assetsCache->RemoveOwnerAsset(ownerName, ownerAddress)) {
-                        error("%s : Failed to Remove Owner from transaction. TXID : ", __func__, tx.GetHash().GetHex());
+                        error("%s : Failed to Remove Owner from transaction. TXID : %s", __func__, tx.GetHash().GetHex());
                         return DISCONNECT_FAILED;
                     }
                 } else if (tx.IsReissueAsset()) {
@@ -1712,7 +1712,7 @@ static DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* 
                     std::string strAddress;
 
                     if (!ReissueAssetFromTransaction(tx, reissue, strAddress)) {
-                        error("%s : Failed to get reissue asset from transaction. TXID : ", __func__,
+                        error("%s : Failed to get reissue asset from transaction. TXID : %s", __func__,
                               tx.GetHash().GetHex());
                         return DISCONNECT_FAILED;
                     }
@@ -1731,7 +1731,7 @@ static DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* 
                     CAssetTransfer transfer;
                     std::string strAddress;
                     if (!TransferAssetFromScript(tx.vout[index].scriptPubKey, transfer, strAddress)) {
-                        error("%s : Failed to get transfer asset from transaction. CTxOut : ", __func__,
+                        error("%s : Failed to get transfer asset from transaction. CTxOut : %s", __func__,
                               tx.vout[index].ToString());
                         return DISCONNECT_FAILED;
                     }

--- a/test/functional/assets.py
+++ b/test/functional/assets.py
@@ -61,8 +61,8 @@ class AssetTest(RavenTestFramework):
         assert_is_hash_string(myassets["MY_ASSET"]["outpoints"][0]["txid"])
         assert_equal(myassets["MY_ASSET"]["outpoints"][0]["txid"], \
                      myassets["MY_ASSET!"]["outpoints"][0]["txid"])
-        assert(int(myassets["MY_ASSET"]["outpoints"][0]["index"]) >= 0)
-        assert(int(myassets["MY_ASSET!"]["outpoints"][0]["index"]) >= 0)
+        assert(int(myassets["MY_ASSET"]["outpoints"][0]["vout"]) >= 0)
+        assert(int(myassets["MY_ASSET!"]["outpoints"][0]["vout"]) >= 0)
         assert_equal(myassets["MY_ASSET"]["outpoints"][0]["amount"], 1000)
         assert_equal(myassets["MY_ASSET!"]["outpoints"][0]["amount"], 1)
 
@@ -87,7 +87,7 @@ class AssetTest(RavenTestFramework):
         assert_equal(myassets["MY_ASSET"]["balance"], 200)
         assert_equal(len(myassets["MY_ASSET"]["outpoints"]), 1)
         assert_is_hash_string(myassets["MY_ASSET"]["outpoints"][0]["txid"])
-        assert(int(myassets["MY_ASSET"]["outpoints"][0]["index"]) >= 0)
+        assert(int(myassets["MY_ASSET"]["outpoints"][0]["vout"]) >= 0)
         assert_equal(n0.listmyassets(asset="MY_ASSET")["MY_ASSET"], 800)
 
         self.log.info("Checking listassetbalancesbyaddress()...")


### PR DESCRIPTION
When a user would spend an asset OutPoint and send the change back to the same address the OutPoint was spent from. It wasn't being databased correctly. This change fixes that issue as well as some small LogPrintf fixes. 