### PR TITLE
Add regtest mining shortcut to assets tab

### DIFF
--- a/src/qt/assetsdialog.h
+++ b/src/qt/assetsdialog.h
@@ -99,6 +99,7 @@ private Q_SLOTS:
     void createAssetButtonClicked();
     void ressieAssetButtonClicked();
     void refreshButtonClicked();
+    void mineButtonClicked();
     /** RVN END */
 
     Q_SIGNALS:

--- a/src/qt/forms/assetsdialog.ui
+++ b/src/qt/forms/assetsdialog.ui
@@ -37,6 +37,32 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="mineButton">
+       <property name="text">
+        <string>Mine Block</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="mineBlocksCount">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>1000</number>
+       </property>
+       <property name="singleStep">
+        <number>10</number>
+       </property>
+       <property name="value">
+        <number>1</number>
+       </property>
+       <property name="displayIntegerBase">
+        <number>10</number>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -635,7 +661,7 @@
         <x>0</x>
         <y>0</y>
         <width>1044</width>
-        <height>278</height>
+        <height>274</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">


### PR DESCRIPTION
Added the ability to click a button to generate a new block while running the wallet on regtest. This should significantly reduce testing time as the user doesn't have to use the debug console anymore to generate blocks using generate *int*

![image](https://user-images.githubusercontent.com/8285518/43414257-81632d26-93ef-11e8-972e-46a9d24d892b.png)
