### PR TITLE
modifying functional tests to reflect the recent RBF change

### DIFF
--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -34,8 +34,9 @@ class BumpFeeTest(RavenTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
-        self.extra_args = [["-prematurewitness", "-walletprematurewitness", "-walletrbf={}".format(i)]
-                           for i in range(self.num_nodes)]
+        self.extra_args = [
+            ["-prematurewitness", "-walletprematurewitness", "-mempoolreplacement", "-walletrbf={}".format(i)] for i in
+            range(self.num_nodes)]
 
     def run_test(self):
         # Encrypt wallet for test_locked_wallet_fails test
@@ -155,7 +156,7 @@ def test_notmine_bumpfee_fails(rbf_node, peer_node, dest_address):
     signedtx = peer_node.signrawtransaction(signedtx["hex"])
     rbfid = rbf_node.sendrawtransaction(signedtx["hex"])
     assert_raises_rpc_error(-4, "Transaction contains inputs that don't belong to this wallet",
-                          rbf_node.bumpfee, rbfid)
+                            rbf_node.bumpfee, rbfid)
 
 
 def test_bumpfee_with_descendant_fails(rbf_node, rbf_node_address, dest_address):
@@ -186,7 +187,7 @@ def test_dust_to_fee(rbf_node, dest_address):
     full_bumped_tx = rbf_node.getrawtransaction(bumped_tx["txid"], 1)
     assert_equal(bumped_tx["fee"], Decimal("0.00050000"))
     assert_equal(len(fulltx["vout"]), 2)
-    assert_equal(len(full_bumped_tx["vout"]), 1)  #change output is eliminated
+    assert_equal(len(full_bumped_tx["vout"]), 1)  # change output is eliminated
 
 
 def test_settxfee(rbf_node, dest_address):
@@ -215,7 +216,7 @@ def test_rebumping_not_replaceable(rbf_node, dest_address):
     rbfid = spend_one_input(rbf_node, dest_address)
     bumped = rbf_node.bumpfee(rbfid, {"totalFee": 10000, "replaceable": False})
     assert_raises_rpc_error(-4, "Transaction is not BIP 125 replaceable", rbf_node.bumpfee, bumped["txid"],
-                          {"totalFee": 20000})
+                            {"totalFee": 20000})
 
 
 def test_unconfirmed_not_spendable(rbf_node, rbf_node_address):
@@ -266,7 +267,7 @@ def test_locked_wallet_fails(rbf_node, dest_address):
     rbfid = spend_one_input(rbf_node, dest_address)
     rbf_node.walletlock()
     assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first.",
