### PR TITLE
Remove the ability to chain reissue transactions

### DIFF
--- a/src/assets/assetdb.h
+++ b/src/assets/assetdb.h
@@ -30,12 +30,14 @@ public:
     bool WriteMyAssetsData(const std::string &strName, const std::set<COutPoint>& setOuts);
     bool WriteAssetAddressQuantity(const std::string& assetName, const std::string& address, const CAmount& quantity);
     bool WriteBlockUndoAssetData(const uint256& blockhash, const std::vector<std::pair<std::string, std::string> >& vIPFSHashes);
+    bool WriteReissuedMempoolState();
 
     // Read from database functions
     bool ReadAssetData(const std::string& strName, CNewAsset& asset);
     bool ReadMyAssetsData(const std::string &strName, std::set<COutPoint>& setOuts);
     bool ReadAssetAddressQuantity(const std::string& assetName, const std::string& address, CAmount& quantity);
     bool ReadBlockUndoAssetData(const uint256& blockhash, std::vector<std::pair<std::string, std::string> >& vIPFSHashes);
+    bool ReadReissuedMempoolState();
 
     // Erase from database functions
     bool EraseAssetData(const std::string& assetName);

--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -28,6 +28,9 @@
 #include "utilmoneystr.h"
 #include "coins.h"
 
+std::map<uint256, std::string> mapReissuedTx;
+std::map<std::string, uint256> mapReissuedAssets;
+
 // excluding owner tag ('!')
 static const auto MAX_NAME_LENGTH = 30;
 

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -49,6 +49,8 @@ struct CAssetOutputEntry;
 // 50000 * 82 Bytes == 4.1 Mb
 #define MAX_CACHE_ASSETS_SIZE 50000
 
+// Create map that store that state of current reissued transaction that the mempool as accepted.
+// If an asset name is in this map, any other reissue transactions wont be accepted into the mempool
 extern std::map<uint256, std::string> mapReissuedTx;
 extern std::map<std::string, uint256> mapReissuedAssets;
 

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -49,6 +49,9 @@ struct CAssetOutputEntry;
 // 50000 * 82 Bytes == 4.1 Mb
 #define MAX_CACHE_ASSETS_SIZE 50000
 
+extern std::map<uint256, std::string> mapReissuedTx;
+extern std::map<std::string, uint256> mapReissuedAssets;
+
 class CAssets {
 public:
     std::map<std::string, std::set<COutPoint> > mapMyUnspentAssets; // Asset Name -> COutPoint

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -16,6 +16,8 @@ class CCoinsViewCache;
 class CTransaction;
 class CValidationState;
 class CAssetsCache;
+class CTxOut;
+class uint256;
 
 /** Transaction validation functions */
 
@@ -32,7 +34,7 @@ namespace Consensus {
 bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee);
 
 /** RVN START */
-bool CheckTxAssets(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, const bool fRunningUnitTests = false);
+bool CheckTxAssets(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, std::vector<std::pair<std::string, uint256> >& vPairReissueAssets, const bool fRunningUnitTests = false);
 /** RVN END */
 } // namespace Consensus
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1456,6 +1456,9 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     break;
                 }
 
+                if (!passetsdb->ReadReissuedMempoolState())
+                    LogPrintf("Database failed to load last Reissued Mempool State. Will have to start from empty state");
+
                 LogPrintf("Loaded Assets from database without error\nCache of assets size: %d\nNumber of assets I have: %d\n", passetsCache->Size(), passets->mapMyUnspentAssets.size());
 
                 if (fReset) {

--- a/src/test/assets/asset_tx_tests.cpp
+++ b/src/test/assets/asset_tx_tests.cpp
@@ -56,7 +56,8 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // The inputs are spending 1000 Assets
         // The outputs are assigning a destination to 1000 Assets
         // This test should pass because all assets are assigned a destination
-        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins, true), "CheckTxAssets Failed");
+        std::vector<std::pair<std::string, uint256>> vReissueAssets;
+        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins, vReissueAssets, true), "CheckTxAssets Failed");
     }
 
     BOOST_AUTO_TEST_CASE(asset_tx_not_valid) {
@@ -109,7 +110,8 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // The inputs of this transaction are spending 1000 Assets
         // The outputs are assigning a destination to only 100 Assets
         // This should fail because 900 Assets aren't being assigned a destination (Trying to burn 900 Assets)
-        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx, state, coins, true), "CheckTxAssets should of failed");
+        std::vector<std::pair<std::string, uint256>> vReissueAssets;
+        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx, state, coins, vReissueAssets, true), "CheckTxAssets should of failed");
     }
 
     BOOST_AUTO_TEST_CASE(asset_tx_valid_multiple_outs) {
@@ -165,7 +167,8 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // The inputs are spending 1000 Assets
         // The outputs are assigned 100 Assets to 10 destinations (10 * 100) = 1000
         // This test should pass all assets that are being spent are assigned to a destination
-        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins, true), "CheckTxAssets failed");
+        std::vector<std::pair<std::string, uint256>> vReissueAssets;
+        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins, vReissueAssets, true), "CheckTxAssets failed");
     }
 
     BOOST_AUTO_TEST_CASE(asset_tx_multiple_outs_invalid) {
@@ -221,7 +224,8 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // The inputs are spending 1000 Assets
         // The outputs are assigning 100 Assets to 12 destinations (12 * 100 = 1200)
         // This test should fail because the Outputs are greater than the inputs
-        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx, state, coins, true), "CheckTxAssets passed when it should of failed");
+        std::vector<std::pair<std::string, uint256>> vReissueAssets;
+        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx, state, coins, vReissueAssets, true), "CheckTxAssets passed when it should of failed");
     }
 
     BOOST_AUTO_TEST_CASE(asset_tx_multiple_assets) {
@@ -336,7 +340,8 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // The inputs are spending 3000 Assets (1000 of each RAVEN, RAVENTEST, RAVENTESTTEST)
         // The outputs are spending 100 Assets to 10 destinations (10 * 100 = 1000) (of each RAVEN, RAVENTEST, RAVENTESTTEST)
         // This test should pass because for each asset that is spent. It is assigned a destination
-        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins, true), "CheckTxAssets Failed");
+        std::vector<std::pair<std::string, uint256>> vReissueAssets;
+        BOOST_CHECK_MESSAGE(Consensus::CheckTxAssets(tx, state, coins, vReissueAssets, true), "CheckTxAssets Failed");
 
 
         // Try it not but only spend 900 of each asset instead of 1000
