### PR TITLE
Add Unique isValid consesus checks

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -253,9 +253,21 @@ bool CNewAsset::IsValid(std::string& strError, CAssetsCache& assetCache, bool fC
         }
     }
 
-    if (!IsAssetNameValid(std::string(strName))) {
+    AssetType assetType;
+    if (!IsAssetNameValid(std::string(strName), assetType)) {
         strError = "Invalid parameter: asset_name must only consist of valid characters and have a size between 3 and 30 characters. See help for more details.";
         return false;
+    }
+
+    if (assetType == AssetType::UNIQUE) {
+        if (units != UNIQUE_ASSET_UNITS) {
+            strError = "Invalid parameter: units must be " + std::to_string(UNIQUE_ASSET_UNITS / COIN);
+            return false;
+        }
+        if (nAmount != UNIQUE_ASSET_AMOUNT) {
+            strError = "Invalid parameter: amount must be " + std::to_string(UNIQUE_ASSET_AMOUNT);
+            return false;
+        }
     }
 
     if (IsAssetNameAnOwner(std::string(strName))) {

--- a/src/qt/createassetdialog.cpp
+++ b/src/qt/createassetdialog.cpp
@@ -604,6 +604,12 @@ void CreateAssetDialog::onAssetTypeActivated(int index)
     if(!(type == IntFromAssetType(AssetType::ROOT) || type == IntFromAssetType(AssetType::SUB) || type == IntFromAssetType(AssetType::UNIQUE)))
         type = IntFromAssetType(AssetType::ROOT);
 
+    // If the type is UNIQUE, set the units and amount to the correct value, and disable them.
+    if (type == IntFromAssetType(AssetType::UNIQUE))
+        setUniqueSelected();
+    else
+        clearSelected();
+
     // Get the identifier for the asset type
     QString identifier = GetSpecialCharacter();
 
@@ -951,4 +957,23 @@ void CreateAssetDialog::updateMinFeeLabel()
         ui->checkBoxMinimumFee->setText(tr("Pay only the required fee of %1").arg(
                 RavenUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), GetRequiredFee(1000)) + "/kB")
         );
+}
+
+void CreateAssetDialog::setUniqueSelected()
+{
+    ui->reissuableBox->setChecked(false);
+    ui->quantitySpinBox->setValue(1);
+    ui->unitBox->setValue(0);
+    ui->reissuableBox->setDisabled(true);
+    ui->unitBox->setDisabled(true);
+    ui->quantitySpinBox->setDisabled(true);
+}
+
+void CreateAssetDialog::clearSelected()
+{
+    ui->reissuableBox->setDisabled(false);
+    ui->unitBox->setDisabled(false);
+    ui->quantitySpinBox->setDisabled(false);
+    ui->reissuableBox->setChecked(true);
+    ui->unitBox->setValue(8);
 }

--- a/src/qt/createassetdialog.h
+++ b/src/qt/createassetdialog.h
@@ -59,6 +59,8 @@ private:
     QString GetAssetName();
     void UpdateAssetNameMaxSize();
     void UpdateAssetNameToUpper();
+    void setUniqueSelected();
+    void clearSelected();
 
     //CoinControl
     // Update the passed in CCoinControl with state from the GUI


### PR DESCRIPTION
Fixes #281 found by @Scotty0448 
At a consensus level the unique asset metadata wasn't being validated. 

This PR adds checks to make sure the Units are set to 0 and the Amount is set to 1 * COIN.

Also, the QT wallet now sets these values for you if you try to create a Unique Asset using the asset creation prompt. 