### PR TITLE
Fixing two additional tests that needed updates for the new max-reorg

### DIFF
--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -12,6 +12,7 @@ class InvalidateTest(RavenTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
+        self.extra_args = [["-maxreorg=10000".format(i)] for i in range(self.num_nodes)]
 
     def setup_network(self):
         self.setup_nodes()

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -11,6 +11,8 @@ from test_framework.util import *
 class TxnMallTest(RavenTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
+        self.extra_args = [["-maxreorg=10000".format(i)] for i in range(self.num_nodes)]
+
 
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",


### PR DESCRIPTION
Since these two tests were in the extended, and now in the base functional tests we missed the max-reorg depth change that also needed to be applied to allow these tests to run correctly.