### PR TITLE
Add Max Reorganization Depth

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -221,6 +221,9 @@ public:
 
         // DGW Activation
         nDGWActivationBlock = 338778;
+
+        nMaxReorganizationDepth = 55; // 55 at 1 minute block timespan is +/- 55 minutes.
+        nMinReorganizationPeers = 3;
         /** RVN End **/
     }
 };

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -102,6 +102,9 @@ public:
     const std::string& GlobalBurnAddress() const { return strGlobalBurnAddress; }
 
     unsigned int DGWActivationBlock() const { return nDGWActivationBlock; }
+
+    int MaxReorganizationDepth() const { return nMaxReorganizationDepth; }
+    int MinReorganizationPeers() const { return nMinReorganizationPeers; }
     /** RVN End **/
 
 protected:
@@ -140,6 +143,9 @@ protected:
     std::string strGlobalBurnAddress;
 
     unsigned int nDGWActivationBlock;
+
+    int nMaxReorganizationDepth;
+    int nMinReorganizationPeers;
     /** RVN End **/
 };
 

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -22,6 +22,9 @@ static const unsigned char REJECT_NONSTANDARD = 0x40;
 // static const unsigned char REJECT_DUST = 0x41; // part of BIP 61
 static const unsigned char REJECT_INSUFFICIENTFEE = 0x42;
 static const unsigned char REJECT_CHECKPOINT = 0x43;
+/** RVN START */
+static const unsigned char REJECT_MAXREORGDEPTH = 0x44;
+/** RVN END */
 
 /** Capture information about block/transaction validation */
 class CValidationState {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -358,6 +358,8 @@ std::string HelpMessage(HelpMessageMode mode)
     if (showDebug)
         strUsage += HelpMessageOpt("-feefilter", strprintf("Tell other nodes to filter invs to us by our mempool min fee (default: %u)", DEFAULT_FEEFILTER));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file on startup"));
+    strUsage += HelpMessageOpt("-maxreorg=<n>", strprintf(_("Set the Maximum reorg depth (default: %u)"), defaultChainParams->MaxReorganizationDepth()));
+    strUsage += HelpMessageOpt("-minreorgpeers=<n>", strprintf(_("Set the Minimum amount of peers required to not allow reorgs. Peers must be greater than. (default: %u)"), defaultChainParams->MinReorganizationPeers()));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
     strUsage += HelpMessageOpt("-maxmempool=<n>", strprintf(_("Keep the transaction memory pool below <n> megabytes (default: %u)"), DEFAULT_MAX_MEMPOOL_SIZE));
     strUsage += HelpMessageOpt("-mempoolexpiry=<n>", strprintf(_("Do not keep transactions in the mempool longer than <n> hours (default: %u)"), DEFAULT_MEMPOOL_EXPIRY));

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1042,8 +1042,11 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     if (chainActive.Contains(mi->second)) {
                         send = true;
                     } else {
+                        // To prevent fingerprinting attacks, only send blocks outside of the active
+                        // chain if they are valid, and no more than a max reorg depth than the best header
+                        // chain we know about.
                         send = mi->second->IsValid(BLOCK_VALID_SCRIPTS) &&
-                            StaleBlockRequestAllowed(mi->second, consensusParams);
+                            StaleBlockRequestAllowed(mi->second, consensusParams) && (chainActive.Height() - mi->second->nHeight < Params().MaxReorganizationDepth());
                         if (!send) {
                             LogPrintf("%s: ignoring request from peer=%i for old block that isn't in the main chain\n", __func__, pfrom->GetId());
                         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -42,6 +42,7 @@
 #include "validationinterface.h"
 #include "versionbits.h"
 #include "warnings.h"
+#include "net.h"
 
 #include <atomic>
 #include <sstream>
@@ -3522,6 +3523,13 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
 {
     assert(pindexPrev != nullptr);
     const int nHeight = pindexPrev->nHeight + 1;
+
+    //If this is a reorg, check that it is not too deep
+    int nMaxReorgDepth = gArgs.GetArg("-maxreorg", Params().MaxReorganizationDepth());
+    int nMinReorgPeers = gArgs.GetArg("-minreorgpeers", Params().MinReorganizationPeers());
+    bool fGreaterThanMaxReorg = chainActive.Height() - nHeight >= nMaxReorgDepth;
+    if (fGreaterThanMaxReorg && g_connman && (int)g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) > nMinReorgPeers && !IsInitialBlockDownload())
+        return state.DoS(1, error("%s: forked chain older than max reorganization depth (height %d), with connections (count %d), and (initial download %s)", __func__, nHeight, g_connman ? g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) : -1, IsInitialBlockDownload() ? "true" : "false"), REJECT_MAXREORGDEPTH, "bad-fork-prior-to-maxreorgdepth");
 
     // Check proof of work
     const Consensus::Params& consensusParams = params.GetConsensus();


### PR DESCRIPTION
This allows clients to run the wallet and not allow reorganizations that are 55 or more blocks. This can be changed on client start by passing in the flag `maxreorg=<n>`

This should help stop potential chain attacks by malicious users as well as allow exchanges to augment the required amount of confirmations required.