-                          rbf_node.bumpfee, rbfid)
+                            rbf_node.bumpfee, rbfid)
 
 
 def spend_one_input(node, dest_address):

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -5,10 +5,13 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the listtransactions API."""
 
+from decimal import Decimal
 from test_framework.test_framework import RavenTestFramework
 from test_framework.util import *
 from test_framework.mininode import CTransaction, COIN
 from io import BytesIO
+
+
 
 def txFromHex(hexstring):
     tx = CTransaction()
@@ -16,81 +19,83 @@ def txFromHex(hexstring):
     tx.deserialize(f)
     return tx
 
+
 class ListTransactionsTest(RavenTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.enable_mocktime()
+        self.extra_args = [["-mempoolreplacement".format(i)] for i in range(self.num_nodes)]
 
     def run_test(self):
         # Simple send, 0 to 1:
         txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
         self.sync_all()
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"txid":txid},
-                           {"category":"send","account":"","amount":Decimal("-0.1"),"confirmations":0})
+                            {"txid": txid},
+                            {"category": "send", "account": "", "amount": Decimal("-0.1"), "confirmations": 0})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"txid":txid},
-                           {"category":"receive","account":"","amount":Decimal("0.1"),"confirmations":0})
+                            {"txid": txid},
+                            {"category": "receive", "account": "", "amount": Decimal("0.1"), "confirmations": 0})
         # mine a block, confirmations should change:
         self.nodes[0].generate(1)
         self.sync_all()
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"txid":txid},
-                           {"category":"send","account":"","amount":Decimal("-0.1"),"confirmations":1})
+                            {"txid": txid},
+                            {"category": "send", "account": "", "amount": Decimal("-0.1"), "confirmations": 1})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"txid":txid},
-                           {"category":"receive","account":"","amount":Decimal("0.1"),"confirmations":1})
+                            {"txid": txid},
+                            {"category": "receive", "account": "", "amount": Decimal("0.1"), "confirmations": 1})
 
         # send-to-self:
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"txid":txid, "category":"send"},
-                           {"amount":Decimal("-0.2")})
+                            {"txid": txid, "category": "send"},
+                            {"amount": Decimal("-0.2")})
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"txid":txid, "category":"receive"},
-                           {"amount":Decimal("0.2")})
+                            {"txid": txid, "category": "receive"},
+                            {"amount": Decimal("0.2")})
 
         # sendmany from node1: twice to self, twice to node2:
-        send_to = { self.nodes[0].getnewaddress() : 0.11,
-                    self.nodes[1].getnewaddress() : 0.22,
-                    self.nodes[0].getaccountaddress("from1") : 0.33,
-                    self.nodes[1].getaccountaddress("toself") : 0.44 }
+        send_to = {self.nodes[0].getnewaddress(): 0.11,
+                   self.nodes[1].getnewaddress(): 0.22,
+                   self.nodes[0].getaccountaddress("from1"): 0.33,
+                   self.nodes[1].getaccountaddress("toself"): 0.44}
         txid = self.nodes[1].sendmany("", send_to)
         self.sync_all()
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"send","amount":Decimal("-0.11")},
-                           {"txid":txid} )
+                            {"category": "send", "amount": Decimal("-0.11")},
+                            {"txid": txid})
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"category":"receive","amount":Decimal("0.11")},
-                           {"txid":txid} )
+                            {"category": "receive", "amount": Decimal("0.11")},
+                            {"txid": txid})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"send","amount":Decimal("-0.22")},
-                           {"txid":txid} )
+                            {"category": "send", "amount": Decimal("-0.22")},
+                            {"txid": txid})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"receive","amount":Decimal("0.22")},
-                           {"txid":txid} )
+                            {"category": "receive", "amount": Decimal("0.22")},
+                            {"txid": txid})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"send","amount":Decimal("-0.33")},
-                           {"txid":txid} )
+                            {"category": "send", "amount": Decimal("-0.33")},
+                            {"txid": txid})
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"category":"receive","amount":Decimal("0.33")},
-                           {"txid":txid, "account" : "from1"} )
+                            {"category": "receive", "amount": Decimal("0.33")},
+                            {"txid": txid, "account": "from1"})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"send","amount":Decimal("-0.44")},
-                           {"txid":txid, "account" : ""} )
+                            {"category": "send", "amount": Decimal("-0.44")},
+                            {"txid": txid, "account": ""})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"receive","amount":Decimal("0.44")},
-                           {"txid":txid, "account" : "toself"} )
+                            {"category": "receive", "amount": Decimal("0.44")},
+                            {"txid": txid, "account": "toself"})
 
         multisig = self.nodes[1].createmultisig(1, [self.nodes[1].getnewaddress()])
         self.nodes[0].importaddress(multisig["redeemScript"], "watchonly", False, True)
         txid = self.nodes[1].sendtoaddress(multisig["address"], 0.1)
         self.nodes[1].generate(1)
         self.sync_all()
-        assert(len(self.nodes[0].listtransactions("watchonly", 100, 0, False)) == 0)
+        assert (len(self.nodes[0].listtransactions("watchonly", 100, 0, False)) == 0)
         assert_array_result(self.nodes[0].listtransactions("watchonly", 100, 0, True),
-                           {"category":"receive","amount":Decimal("0.1")},
-                           {"txid":txid, "account" : "watchonly"} )
+                            {"category": "receive", "amount": Decimal("0.1")},
+                            {"txid": txid, "account": "watchonly"})
 
         self.run_rbf_opt_in_test()
 
@@ -115,34 +120,34 @@ class ListTransactionsTest(RavenTestFramework):
 
         # 1. Chain a few transactions that don't opt-in.
         txid_1 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
-        assert(not is_opt_in(self.nodes[0], txid_1))
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_1}, {"bip125-replaceable":"no"})
+        assert (not is_opt_in(self.nodes[0], txid_1))
+        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_1}, {"bip125-replaceable": "no"})
         sync_mempools(self.nodes)
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_1}, {"bip125-replaceable":"no"})
+        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_1}, {"bip125-replaceable": "no"})
 
         # Tx2 will build off txid_1, still not opting in to RBF.
         utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[0], txid_1)
         assert_equal(utxo_to_use["safe"], True)
-        utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[1], txid_1)
+        #utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[1], txid_1)
         utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[1], txid_1)
         assert_equal(utxo_to_use["safe"], False)
 
         # Create tx2 using createrawtransaction
-        inputs = [{"txid":utxo_to_use["txid"], "vout":utxo_to_use["vout"]}]
+        inputs = [{"txid": utxo_to_use["txid"], "vout": utxo_to_use["vout"]}]
         outputs = {self.nodes[0].getnewaddress(): 0.999}
         tx2 = self.nodes[1].createrawtransaction(inputs, outputs)
         tx2_signed = self.nodes[1].signrawtransaction(tx2)["hex"]
         txid_2 = self.nodes[1].sendrawtransaction(tx2_signed)
 
         # ...and check the result
-        assert(not is_opt_in(self.nodes[1], txid_2))
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_2}, {"bip125-replaceable":"no"})
+        assert (not is_opt_in(self.nodes[1], txid_2))
+        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_2}, {"bip125-replaceable": "no"})
         sync_mempools(self.nodes)
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_2}, {"bip125-replaceable":"no"})
+        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_2}, {"bip125-replaceable": "no"})
 
         # Tx3 will opt-in to RBF
         utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[0], txid_2)
-        inputs = [{"txid": txid_2, "vout":utxo_to_use["vout"]}]
+        inputs = [{"txid": txid_2, "vout": utxo_to_use["vout"]}]
         outputs = {self.nodes[1].getnewaddress(): 0.998}
         tx3 = self.nodes[0].createrawtransaction(inputs, outputs)
         tx3_modified = txFromHex(tx3)
@@ -151,36 +156,36 @@ class ListTransactionsTest(RavenTestFramework):
         tx3_signed = self.nodes[0].signrawtransaction(tx3)['hex']
         txid_3 = self.nodes[0].sendrawtransaction(tx3_signed)
 
-        assert(is_opt_in(self.nodes[0], txid_3))
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_3}, {"bip125-replaceable":"yes"})
+        assert (is_opt_in(self.nodes[0], txid_3))
+        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_3}, {"bip125-replaceable": "yes"})
         sync_mempools(self.nodes)
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_3}, {"bip125-replaceable":"yes"})
+        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_3}, {"bip125-replaceable": "yes"})
 
         # Tx4 will chain off tx3.  Doesn't signal itself, but depends on one
         # that does.
         utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[1], txid_3)
-        inputs = [{"txid": txid_3, "vout":utxo_to_use["vout"]}]
+        inputs = [{"txid": txid_3, "vout": utxo_to_use["vout"]}]
         outputs = {self.nodes[0].getnewaddress(): 0.997}
         tx4 = self.nodes[1].createrawtransaction(inputs, outputs)
         tx4_signed = self.nodes[1].signrawtransaction(tx4)["hex"]
         txid_4 = self.nodes[1].sendrawtransaction(tx4_signed)
 
-        assert(not is_opt_in(self.nodes[1], txid_4))
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"yes"})
+        assert (not is_opt_in(self.nodes[1], txid_4))
+        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "yes"})
         sync_mempools(self.nodes)
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"yes"})
+        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "yes"})
 
         # Replace tx3, and check that tx4 becomes unknown
         tx3_b = tx3_modified
-        tx3_b.vout[0].nValue -= int(Decimal("0.004") * COIN) # bump the fee
+        tx3_b.vout[0].nValue -= int(Decimal("0.004") * COIN)  # bump the fee
         tx3_b = bytes_to_hex_str(tx3_b.serialize())
         tx3_b_signed = self.nodes[0].signrawtransaction(tx3_b)['hex']
         txid_3b = self.nodes[0].sendrawtransaction(tx3_b_signed, True)
-        assert(is_opt_in(self.nodes[0], txid_3b))
+        assert (is_opt_in(self.nodes[0], txid_3b))
 
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"unknown"})
+        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "unknown"})
         sync_mempools(self.nodes)
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"unknown"})
+        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "unknown"})
 
         # Check gettransaction as well:
         for n in self.nodes[0:2]:
@@ -192,11 +197,10 @@ class ListTransactionsTest(RavenTestFramework):
 
         # After mining a transaction, it's no longer BIP125-replaceable
         self.nodes[0].generate(1)
-        assert(txid_3b not in self.nodes[0].getrawmempool())
+        assert (txid_3b not in self.nodes[0].getrawmempool())
         assert_equal(self.nodes[0].gettransaction(txid_3b)["bip125-replaceable"], "no")
         assert_equal(self.nodes[0].gettransaction(txid_4)["bip125-replaceable"], "unknown")
 
 
 if __name__ == '__main__':
     ListTransactionsTest().main()
-


### PR DESCRIPTION
The wallet_bumpfree.py and wallet_listtransactions.py tests both needed to be modified to reflect the change [PR-286](https://github.com/RavenProject/Ravencoin/pull/286).