### PR TITLE
Default to 60 block re-org.  Note: Will not re-org AT 60 or above - s…

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -57,7 +57,7 @@ static const std::regex CHANNEL_INDICATOR(R"(^[^^~#!]+~[^~#!\/]+$)");
 static const std::regex OWNER_INDICATOR(R"(^[^^~#!]+!$)");
 static const std::regex VOTE_INDICATOR(R"(^[^^~#!]+\^[^~#!\/]+$)");
 
-static const std::regex RAVEN_NAMES("^RVN$|^RAVEN$|^RAVENCOIN$|^RAVENC0IN$|^RAVENCO1N$|^RAVENC01N$");
+static const std::regex RAVEN_NAMES("^RVN$|^RAVEN$|^RAVENCOIN$");
 
 bool IsRootNameValid(const std::string& name)
 {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -223,7 +223,7 @@ public:
         // DGW Activation
         nDGWActivationBlock = 338778;
 
-        nMaxReorganizationDepth = 55; // 55 at 1 minute block timespan is +/- 55 minutes.
+        nMaxReorganizationDepth = 60; // 60 at 1 minute block timespan is +/- 60 minutes.
         nMinReorganizationPeers = 3;
         /** RVN End **/
     }
@@ -392,7 +392,11 @@ public:
 
         // DGW Activation
         nDGWActivationBlock = 200;
+
+        nMaxReorganizationDepth = 60; // 60 at 1 minute block timespan is +/- 60 minutes.
+        nMinReorganizationPeers = 3;
         /** RVN End **/
+
     }
 };
 
@@ -546,6 +550,9 @@ public:
 
         // DGW Activation
         nDGWActivationBlock = 200;
+
+        nMaxReorganizationDepth = 60; // 60 at 1 minute block timespan is +/- 60 minutes.
+        nMinReorganizationPeers = 3;
         /** RVN End **/
     }
 };


### PR DESCRIPTION
Switching from 55 to 60.  The 5 block buffer isn't necessary.  Exchanges operate on confirms (not time), and the re-org comparison is >= so at 60 it will not re-org if all the other conditions (node count and !IsInitialDownload) are met.  Recommend 60 confirms before acceptance of RVN or Ravencoin hosted assets.