### PR TITLE
Fix asset database error, fix unit tests

### DIFF
--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -32,7 +32,7 @@ namespace Consensus {
 bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee);
 
 /** RVN START */
-bool CheckTxAssets(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs);
+bool CheckTxAssets(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, const bool fRunningUnitTests = false);
 /** RVN END */
 } // namespace Consensus
 

--- a/src/test/assets/asset_tx_tests.cpp
+++ b/src/test/assets/asset_tx_tests.cpp
@@ -16,7 +16,6 @@
 
 BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
 
-
     BOOST_AUTO_TEST_CASE(asset_tx_valid) {
 
         SelectParams(CBaseChainParams::MAIN);
@@ -57,7 +56,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // The inputs are spending 1000 Assets
         // The outputs are assigning a destination to 1000 Assets
         // This test should pass because all assets are assigned a destination
-        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins), "CheckTxAssets Failed");
+        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins, true), "CheckTxAssets Failed");
     }
 
     BOOST_AUTO_TEST_CASE(asset_tx_not_valid) {
@@ -110,7 +109,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // The inputs of this transaction are spending 1000 Assets
         // The outputs are assigning a destination to only 100 Assets
         // This should fail because 900 Assets aren't being assigned a destination (Trying to burn 900 Assets)
-        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx, state, coins), "CheckTxAssets should of failed");
+        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx, state, coins, true), "CheckTxAssets should of failed");
     }
 
     BOOST_AUTO_TEST_CASE(asset_tx_valid_multiple_outs) {
@@ -166,7 +165,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // The inputs are spending 1000 Assets
         // The outputs are assigned 100 Assets to 10 destinations (10 * 100) = 1000
         // This test should pass all assets that are being spent are assigned to a destination
-        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins), "CheckTxAssets failed");
+        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins, true), "CheckTxAssets failed");
     }
 
     BOOST_AUTO_TEST_CASE(asset_tx_multiple_outs_invalid) {
@@ -222,7 +221,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // The inputs are spending 1000 Assets
         // The outputs are assigning 100 Assets to 12 destinations (12 * 100 = 1200)
         // This test should fail because the Outputs are greater than the inputs
-        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx, state, coins), "CheckTxAssets passed when it should of failed");
+        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx, state, coins, true), "CheckTxAssets passed when it should of failed");
     }
 
     BOOST_AUTO_TEST_CASE(asset_tx_multiple_assets) {
@@ -337,7 +336,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // The inputs are spending 3000 Assets (1000 of each RAVEN, RAVENTEST, RAVENTESTTEST)
         // The outputs are spending 100 Assets to 10 destinations (10 * 100 = 1000) (of each RAVEN, RAVENTEST, RAVENTESTTEST)
         // This test should pass because for each asset that is spent. It is assigned a destination
-        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins), "CheckTxAssets Failed");
+        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins, true), "CheckTxAssets Failed");
 
 
         // Try it not but only spend 900 of each asset instead of 1000
@@ -389,7 +388,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // Check the transaction that contains inputs that are spending 1000 Assets for 3 different assets
         // While only outputs only contain 900 Assets being sent to a destination
         // This should fail because 100 of each Asset isn't being sent to a destination (Trying to burn 100 Assets each)
-        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx2, state, coins), "CheckTxAssets should of failed");
+        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx2, state, coins, true), "CheckTxAssets should of failed");
     }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
1. When a user would shutdown the wallet, after they issued an asset, and transfer an asset within a couple blocks then performed a wallet shutdown.

2. When the wallet is loaded back up, it would undo a certain amount blocks to verify the validity of the most recent chain. This allowed the database and memory to become out on sync because it was Writing the transfer asset data before the issued asset data.  

Fixed - This change fixes the problem by changing the order the assets database performs its Write/Erases, so they overlap in the correct order. 
Fixed - Fixed units tests that broke when #223 was implemented