### PR TITLE
Make 'issueunique' cli-help message more clear

### DIFF
--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -248,8 +248,8 @@ UniValue issueunique(const JSONRPCRequest& request)
                 "\"txid\"                     (string) The transaction id\n"
 
                 "\nExamples:\n"
-                + HelpExampleCli("issueunique", "\"MY_ASSET\" [\"primo\",\"secundo\"]")
-                + HelpExampleCli("issueunique", "\"MY_ASSET\" [\"primo\",\"secundo\"] [\"first_hash\",\"second_hash\"]")
+                + HelpExampleCli("issueunique", "\"MY_ASSET\" \'[\"primo\",\"secundo\"]\'")
+                + HelpExampleCli("issueunique", "\"MY_ASSET\" \'[\"primo\",\"secundo\"\'] \'[\"first_hash\",\"second_hash\"]\'")
         );
 
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);


### PR DESCRIPTION
The issueuniqe command help was a little unclear on how to actually invoke it.  It requires using single quotes (') around the array in order to be called.  This isn't listed in the help message.  This only updates the help to include the single quote around the arrays.