### PR TITLE
Fix send assets max value

### DIFF
--- a/src/qt/forms/sendassetsentry.ui
+++ b/src/qt/forms/sendassetsentry.ui
@@ -56,6 +56,9 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
+        <property name="maximum">
+         <double>21000000000.000000000000000</double>
+        </property>
        </widget>
       </item>
       <item>


### PR DESCRIPTION
The max value the QT wallet would allow was 99.99. Not sure how this got changed, but this reverts that change back to 21,000,000,000