### PR TITLE
Fixing Linux build errror - missing string include in header

### DIFF
--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <vector>
+#include <string>
 
 class CBlockIndex;
 class CCoinsViewCache;


### PR DESCRIPTION
Not sure why this builds fine on OS-X.  Should be failing to build there too.  Simple one-line change to include string...