### PR TITLE
[Rename] AssetType CHANNEL

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -128,7 +128,7 @@ bool IsAssetNameValid(const std::string& name, AssetType& assetType)
         boost::split(parts, name, boost::is_any_of(CHANNEL_TAG_DELIMITER));
         bool valid = IsNameValidBeforeTag(parts.front()) && IsChannelTagValid(parts.back());
         if (!valid) return false;
-        assetType = AssetType::CHANNEL;
+        assetType = AssetType::ACHANNEL;
         return true;
     }
     else if (std::regex_match(name, OWNER_INDICATOR))

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -55,7 +55,7 @@ enum AssetType
     OWNER,
     SUB,
     UNIQUE,
-    CHANNEL,
+    ACHANNEL,
     VOTE,
     INVALID
 };

--- a/src/test/assets/asset_tests.cpp
+++ b/src/test/assets/asset_tests.cpp
@@ -103,7 +103,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
 
         // channel
         BOOST_CHECK(IsAssetNameValid("ABC~1", type));
-        BOOST_CHECK(type == AssetType::CHANNEL);
+        BOOST_CHECK(type == AssetType::ACHANNEL);
         BOOST_CHECK(IsAssetNameValid("ABC~STILL_MAX_OF_30.CHARS_1234", type));
 
         BOOST_CHECK(!IsAssetNameValid("MIN~", type));


### PR DESCRIPTION
Due to a previously un-noticed declaration of __channel in BDB 5.3 the two declarations of CHANNEL compete and cause a failure to compile when BDB is > 4.8. Although this is an edge case, renaming CHANNEL to ACHANNEL (or some derivative) should alleviate compatibility issues with non standard BDB version, as some compilations may require

This addresses #193