### PR TITLE
remove the forced fpic flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -446,8 +446,6 @@ case $host in
    *linux*)
      TARGET_OS=linux
      LEVELDB_TARGET_FLAGS="-DOS_LINUX"
-     CXXFLAGS="$TEMP_CXXFLAGS -fPIC"
-     CPPFLAGS="$CPPFLAGS -fPIC"
      ;;
    *freebsd*)
      LEVELDB_TARGET_FLAGS="-DOS_FREEBSD"


### PR DESCRIPTION
This is really like using thors hammer to "fix" a wee tiny nail. Don't force fpic on all linux builds. Its only an issue with gcc on certain versions of nix. for those version people should compile with the correct fpic flags.