### PR TITLE
MNEY - add $ to end of regex for better compatability

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -48,7 +48,7 @@ static const std::regex UNIQUE_INDICATOR("^[^#]+#[^#]+$");
 static const std::regex CHANNEL_INDICATOR("^[^~]+~[^~]+$");
 static const std::regex OWNER_INDICATOR("^[^!]+!$");
 
-static const std::regex RAVEN_NAMES("^RVN|^RAVEN|^RAVENCOIN|^RAVENC0IN|^RAVENCO1N|^RAVENC01N");
+static const std::regex RAVEN_NAMES("^RVN$|^RAVEN$|^RAVENCOIN$|^RAVENC0IN$|^RAVENCO1N$|^RAVENC01N$");
 
 bool IsRootNameValid(const std::string& name)
 {


### PR DESCRIPTION
Initially, when I added the asset name validation regex to exclude variations of RAVEN I removed the end delimiter '$' as things worked fine without it.  For better compatibility, this is being added back.