### PR TITLE
 changes to script serialization of IPFS hash for issue/reissue

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -356,6 +356,14 @@ bool CNewAsset::IsValid(std::string& strError, CAssetsCache& assetCache, bool fC
         return false;
     }
 
+    if (nHasIPFS) {
+        std::string encoded = EncodeIPFS(strIPFSHash);
+        if (encoded.substr(0,2) != "Qm") {
+            strError = "Invalid parameter: ipfs_hash must start with 'Qm'.";
+            return false;
+        }
+    }
+
     return true;
 }
 
@@ -912,6 +920,14 @@ bool CReissueAsset::IsValid(std::string &strError, CAssetsCache& assetCache) con
     if (strIPFSHash != "" && strIPFSHash.size() != 34) {
         strError = "Unable to reissue asset: new ipfs_hash must be 34 bytes.";
         return false;
+    }
+
+    if (strIPFSHash != "") {
+        std::string encoded = EncodeIPFS(strIPFSHash);
+        if (encoded.substr(0,2) != "Qm") {
+            strError = "Invalid parameter: ipfs_hash must start with 'Qm'.";
+            return false;
+        }
     }
 
     if (nAmount < 0) {

--- a/src/assets/assettypes.h
+++ b/src/assets/assettypes.h
@@ -7,11 +7,9 @@
 #define RAVENCOIN_NEWASSET_H
 
 #include <string>
-#include <iostream>
 #include <sstream>
 #include <list>
 #include <unordered_map>
-#include "assert.h"
 #include "amount.h"
 #include "primitives/transaction.h"
 
@@ -38,7 +36,8 @@ const char IPFS_SHA2_256 = 0x12;
 const char IPFS_SHA2_256_LEN = 0x20;
 
 template <typename Stream, typename Operation>
-void ReadWriteIPFSHash(Stream& s, Operation ser_action, std::string& strIPFSHash) {
+void ReadWriteIPFSHash(Stream& s, Operation ser_action, std::string& strIPFSHash)
+{
     // 34-byte IPFS SHA2-256 decoded hash (0x12, 0x20, ...)
     if (ser_action.ForRead())
     {
@@ -56,7 +55,9 @@ void ReadWriteIPFSHash(Stream& s, Operation ser_action, std::string& strIPFSHash
                 }
             }
         }
-    } else {
+    }
+    else
+    {
         if (strIPFSHash.length() == 34 && strIPFSHash.at(0) == IPFS_SHA2_256 && strIPFSHash.at(1) == IPFS_SHA2_256_LEN) {
             ::Serialize(s, IPFS_SHA2_256);
             ::Serialize(s, strIPFSHash.substr(2));

--- a/src/assets/assettypes.h
+++ b/src/assets/assettypes.h
@@ -38,27 +38,23 @@ const char IPFS_SHA2_256_LEN = 0x20;
 template <typename Stream, typename Operation>
 void ReadWriteIPFSHash(Stream& s, Operation ser_action, std::string& strIPFSHash)
 {
-    // 34-byte IPFS SHA2-256 decoded hash (0x12, 0x20, ...)
+    // assuming 34-byte IPFS SHA2-256 decoded hash (0x12, 0x20, 32 more bytes)
     if (ser_action.ForRead())
     {
         strIPFSHash = "";
         if (!s.empty() and s.size() >= 34) {
-            char sha2_256;
-            ::Unserialize(s, sha2_256);
-            if (sha2_256 == IPFS_SHA2_256) {
-                std::basic_string<char> hash;
-                ::Unserialize(s, hash);
-                if (hash.length() == 32) {
-                    std::ostringstream os;
-                    os << sha2_256 << IPFS_SHA2_256_LEN << hash;
-                    strIPFSHash = os.str();
-                }
-            }
+            char _sha2_256;
+            ::Unserialize(s, _sha2_256);
+            std::basic_string<char> hash;
+            ::Unserialize(s, hash);
+            std::ostringstream os;
+            os << IPFS_SHA2_256 << IPFS_SHA2_256_LEN << hash.substr(0, 32);
+            strIPFSHash = os.str();
         }
     }
     else
     {
-        if (strIPFSHash.length() == 34 && strIPFSHash.at(0) == IPFS_SHA2_256 && strIPFSHash.at(1) == IPFS_SHA2_256_LEN) {
+        if (strIPFSHash.length() == 34) {
             ::Serialize(s, IPFS_SHA2_256);
             ::Serialize(s, strIPFSHash.substr(2));
         }

--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -187,8 +187,13 @@ UniValue issue(const JSONRPCRequest& request)
         has_ipfs = request.params[6].get_bool();
 
     std::string ipfs_hash = "";
-    if (request.params.size() > 7 && has_ipfs)
+    if (request.params.size() > 7 && has_ipfs) {
         ipfs_hash = request.params[7].get_str();
+        if (ipfs_hash.length() != 46)
+            throw JSONRPCError(RPC_INVALID_PARAMS, std::string("Invalid IPFS hash (must be 46 characters)"));
+        if (ipfs_hash.substr(0,2) != "Qm")
+            throw JSONRPCError(RPC_INVALID_PARAMS, std::string("Invalid IPFS hash (doesn't start with 'Qm')"));
+    }
 
     // check for required unique asset params
     if (assetType == AssetType::UNIQUE && (nAmount != COIN || units != 0 || reissuable)) {
@@ -815,7 +820,9 @@ UniValue reissue(const JSONRPCRequest& request)
     if (request.params.size() > 6) {
         newipfs = request.params[6].get_str();
         if (newipfs.length() != 46)
-            throw JSONRPCError(RPC_INVALID_PARAMS, std::string("Invalid IPFS hash (must be 46 characters"));
+            throw JSONRPCError(RPC_INVALID_PARAMS, std::string("Invalid IPFS hash (must be 46 characters)"));
+        if (newipfs.substr(0,2) != "Qm")
+            throw JSONRPCError(RPC_INVALID_PARAMS, std::string("Invalid IPFS hash (doesn't start with 'Qm')"));
     }
 
     CReissueAsset reissueAsset(asset_name, nAmount, newUnits, reissuable, DecodeIPFS(newipfs));

--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -94,7 +94,7 @@ UniValue issue(const JSONRPCRequest& request)
             "5. \"units\"                 (integer, optional, default=0, min=0, max=8), the number of decimals precision for the asset (0 for whole units (\"1\"), 8 for max precision (\"1.00000000\")\n"
             "6. \"reissuable\"            (boolean, optional, default=true (false for unique assets)), whether future reissuance is allowed\n"
             "7. \"has_ipfs\"              (boolean, optional, default=false), whether ifps hash is going to be added to the asset\n"
-            "8. \"ipfs_hash\"             (string, optional but required if has_ipfs = 1), an ipfs hash\n"
+            "8. \"ipfs_hash\"             (string, optional but required if has_ipfs = 1), an ipfs hash (only sha2-256 hashes currently supported -- Qm...)\n"
 
             "\nResult:\n"
             "\"txid\"                     (string) The transaction id\n"
@@ -234,7 +234,7 @@ UniValue issueunique(const JSONRPCRequest& request)
                 "\nArguments:\n"
                 "1. \"root_name\"             (string, required) name of the asset the unique asset(s) are being issued under\n"
                 "2. \"asset_tags\"            (array, required) the unique tag for each asset which is to be issued\n"
-                "3. \"ipfs_hashes\"           (array, optional) ipfs hashes corresponding to each supplied tag (should be same size as \"asset_tags\")\n"
+                "3. \"ipfs_hashes\"           (array, optional) ipfs hashes corresponding to each supplied tag (should be same size as \"asset_tags\") (only sha2-256 hashes currently supported -- Qm...)\n"
                 "4. \"to_address\"            (string, optional, default=\"\"), address assets will be sent to, if it is empty, address will be generated for you\n"
                 "5. \"change_address\"        (string, optional, default=\"\"), address the the rvn change will be sent to, if it is empty, change address will be generated for you\n"
 
@@ -770,7 +770,7 @@ UniValue reissue(const JSONRPCRequest& request)
                 "3. \"to_address\"               (string, required) address to send the asset to\n"
                 "4. \"change_address\"           (string, optional) address that the change of the transaction will be sent to\n"
                 "5. \"reissuable\"               (boolean, optional, default=true), whether future reissuance is allowed\n"
-                "6. \"new_ifps\"                 (string, optional, default=\"\"), whether to update the current ipfshash\n"
+                "6. \"new_ifps\"                 (string, optional, default=\"\"), whether to update the current ipfshash (only sha2-256 hashes currently supported -- Qm...)\n"
 
                 "\nResult:\n"
                 "\"txid\"                     (string) The transaction id\n"

--- a/src/test/assets/serialization_tests.cpp
+++ b/src/test/assets/serialization_tests.cpp
@@ -15,26 +15,45 @@
 BOOST_FIXTURE_TEST_SUITE(serialization_tests, BasicTestingSetup)
 
     BOOST_AUTO_TEST_CASE(issue_asset_serialization) {
-    SelectParams("test");
+        SelectParams("test");
 
-    // Create asset
-    CNewAsset asset("SERIALIZATION", 100000000);
+        // Create asset
+        CNewAsset asset("SERIALIZATION", 100000000, 0, 0, 1, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
 
-    // Create destination
-    CTxDestination dest = DecodeDestination("mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp"); // Testnet Address
+        // Create destination
+        CTxDestination dest = DecodeDestination("mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp"); // Testnet Address
 
-    BOOST_CHECK(IsValidDestination(dest));
+        BOOST_CHECK(IsValidDestination(dest));
 
-    CScript scriptPubKey = GetScriptForDestination(dest);
+        CScript scriptPubKey = GetScriptForDestination(dest);
 
-    asset.ConstructTransaction(scriptPubKey);
+        asset.ConstructTransaction(scriptPubKey);
 
-    CNewAsset serializedAsset;
-    std::string address;
-    BOOST_CHECK_MESSAGE(AssetFromScript(scriptPubKey, serializedAsset, address), "Failed to get asset from script");
-    BOOST_CHECK_MESSAGE(address == "mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp", "Addresses weren't equal");
-    BOOST_CHECK_MESSAGE(serializedAsset.strName == "SERIALIZATION", "Asset names weren't equal");
-    BOOST_CHECK_MESSAGE(serializedAsset.nAmount == 100000000, "Amount weren't equal");
+        CNewAsset serializedAsset;
+        std::string address;
+        BOOST_CHECK_MESSAGE(AssetFromScript(scriptPubKey, serializedAsset, address), "Failed to get asset from script");
+        BOOST_CHECK_MESSAGE(address == "mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp", "Addresses weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset.strName == "SERIALIZATION", "Asset names weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset.nAmount == 100000000, "Amount weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset.units == 0, "Units weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset.nReissuable == 0, "Reissuable wasn't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset.nHasIPFS == 1, "HasIPFS wasn't equal");
+        std::cout << EncodeIPFS(serializedAsset.strIPFSHash);
+        BOOST_CHECK_MESSAGE(EncodeIPFS(serializedAsset.strIPFSHash) == "QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo", "IPFSHash wasn't equal");
+        
+        // Bare asset
+        asset = CNewAsset("SERIALIZATION", 100000000);
+        scriptPubKey = GetScriptForDestination(dest);
+        asset.ConstructTransaction(scriptPubKey);
+        BOOST_CHECK_MESSAGE(AssetFromScript(scriptPubKey, serializedAsset, address), "Failed to get asset from script");
+        BOOST_CHECK_MESSAGE(address == "mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp", "Addresses weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset.strName == "SERIALIZATION", "Asset names weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset.nAmount == 100000000, "Amount weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset.units == 0, "Units weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset.nReissuable == 1, "Reissuable wasn't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset.nHasIPFS == 0, "HasIPFS wasn't equal");
+        std::cout << EncodeIPFS(serializedAsset.strIPFSHash);
+        BOOST_CHECK_MESSAGE(serializedAsset.strIPFSHash == "", "IPFSHash wasn't equal");
     }
 
     BOOST_AUTO_TEST_CASE(reissue_asset_serialization) {
@@ -42,7 +61,7 @@ BOOST_FIXTURE_TEST_SUITE(serialization_tests, BasicTestingSetup)
 
         // Create asset
         std::string name = "SERIALIZATION";
-        CReissueAsset reissue(name, 100000000, 0, "");
+        CReissueAsset reissue(name, 100000000, 0, DecodeIPFS("QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"));
 
         // Create destination
         CTxDestination dest = DecodeDestination("mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp"); // Testnet Address
@@ -59,6 +78,7 @@ BOOST_FIXTURE_TEST_SUITE(serialization_tests, BasicTestingSetup)
         BOOST_CHECK_MESSAGE(address == "mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp", "Addresses weren't equal");
         BOOST_CHECK_MESSAGE(serializedAsset.strName == "SERIALIZATION", "Asset names weren't equal");
         BOOST_CHECK_MESSAGE(serializedAsset.nAmount == 100000000, "Amount weren't equal");
+        BOOST_CHECK_MESSAGE(EncodeIPFS(serializedAsset.strIPFSHash) == "QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo", "IPFSHash wasn't equal");
     }
 
     BOOST_AUTO_TEST_CASE(owner_asset_serialization) {

--- a/src/test/assets/serialization_tests.cpp
+++ b/src/test/assets/serialization_tests.cpp
@@ -38,22 +38,21 @@ BOOST_FIXTURE_TEST_SUITE(serialization_tests, BasicTestingSetup)
         BOOST_CHECK_MESSAGE(serializedAsset.units == 0, "Units weren't equal");
         BOOST_CHECK_MESSAGE(serializedAsset.nReissuable == 0, "Reissuable wasn't equal");
         BOOST_CHECK_MESSAGE(serializedAsset.nHasIPFS == 1, "HasIPFS wasn't equal");
-        std::cout << EncodeIPFS(serializedAsset.strIPFSHash);
         BOOST_CHECK_MESSAGE(EncodeIPFS(serializedAsset.strIPFSHash) == "QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo", "IPFSHash wasn't equal");
         
         // Bare asset
-        asset = CNewAsset("SERIALIZATION", 100000000);
+        CNewAsset asset2("SERIALIZATION", 100000000);
         scriptPubKey = GetScriptForDestination(dest);
-        asset.ConstructTransaction(scriptPubKey);
-        BOOST_CHECK_MESSAGE(AssetFromScript(scriptPubKey, serializedAsset, address), "Failed to get asset from script");
+        asset2.ConstructTransaction(scriptPubKey);
+        CNewAsset serializedAsset2;
+        BOOST_CHECK_MESSAGE(AssetFromScript(scriptPubKey, serializedAsset2, address), "Failed to get asset from script");
         BOOST_CHECK_MESSAGE(address == "mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp", "Addresses weren't equal");
-        BOOST_CHECK_MESSAGE(serializedAsset.strName == "SERIALIZATION", "Asset names weren't equal");
-        BOOST_CHECK_MESSAGE(serializedAsset.nAmount == 100000000, "Amount weren't equal");
-        BOOST_CHECK_MESSAGE(serializedAsset.units == 0, "Units weren't equal");
-        BOOST_CHECK_MESSAGE(serializedAsset.nReissuable == 1, "Reissuable wasn't equal");
-        BOOST_CHECK_MESSAGE(serializedAsset.nHasIPFS == 0, "HasIPFS wasn't equal");
-        std::cout << EncodeIPFS(serializedAsset.strIPFSHash);
-        BOOST_CHECK_MESSAGE(serializedAsset.strIPFSHash == "", "IPFSHash wasn't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset2.strName == "SERIALIZATION", "Asset names weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset2.nAmount == 100000000, "Amount weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset2.units == 0, "Units weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset2.nReissuable == 1, "Reissuable wasn't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset2.nHasIPFS == 0, "HasIPFS wasn't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset2.strIPFSHash == "", "IPFSHash wasn't equal");
     }
 
     BOOST_AUTO_TEST_CASE(reissue_asset_serialization) {
@@ -79,6 +78,17 @@ BOOST_FIXTURE_TEST_SUITE(serialization_tests, BasicTestingSetup)
         BOOST_CHECK_MESSAGE(serializedAsset.strName == "SERIALIZATION", "Asset names weren't equal");
         BOOST_CHECK_MESSAGE(serializedAsset.nAmount == 100000000, "Amount weren't equal");
         BOOST_CHECK_MESSAGE(EncodeIPFS(serializedAsset.strIPFSHash) == "QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo", "IPFSHash wasn't equal");
+
+        // Empty IPFS
+        CReissueAsset reissue2(name, 100000000, 0, "");
+        scriptPubKey = GetScriptForDestination(dest);
+        reissue2.ConstructTransaction(scriptPubKey);
+        CReissueAsset serializedAsset2;
+        BOOST_CHECK_MESSAGE(ReissueAssetFromScript(scriptPubKey, serializedAsset2, address), "Failed to get asset from script");
+        BOOST_CHECK_MESSAGE(address == "mfe7MqgYZgBuXzrT2QTFqZwBXwRDqagHTp", "Addresses weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset2.strName == "SERIALIZATION", "Asset names weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset2.nAmount == 100000000, "Amount weren't equal");
+        BOOST_CHECK_MESSAGE(serializedAsset2.strIPFSHash == "", "IPFSHash wasn't equal");
     }
 
     BOOST_AUTO_TEST_CASE(owner_asset_serialization) {


### PR DESCRIPTION
The purpose here is to get close enough to the KAAAW protocol to allow for future expansion without protocol changes.