### PR TITLE
Add units to reissuable data

### DIFF
--- a/src/assets/assetdb.cpp
+++ b/src/assets/assetdb.cpp
@@ -73,16 +73,16 @@ bool CAssetsDB::EraseMyOutPoints(const std::string& assetName)
     return true;
 }
 
-bool CAssetsDB::WriteBlockUndoAssetData(const uint256& blockhash, const std::vector<std::pair<std::string, std::string> >& vIPFSHashes)
+bool CAssetsDB::WriteBlockUndoAssetData(const uint256& blockhash, const std::vector<std::pair<std::string, CBlockAssetUndo> >& assetUndoData)
 {
-    return Write(std::make_pair(BLOCK_ASSET_UNDO_DATA, blockhash), vIPFSHashes);
+    return Write(std::make_pair(BLOCK_ASSET_UNDO_DATA, blockhash), assetUndoData);
 }
 
-bool CAssetsDB::ReadBlockUndoAssetData(const uint256 &blockhash, std::vector<std::pair<std::string, std::string> > &vIPFSHashes)
+bool CAssetsDB::ReadBlockUndoAssetData(const uint256 &blockhash, std::vector<std::pair<std::string, CBlockAssetUndo> > &assetUndoData)
 {
     // If it exists, return the read value.
     if (Exists(std::make_pair(BLOCK_ASSET_UNDO_DATA, blockhash)))
-           return Read(std::make_pair(BLOCK_ASSET_UNDO_DATA, blockhash), vIPFSHashes);
+           return Read(std::make_pair(BLOCK_ASSET_UNDO_DATA, blockhash), assetUndoData);
 
     // If it doesn't exist, we just return true because we don't want to fail just because it didn't exist in the db
     return true;

--- a/src/assets/assetdb.h
+++ b/src/assets/assetdb.h
@@ -16,6 +16,24 @@ class CNewAsset;
 class uint256;
 class COutPoint;
 
+struct CBlockAssetUndo
+{
+    bool fChangedIPFS;
+    bool fChangedUnits;
+    std::string strIPFS;
+    int nUnits;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(fChangedUnits);
+        READWRITE(fChangedIPFS);
+        READWRITE(strIPFS);
+        READWRITE(nUnits);
+    }
+};
+
 /** Access to the block database (blocks/index/) */
 class CAssetsDB : public CDBWrapper
 {
@@ -29,14 +47,14 @@ public:
     bool WriteAssetData(const CNewAsset& asset);
     bool WriteMyAssetsData(const std::string &strName, const std::set<COutPoint>& setOuts);
     bool WriteAssetAddressQuantity(const std::string& assetName, const std::string& address, const CAmount& quantity);
-    bool WriteBlockUndoAssetData(const uint256& blockhash, const std::vector<std::pair<std::string, std::string> >& vIPFSHashes);
+    bool WriteBlockUndoAssetData(const uint256& blockhash, const std::vector<std::pair<std::string, CBlockAssetUndo> >& assetUndoData);
     bool WriteReissuedMempoolState();
 
     // Read from database functions
     bool ReadAssetData(const std::string& strName, CNewAsset& asset);
     bool ReadMyAssetsData(const std::string &strName, std::set<COutPoint>& setOuts);
     bool ReadAssetAddressQuantity(const std::string& assetName, const std::string& address, CAmount& quantity);
-    bool ReadBlockUndoAssetData(const uint256& blockhash, std::vector<std::pair<std::string, std::string> >& vIPFSHashes);
+    bool ReadBlockUndoAssetData(const uint256& blockhash, std::vector<std::pair<std::string, CBlockAssetUndo> >& assetUndoData);
     bool ReadReissuedMempoolState();
 
     // Erase from database functions

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -50,6 +50,7 @@ class CReserveKey;
 class CWalletTx;
 struct CAssetOutputEntry;
 class CCoinControl;
+struct CBlockAssetUndo;
 
 // 50000 * 82 Bytes == 4.1 Mb
 #define MAX_CACHE_ASSETS_SIZE 50000
@@ -238,7 +239,7 @@ public :
     bool RemoveNewAsset(const CNewAsset& asset, const std::string address);
     bool RemoveTransfer(const CAssetTransfer& transfer, const std::string& address, const COutPoint& out);
     bool RemoveOwnerAsset(const std::string& assetsName, const std::string address);
-    bool RemoveReissueAsset(const CReissueAsset& reissue, const std::string address, const COutPoint& out, const std::vector<std::pair<std::string, std::string> >& vUndoIPFS);
+    bool RemoveReissueAsset(const CReissueAsset& reissue, const std::string address, const COutPoint& out, const std::vector<std::pair<std::string, CBlockAssetUndo> >& vUndoIPFS);
     bool UndoAssetCoin(const Coin& coin, const COutPoint& out);
 
     // Cache only add asset functions

--- a/src/assets/assettypes.h
+++ b/src/assets/assettypes.h
@@ -131,6 +131,7 @@ class CReissueAsset
 public:
     std::string strName;
     CAmount nAmount;
+    int8_t nUnits;
     int8_t nReissuable;
     std::string strIPFSHash;
 
@@ -143,6 +144,7 @@ public:
     {
         nAmount = 0;
         strName = "";
+        nUnits = 0;
         nReissuable = 1;
         strIPFSHash = "";
     }
@@ -154,11 +156,12 @@ public:
     {
         READWRITE(strName);
         READWRITE(nAmount);
+        READWRITE(nUnits);
         READWRITE(nReissuable);
         READWRITE(strIPFSHash);
     }
 
-    CReissueAsset(const std::string& strAssetName, const CAmount& nAmount, const int& nReissuable, const std::string& strIPFSHash);
+    CReissueAsset(const std::string& strAssetName, const CAmount& nAmount, const int& nUnits, const int& nReissuable, const std::string& strIPFSHash);
     bool IsValid(std::string& strError, CAssetsCache& assetCache) const;
     void ConstructTransaction(CScript& script) const;
     bool IsNull() const;

--- a/src/coins.h
+++ b/src/coins.h
@@ -20,6 +20,7 @@
 
 #include <unordered_map>
 #include <assets/assets.h>
+#include <assets/assetdb.h>
 
 /**
  * A UTXO entry.
@@ -309,7 +310,7 @@ private:
 // an overwrite.
 // TODO: pass in a boolean to limit these possible overwrites to known
 // (pre-BIP34) cases.
-void AddCoins(CCoinsViewCache& cache, const CTransaction& tx, int nHeight, bool check = false, CAssetsCache* assetsCache = nullptr, std::pair<std::string, std::string>* undoIPFSHash = nullptr);
+void AddCoins(CCoinsViewCache& cache, const CTransaction& tx, int nHeight, bool check = false, CAssetsCache* assetsCache = nullptr, std::pair<std::string, CBlockAssetUndo>* undoAssetData = nullptr);
 
 //! Utility function to find any unspent output with a given txid.
 // This function can be quite expensive because in the event of a transaction

--- a/src/qt/forms/reissueassetdialog.ui
+++ b/src/qt/forms/reissueassetdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1260</width>
-    <height>1089</height>
+    <width>1454</width>
+    <height>1185</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -662,6 +662,44 @@
          </layout>
         </item>
         <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QLabel" name="unitLabel">
+            <property name="text">
+             <string>Unit:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="unitSpinBox">
+            <property name="maximum">
+             <number>8</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="unitExampleLabel">
+            <property name="text">
+             <string>e.g. 1.00000000</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_9">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_4">
           <item>
            <widget class="QCheckBox" name="reissuableBox">
@@ -797,6 +835,19 @@
           </property>
          </widget>
         </item>
+        <item>
+         <spacer name="verticalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>100</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
       </item>
      </layout>
@@ -854,7 +905,7 @@
           <property name="sizeHint" stdset="0">
            <size>
             <width>5</width>
-            <height>500</height>
+            <height>250</height>
            </size>
           </property>
          </spacer>

--- a/src/qt/reissueassetdialog.h
+++ b/src/qt/reissueassetdialog.h
@@ -77,6 +77,7 @@ private Q_SLOTS:
     void onAddressNameChanged(QString address);
     void onReissueAssetClicked();
     void onReissueBoxChanged();
+    void onUnitChanged(int value);
 
     //CoinControl
     void coinControlFeatureChanged(bool);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -38,6 +38,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "transfer", 1, "qty"},
     { "reissue", 1, "qty"},
     { "reissue", 4, "reissuable"},
+    { "reissue", 5, "new_unit"},
     { "listmyassets", 1, "verbose" },
     { "listmyassets", 2, "count" },
     { "listmyassets", 3, "start"},

--- a/src/test/assets/asset_reissue_tests.cpp
+++ b/src/test/assets/asset_reissue_tests.cpp
@@ -25,13 +25,13 @@ BOOST_FIXTURE_TEST_SUITE(asset_reissue_tests, BasicTestingSetup)
     // Create assets cache
     CAssetsCache cache;
 
-    CNewAsset asset1("RVNASSET", CAmount(100), 8, 1, 0, "");
+    CNewAsset asset1("RVNASSET", CAmount(100 * COIN), 8, 1, 0, "");
 
     // Add an asset to a valid rvn address
     BOOST_CHECK_MESSAGE(cache.AddNewAsset(asset1, Params().GlobalBurnAddress()), "Failed to add new asset");
 
     // Create a reissuance of the asset
-    CReissueAsset reissue1("RVNASSET", CAmount(1), 1, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
+    CReissueAsset reissue1("RVNASSET", CAmount(1 * COIN), 8, 1, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
     COutPoint out(uint256S("BF50CB9A63BE0019171456252989A459A7D0A5F494735278290079D22AB704A4"), 1);
 
     // Add an reissuance of the asset to the cache
@@ -39,7 +39,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_reissue_tests, BasicTestingSetup)
 
     // Check to see if the reissue changed the cache data correctly
     BOOST_CHECK_MESSAGE(cache.mapReissuedAssetData.count("RVNASSET"), "Map Reissued Asset should contain the asset \"RVNASSET\"");
-    BOOST_CHECK_MESSAGE(cache.mapAssetsAddressAmount.at(make_pair("RVNASSET", Params().GlobalBurnAddress())) == CAmount(101), "Reissued amount wasn't added to the previous total");
+    BOOST_CHECK_MESSAGE(cache.mapAssetsAddressAmount.at(make_pair("RVNASSET", Params().GlobalBurnAddress())) == CAmount(101 * COIN), "Reissued amount wasn't added to the previous total");
     BOOST_CHECK_MESSAGE(cache.mapAssetsAddresses.at("RVNASSET").count(Params().GlobalBurnAddress()), "Reissued address wasn't in the map");
 
     // Get the new asset data from the cache
@@ -48,15 +48,15 @@ BOOST_FIXTURE_TEST_SUITE(asset_reissue_tests, BasicTestingSetup)
 
     // Chech the asset metadata
     BOOST_CHECK_MESSAGE(asset2.nReissuable == 1, "Asset2: Reissuable isn't 1");
-    BOOST_CHECK_MESSAGE(asset2.nAmount == CAmount(101), "Asset2: Amount isn't 101");
+    BOOST_CHECK_MESSAGE(asset2.nAmount == CAmount(101 * COIN), "Asset2: Amount isn't 101");
     BOOST_CHECK_MESSAGE(asset2.strName == "RVNASSET", "Asset2: Asset name is wrong");
     BOOST_CHECK_MESSAGE(asset2.units == 8, "Asset2: Units is wrong");
     BOOST_CHECK_MESSAGE(EncodeIPFS(asset2.strIPFSHash) == "QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo", "Asset2: IPFS hash is wrong");
 
     // Remove the reissue from the cache
-    std::vector<std::pair<std::string, std::string> > undoBlockIPFS;
-    undoBlockIPFS.emplace_back(std::make_pair("RVNASSET", ""));
-    BOOST_CHECK_MESSAGE(cache.RemoveReissueAsset(reissue1, Params().GlobalBurnAddress(), out, undoBlockIPFS), "Failed to remove reissue");
+    std::vector<std::pair<std::string, CBlockAssetUndo> > undoBlockData;
+    undoBlockData.emplace_back(std::make_pair("RVNASSET", CBlockAssetUndo {true, false, "", 0}));
+    BOOST_CHECK_MESSAGE(cache.RemoveReissueAsset(reissue1, Params().GlobalBurnAddress(), out, undoBlockData), "Failed to remove reissue");
 
     // Get the asset data from the cache now that the reissuance was removed
     CNewAsset asset3;
@@ -64,14 +64,14 @@ BOOST_FIXTURE_TEST_SUITE(asset_reissue_tests, BasicTestingSetup)
 
     // Chech the asset3 metadata and make sure all the changed from the reissue were removed
     BOOST_CHECK_MESSAGE(asset3.nReissuable == 1, "Asset3: Reissuable isn't 1");
-    BOOST_CHECK_MESSAGE(asset3.nAmount == CAmount(100), "Asset3: Amount isn't 100");
+    BOOST_CHECK_MESSAGE(asset3.nAmount == CAmount(100 * COIN), "Asset3: Amount isn't 100");
     BOOST_CHECK_MESSAGE(asset3.strName == "RVNASSET", "Asset3: Asset name is wrong");
     BOOST_CHECK_MESSAGE(asset3.units == 8, "Asset3: Units is wrong");
     BOOST_CHECK_MESSAGE(asset3.strIPFSHash == "", "Asset3: IPFS hash is wrong");
 
     // Check to see if the reissue removal updated the cache correctly
     BOOST_CHECK_MESSAGE(cache.mapReissuedAssetData.count("RVNASSET"), "Map of reissued data was removed, even though changes were made and not databased yet");
-    BOOST_CHECK_MESSAGE(cache.mapAssetsAddressAmount.at(make_pair("RVNASSET", Params().GlobalBurnAddress())) == CAmount(100), "Assets total wasn't undone when reissuance was");
+    BOOST_CHECK_MESSAGE(cache.mapAssetsAddressAmount.at(make_pair("RVNASSET", Params().GlobalBurnAddress())) == CAmount(100 * COIN), "Assets total wasn't undone when reissuance was");
     }
 
 
@@ -82,22 +82,47 @@ BOOST_FIXTURE_TEST_SUITE(asset_reissue_tests, BasicTestingSetup)
         // Create assets cache
         CAssetsCache cache;
 
-        CNewAsset asset1("RVNASSET", CAmount(100), 8, 1, 0, "");
+        CNewAsset asset1("RVNASSET", CAmount(100 * COIN), 8, 1, 0, "");
 
         // Add an asset to a valid rvn address
         BOOST_CHECK_MESSAGE(cache.AddNewAsset(asset1, Params().GlobalBurnAddress()), "Failed to add new asset");
 
         // Create a reissuance of the asset that is valid
-        CReissueAsset reissue1("RVNASSET", CAmount(1), 1, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
+        CReissueAsset reissue1("RVNASSET", CAmount(1 * COIN), 8, 1, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
 
         std::string error;
         BOOST_CHECK_MESSAGE(reissue1.IsValid(error, cache), "Reissue should of been valid");
 
         // Create a reissuance of the asset that is not valid
-        CReissueAsset reissue2("NOTEXIST", CAmount(1), 1, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
+        CReissueAsset reissue2("NOTEXIST", CAmount(1 * COIN), 8, 1, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
 
         BOOST_CHECK_MESSAGE(!reissue2.IsValid(error, cache), "Reissue shouldn't of been valid");
 
+        // Create a reissuance of the asset that is not valid (unit is smaller than current asset)
+        CReissueAsset reissue3("RVNASSET", CAmount(1 * COIN), 7, 1, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
+
+        BOOST_CHECK_MESSAGE(!reissue3.IsValid(error, cache), "Reissue shouldn't of been valid because of units");
+
+        // Create a reissuance of the asset that is not valid (unit is not changed)
+        CReissueAsset reissue4("RVNASSET", CAmount(1 * COIN), -1, 1, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
+
+        BOOST_CHECK_MESSAGE(reissue4.IsValid(error, cache), "Reissue4 wasn't valid");
+
+        // Create a new asset object with units of 0
+        CNewAsset asset2("RVNASSET2", CAmount(100 * COIN), 0, 1, 0, "");
+
+        // Add new asset to a valid rvn address
+        BOOST_CHECK_MESSAGE(cache.AddNewAsset(asset2, Params().GlobalBurnAddress()), "Failed to add new asset");
+
+        // Create a reissuance of the asset that is valid unit go from 0 -> 1 and change the ipfs hash
+        CReissueAsset reissue5("RVNASSET2", CAmount(1 * COIN), 1, 1, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
+
+        BOOST_CHECK_MESSAGE(reissue5.IsValid(error, cache), "Reissue5 wasn't valid");
+
+        // Create a reissuance of the asset that is valid unit go from 1 -> 1 and change the ipfs hash
+        CReissueAsset reissue6("RVNASSET2", CAmount(1 * COIN), 1, 1, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
+
+        BOOST_CHECK_MESSAGE(reissue6.IsValid(error, cache), "Reissue6 wasn't valid");
     }
 
 

--- a/src/test/assets/serialization_tests.cpp
+++ b/src/test/assets/serialization_tests.cpp
@@ -42,7 +42,7 @@ BOOST_FIXTURE_TEST_SUITE(serialization_tests, BasicTestingSetup)
 
         // Create asset
         std::string name = "SERIALIZATION";
-        CReissueAsset reissue(name, 100000000, 0, "");
+        CReissueAsset reissue(name, 100000000, 0, 0, "");
 
         // Create destination
         CTxDestination dest = DecodeDestination("mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp"); // Testnet Address

--- a/src/validation.h
+++ b/src/validation.h
@@ -34,6 +34,7 @@
 
 #include <atomic>
 #include <assets/assets.h>
+#include <assets/assetdb.h>
 
 class CBlockIndex;
 class CBlockTreeDB;
@@ -342,7 +343,7 @@ int VersionBitsTipStateSinceHeight(const Consensus::Params& params, Consensus::D
 /** Apply the effects of this transaction on the UTXO set represented by view */
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);
 
-void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo& txundo, int nHeight, CAssetsCache* assetCache = nullptr, std::pair<std::string, std::string>* undoIPFSHash = nullptr);
+void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo& txundo, int nHeight, CAssetsCache* assetCache = nullptr, std::pair<std::string, CBlockAssetUndo>* undoAssetData = nullptr);
 
 /** Transaction validation functions */
 


### PR DESCRIPTION
Now, when you reissue an asset. You can change the units assigned to that asset. You can only make the units larger/more precise 

**Unit from 0 -> 1**
`e.g.  1 -> 1.0` Valid Unit Change
**Unit from 0 -> 2**
`e.g. 1 -> 1.00` Valid Unit Change

**Unit from 1 -> 0**
`e.g. 1.0 -> 1` Not Valid