@@ -388,7 +393,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_tx_tests, BasicTestingSetup)
         // Check the transaction that contains inputs that are spending 1000 Assets for 3 different assets
         // While only outputs only contain 900 Assets being sent to a destination
         // This should fail because 100 of each Asset isn't being sent to a destination (Trying to burn 100 Assets each)
-        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx2, state, coins, true), "CheckTxAssets should of failed");
+        BOOST_CHECK_MESSAGE(!Consensus::CheckTxAssets(tx2, state, coins, vReissueAssets, true), "CheckTxAssets should of failed");
     }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -597,6 +597,16 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
     if (minerPolicyEstimator) {minerPolicyEstimator->removeTx(hash, false);}
     removeAddressIndex(hash);
     removeSpentIndex(hash);
+
+    /** RVN START */
+    // If the transaction being removed from the mempool is locking other reissues. Free them
+    if (mapReissuedTx.count(hash)) {
+        if (mapReissuedAssets.count(mapReissuedTx.at(hash))) {
+            mapReissuedAssets.erase(mapReissuedTx.at((hash)));
+            mapReissuedTx.erase(hash);
+        }
+    }
+    /** RVN END */
 }
 
 // Calculates descendants of entry that are not already in setDescendants, and adds to

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -771,7 +771,8 @@ static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& m
     bool fCheckResult = tx.IsCoinBase() || Consensus::CheckTxInputs(tx, state, mempoolDuplicate, spendheight, txfee);
     /** RVN START */
     if (AreAssetsDeployed()) {
-        bool fCheckAssets = Consensus::CheckTxAssets(tx, state, mempoolDuplicate);
+        std::vector<std::pair<std::string, uint256>> vReissueAssets;
+        bool fCheckAssets = Consensus::CheckTxAssets(tx, state, mempoolDuplicate, vReissueAssets);
         assert(fCheckResult && fCheckAssets);
     } else
         assert(fCheckResult);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -916,11 +916,11 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             if (!pool.exists(hash))
                 return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
         }
-    }
 
-    for (auto out : vReissueAssets) {
-        mapReissuedAssets.insert(out);
-        mapReissuedTx.insert(std::make_pair(out.second, out.first));
+        for (auto out : vReissueAssets) {
+            mapReissuedAssets.insert(out);
+            mapReissuedTx.insert(std::make_pair(out.second, out.first));
+        }
     }
 
     GetMainSignals().TransactionAddedToMempool(ptx);
@@ -2501,6 +2501,9 @@ bool static FlushStateToDisk(const CChainParams& chainparams, CValidationState &
                         return AbortNode(state, "Failed to write to asset database");
                 }
             }
+            // Write the reissue mempool data to database
+            if (passetsdb)
+                passetsdb->WriteReissuedMempoolState();
             /** RVN END */
 
             nLastFlush = nNow;


### PR DESCRIPTION
Because reissue transaction require a state based check from memory or database to verify the validity of the reissue transaction. Only one reissue transaction can be made per asset until the transaction is accepted into a block. 

If a transaction doesn't contain a necessary fee to get accepted into a block, the owner of the asset will have to wait until the transaction is removed/expires from the mempool to be able to reissue the asset again. 