### PR TITLE
Fixes incorrect wallet check on reissue.

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -2579,7 +2579,7 @@ bool CreateReissueAssetTransaction(CWallet* pwallet, CCoinControl& coinControl, 
     }
 
     // Verify that this wallet is the owner for the asset, and get the owner asset outpoint
-    if (!VerifyWalletHasAsset(asset_name, error)) {
+    if (!VerifyWalletHasAsset(asset_name + OWNER_TAG, error)) {
         return false;
     }
 

--- a/test/functional/feature_assets.py
+++ b/test/functional/feature_assets.py
@@ -108,6 +108,11 @@ class AssetTest(RavenTestFramework):
         assert(changeaddress != None)
         assert_equal(n0.listassetbalancesbyaddress(address0)["MY_ASSET!"], 1)
 
+        self.log.info("Burning all units to test reissue on zero units...")
+        n0.transfer(asset_name="MY_ASSET", qty=800, to_address="n1BurnXXXXXXXXXXXXXXXXXXXXXXU1qejP")
+        n0.generate(1)
+        assert_equal(0, n0.listmyassets(asset="MY_ASSET", verbose=True)["MY_ASSET"]["balance"])
+
         self.log.info("Calling reissue()...")
         address1 = n0.getnewaddress()
         ipfs_hash2 = "QmcvyefkqQX3PpjpY5L8B2yMd47XrVwAipr6cxUt2zvYU8"


### PR DESCRIPTION
Fixes inability to reissue when owning zero units.

![screen shot 2018-09-25 at 3 50 38 pm](https://user-images.githubusercontent.com/29618/46046646-1194bb00-c0df-11e8-9d95-43c0efea619b.png)
