### PR TITLE
Hide asset change addresses

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -2095,7 +2095,7 @@ void GetAssetData(const CScript& script, CAssetOutputEntry& data)
             data.destination = DecodeDestination(address);
             data.assetName = transfer.strName;
         }
-    } else if (type == TX_NEW_ASSET && !fIsOwner) {
+    } else if (type == TX_NEW_ASSET && fIsOwner) {
         if (OwnerAssetFromScript(script, assetName, address)) {
             data.type = ASSET_NEW_STRING;
             data.amount = OWNER_ASSET_AMOUNT;

--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -2357,14 +2357,7 @@ bool CreateAssetTransaction(CWallet* pwallet, const std::vector<CNewAsset> asset
             return false;
         }
     } else {
-        // Note: We use a new key here to keep it from being obvious which side is the change.
-        //  The drawback is that by not reusing a previous key, the change may be lost if a
-        //  backup is restored, if the backup doesn't have the new private key for the change.
-        //  If we reused the old key, it would be possible to add code to look for and
-        //  rediscover unknown transactions that were written with keys of ours to recover
-        //  post-backup change.
-
-        // Reserve a new key pair from key pool
+        // no coin control: send change to newly generated address
         CKeyID keyID;
         std::string strFailReason;
         if (!pwallet->CreateNewChangeAddress(reservekey, keyID, strFailReason)) {
@@ -2475,14 +2468,6 @@ bool CreateReissueAssetTransaction(CWallet* pwallet, const CReissueAsset& reissu
             return false;
         }
     } else {
-        // Note: We use a new key here to keep it from being obvious which side is the change.
-        //  The drawback is that by not reusing a previous key, the change may be lost if a
-        //  backup is restored, if the backup doesn't have the new private key for the change.
-        //  If we reused the old key, it would be possible to add code to look for and
-        //  rediscover unknown transactions that were written with keys of ours to recover
-        //  post-backup change.
-
-        // Reserve a new key pair from key pool
         CKeyID keyID;
         std::string strFailReason;
         if (!pwallet->CreateNewChangeAddress(reservekey, keyID, strFailReason)) {

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -195,8 +195,9 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     sub.type = TransactionRecord::Reissue;
                 else if (data.type == ASSET_TRANSFER_STRING)
                     sub.type = TransactionRecord::TransferFrom;
-                else
+                else {
                     sub.type = TransactionRecord::Other;
+                }
 
                 if (IsAssetNameAnOwner(sub.assetName))
                     sub.units = OWNER_UNITS;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2774,6 +2774,31 @@ bool CWallet::SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAm
 }
 
 /** RVN START */
+bool CWallet::CreateNewChangeAddress(CReserveKey& reservekey, CKeyID& keyID, std::string& strFailReason)
+{
+    // Called with coin control doesn't have a change_address
+    // no coin control: send change to newly generated address
+    // Note: We use a new key here to keep it from being obvious which side is the change.
+    //  The drawback is that by not reusing a previous key, the change may be lost if a
+    //  backup is restored, if the backup doesn't have the new private key for the change.
+    //  If we reused the old key, it would be possible to add code to look for and
+    //  rediscover unknown transactions that were written with keys of ours to recover
+    //  post-backup change.
+
+    // Reserve a new key pair from key pool
+    CPubKey vchPubKey;
+    bool ret;
+    ret = reservekey.GetReservedKey(vchPubKey, true);
+    if (!ret)
+    {
+        strFailReason = _("Keypool ran out, please call keypoolrefill first");
+        return false;
+    }
+
+    keyID = vchPubKey.GetID();
+    return true;
+}
+
 bool CWallet::SelectAssetsMinConf(const CAmount& nTargetValue, const int nConfMine, const int nConfTheirs, const uint64_t nMaxAncestors, const std::string& strAssetName, std::vector<COutput> vCoins,
                                  std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet) const
 {
@@ -3239,16 +3264,11 @@ bool CWallet::CreateTransactionAll(const std::vector<CRecipient>& vecSend, CWall
                 //  post-backup change.
 
                 // Reserve a new key pair from key pool
-                CPubKey vchPubKey;
-                bool ret;
-                ret = reservekey.GetReservedKey(vchPubKey, true);
-                if (!ret)
-                {
-                    strFailReason = _("Keypool ran out, please call keypoolrefill first");
+                CKeyID keyID;
+                if (!CreateNewChangeAddress(reservekey, keyID, strFailReason))
                     return false;
-                }
 
-                scriptChange = GetScriptForDestination(vchPubKey.GetID());
+                scriptChange = GetScriptForDestination(keyID);
             }
 
             CTxOut change_prototype_txout(0, scriptChange);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3254,15 +3254,9 @@ bool CWallet::CreateTransactionAll(const std::vector<CRecipient>& vecSend, CWall
             // coin control: send change to custom address
             if (!boost::get<CNoDestination>(&coin_control.destChange)) {
                 scriptChange = GetScriptForDestination(coin_control.destChange);
-            } else { // no coin control: send change to newly generated address
-                // Note: We use a new key here to keep it from being obvious which side is the change.
-                //  The drawback is that by not reusing a previous key, the change may be lost if a
-                //  backup is restored, if the backup doesn't have the new private key for the change.
-                //  If we reused the old key, it would be possible to add code to look for and
-                //  rediscover unknown transactions that were written with keys of ours to recover
-                //  post-backup change.
+            } else {
 
-                // Reserve a new key pair from key pool
+                // no coin control: send change to newly generated address
                 CKeyID keyID;
                 if (!CreateNewChangeAddress(reservekey, keyID, strFailReason))
                     return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1563,7 +1563,6 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
 
                 if (fIsMine & filter)
                     assetsReceived.emplace_back(assetoutput);
-
             }
         }
         /** RVN END */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1018,6 +1018,7 @@ public:
     bool CreateTransactionAll(const std::vector<CRecipient>& vecSend, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet,
                               int& nChangePosInOut, std::string& strFailReason, const CCoinControl& coin_control, bool fNewAsset, const std::vector<CNewAsset> assets, const CTxDestination destination, bool fTransferAsset, bool fReissueAsset, const CReissueAsset& reissueAsset, const AssetType& assetType, bool sign);
 
+    bool CreateNewChangeAddress(CReserveKey& reservekey, CKeyID& keyID, std::string& strFailReason);
 
     /** RVN END */
 


### PR DESCRIPTION
Normal RVN transactions were not showing the change outputs in the transaction page. They do this by creating change address and not adding them to the wallet. Asset change addresses where not being created the same way and because of that they were spamming the transaction list on the GUI. This made the GUI messy. 

This changes makes it so asset change addresses are created like normal RVN transactions. This also fixes a bug where ownership assets weren't showing up in the GUI correctly. 