### PR TITLE
Default RBF to off

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -149,7 +149,7 @@ static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 /** Default for -persistmempool */
 static const bool DEFAULT_PERSIST_MEMPOOL = true;
 /** Default for -mempoolreplacement */
-static const bool DEFAULT_ENABLE_REPLACEMENT = true;
+static const bool DEFAULT_ENABLE_REPLACEMENT = false;
 /** Default for using fee filter */
 static const bool DEFAULT_FEEFILTER = true;
 


### PR DESCRIPTION
Default RBF (BIP125) to off.

Advantage: Works like Bitcoin prior to ver 12 when 0 conf was accepted for low dollar items.  Increases difficulty of undoing a 0 conf transaction.