### PR TITLE
Switch to >= 4 instead of > 3 to make min=req amount. Fix msg for thr…

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -224,7 +224,7 @@ public:
         nDGWActivationBlock = 338778;
 
         nMaxReorganizationDepth = 60; // 60 at 1 minute block timespan is +/- 60 minutes.
-        nMinReorganizationPeers = 3;
+        nMinReorganizationPeers = 4;
         /** RVN End **/
     }
 };
@@ -394,7 +394,7 @@ public:
         nDGWActivationBlock = 200;
 
         nMaxReorganizationDepth = 60; // 60 at 1 minute block timespan is +/- 60 minutes.
-        nMinReorganizationPeers = 3;
+        nMinReorganizationPeers = 4;
         /** RVN End **/
 
     }
@@ -552,7 +552,7 @@ public:
         nDGWActivationBlock = 200;
 
         nMaxReorganizationDepth = 60; // 60 at 1 minute block timespan is +/- 60 minutes.
-        nMinReorganizationPeers = 3;
+        nMinReorganizationPeers = 4;
         /** RVN End **/
     }
 };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3528,8 +3528,12 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
     int nMaxReorgDepth = gArgs.GetArg("-maxreorg", Params().MaxReorganizationDepth());
     int nMinReorgPeers = gArgs.GetArg("-minreorgpeers", Params().MinReorganizationPeers());
     bool fGreaterThanMaxReorg = chainActive.Height() - nHeight >= nMaxReorgDepth;
-    if (fGreaterThanMaxReorg && g_connman && (int)g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) > nMinReorgPeers && !IsInitialBlockDownload())
-        return state.DoS(1, error("%s: forked chain older than max reorganization depth (height %d), with connections (count %d), and (initial download %s)", __func__, nHeight, g_connman ? g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) : -1, IsInitialBlockDownload() ? "true" : "false"), REJECT_MAXREORGDEPTH, "bad-fork-prior-to-maxreorgdepth");
+    if (fGreaterThanMaxReorg && g_connman) {
+        int nCurrentNodeCount = g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL);
+        bool bIsInitialBlockDownload = IsInitialBlockDownload();
+        if ((nCurrentNodeCount >= nMinReorgPeers) && !bIsInitialBlockDownload)
+            return state.DoS(1, error("%s: forked chain older than max reorganization depth (height %d), with connections (count %d), and (initial download %s)", __func__, nHeight, nCurrentNodeCount, bIsInitialBlockDownload ? "true" : "false"), REJECT_MAXREORGDEPTH, "bad-fork-prior-to-maxreorgdepth");
+    }
 
     // Check proof of work
     const Consensus::Params& consensusParams = params.GetConsensus();


### PR DESCRIPTION
nMinReorganizationPeers now matches number of peers required to prevent re-org.
Prevent changes between event and logged msg.