### PR TITLE
Update wallet balance and transfer GUI

### DIFF
--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -259,7 +259,7 @@ public :
     bool AddPossibleOutPoint(const CAssetCachePossibleMine& possibleMine);
 
     bool CheckIfAssetExists(const std::string& name);
-    bool GetAssetIfExists(const std::string& name, CNewAsset& asset);
+    bool GetAssetMetaDataIfExists(const std::string &name, CNewAsset &asset);
 
     //! Calculate the size of the CAssets (in bytes)
     size_t DynamicMemoryUsage() const;
@@ -359,8 +359,8 @@ bool IsScriptTransferAsset(const CScript& scriptPubKey);
 
 bool IsNewOwnerTxValid(const CTransaction& tx, const std::string& assetName, const std::string& address, std::string& errorMsg);
 
-void GetAllAdministrativeAssets(CWallet *pwallet, std::vector<std::string> &names);
-void GetAllMyAssets(CWallet* pwallet, std::vector<std::string>& names, bool fIncludeAdministrator = false, bool fOnlyAdministrator = false);
+void GetAllAdministrativeAssets(CWallet *pwallet, std::vector<std::string> &names, int nMinConf = 1);
+void GetAllMyAssets(CWallet* pwallet, std::vector<std::string>& names, int nMinConf = 1, bool fIncludeAdministrator = false, bool fOnlyAdministrator = false);
 /** TO BE USED ONLY ON STARTUP */
 void GetAllMyAssetsFromCache(std::vector<std::string>& names);
 

--- a/src/assets/assettypes.h
+++ b/src/assets/assettypes.h
@@ -14,6 +14,7 @@
 #include "primitives/transaction.h"
 
 #define MAX_UNIT 8
+#define MIN_UNIT 0
 
 class CAssetsCache;
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -140,7 +140,7 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, bool 
 
                 // Get the asset before we change it
                 CNewAsset asset;
-                if (!assetsCache->GetAssetIfExists(reissue.strName, asset))
+                if (!assetsCache->GetAssetMetaDataIfExists(reissue.strName, asset))
                     error("%s: Failed to get the original asset that is getting reissued. Asset Name : %s",
                           __func__, reissue.strName);
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -462,7 +462,7 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, CValidationState& state, c
                 } else {
                     // For all other types of assets, make sure they are sending the right type of units
                     CNewAsset asset;
-                    if (!passets->GetAssetIfExists(transfer.strName, asset))
+                    if (!passets->GetAssetMetaDataIfExists(transfer.strName, asset))
                         return state.DoS(100, false, REJECT_INVALID, "bad-txns-transfer-asset-not-exist");
 
                     if (asset.strName != transfer.strName)

--- a/src/qt/assetcontroldialog.cpp
+++ b/src/qt/assetcontroldialog.cpp
@@ -773,9 +773,9 @@ void AssetControlDialog::updateAssetList(bool fSetOnStart)
     // Get the assets
     std::vector<std::string> assets;
     if (showAdministrator)
-        GetAllAdministrativeAssets(model->getWallet(), assets);
+        GetAllAdministrativeAssets(model->getWallet(), assets, 0);
     else
-        GetAllMyAssets(model->getWallet(), assets);
+        GetAllMyAssets(model->getWallet(), assets, 0);
 
     QStringList list;
     for (auto name : assets) {

--- a/src/qt/assettablemodel.cpp
+++ b/src/qt/assettablemodel.cpp
@@ -56,7 +56,7 @@ public:
                     if (!IsAssetNameAnOwner(bal->first)) {
                         // Asset is not an administrator asset
                         CNewAsset assetData;
-                        if (!passets->GetAssetIfExists(bal->first, assetData)) {
+                        if (!passets->GetAssetMetaDataIfExists(bal->first, assetData)) {
                             qWarning("AssetTablePriv::refreshWallet: Error retrieving asset data");
                             return;
                         }

--- a/src/qt/createassetdialog.cpp
+++ b/src/qt/createassetdialog.cpp
@@ -206,7 +206,7 @@ void CreateAssetDialog::setUpValues()
     // Setup the asset list
     ui->assetList->hide();
     std::vector<std::string> names;
-    GetAllAdministrativeAssets(model->getWallet(), names);
+    GetAllAdministrativeAssets(model->getWallet(), names, 0);
     for (auto item : names) {
         std::string name = QString::fromStdString(item).split("!").first().toStdString();
         if (name.size() != 30)
@@ -343,7 +343,7 @@ void CreateAssetDialog::checkAvailabilityClicked()
     LOCK(cs_main);
     if (passets) {
         CNewAsset asset;
-        if (passets->GetAssetIfExists(name.toStdString(), asset)) {
+        if (passets->GetAssetMetaDataIfExists(name.toStdString(), asset)) {
             ui->nameText->setStyleSheet("border: 1px solid red");
             showMessage(tr("Invalid: Asset name already in use"));
             disableCreateButton();

--- a/src/qt/reissueassetdialog.cpp
+++ b/src/qt/reissueassetdialog.cpp
@@ -200,7 +200,7 @@ void ReissueAssetDialog::setUpValues()
 
     LOCK(cs_main);
     std::vector<std::string> assets;
-    GetAllAdministrativeAssets(model->getWallet(), assets);
+    GetAllAdministrativeAssets(model->getWallet(), assets, 0);
 
     ui->comboBox->addItem("Select an asset");
 
@@ -208,7 +208,7 @@ void ReissueAssetDialog::setUpValues()
     for (auto item : assets) {
         std::string name = QString::fromStdString(item).split("!").first().toStdString();
         CNewAsset asset;
-        if (passets->GetAssetIfExists(name, asset)) {
+        if (passets->GetAssetMetaDataIfExists(name, asset)) {
             if (asset.nReissuable)
                 ui->comboBox->addItem(QString::fromStdString(asset.strName));
         }
@@ -429,7 +429,7 @@ void ReissueAssetDialog::onAssetSelected(int index)
 
         LOCK(cs_main);
         // Get the asset data
-        if (!passets->GetAssetIfExists(qstr_name.toStdString(), *asset)) {
+        if (!passets->GetAssetMetaDataIfExists(qstr_name.toStdString(), *asset)) {
             CheckFormState();
             disableAll();
             asset->SetNull();

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -297,7 +297,7 @@ QString TransactionDesc::toAssetHTML(CWallet *wallet, CWalletTx &wtx, Transactio
     CNewAsset asset;
     if (IsAssetNameAnOwner(rec->assetName))
         rec->units = OWNER_UNITS;
-    else if (passets && passets->GetAssetIfExists(rec->assetName, asset))
+    else if (passets && passets->GetAssetMetaDataIfExists(rec->assetName, asset))
         rec->units = asset.units;
     else
         rec->units = MAX_ASSET_UNITS;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -251,7 +251,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 else
                 {
                     CNewAsset asset;
-                    if (passets->GetAssetIfExists(sub.assetName, asset))
+                    if (passets->GetAssetMetaDataIfExists(sub.assetName, asset))
                         sub.units = asset.units;
                 }
 
@@ -287,7 +287,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 else
                 {
                     CNewAsset asset;
-                    if (passets->GetAssetIfExists(sub.assetName, asset))
+                    if (passets->GetAssetMetaDataIfExists(sub.assetName, asset))
                         sub.units = asset.units;
                 }
 

--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -65,7 +65,7 @@ UniValue UnitValueFromAmount(const CAmount& amount, const std::string asset_name
     uint8_t units = OWNER_UNITS;
     if (!IsAssetNameAnOwner(asset_name)) {
         CNewAsset assetData;
-        if (!passets->GetAssetIfExists(asset_name, assetData))
+        if (!passets->GetAssetMetaDataIfExists(asset_name, assetData))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't load asset from cache: " + asset_name);
 
         units = assetData.units;
@@ -446,7 +446,7 @@ UniValue getassetdata(const JSONRPCRequest& request)
 
     if (passets) {
         CNewAsset asset;
-        if (!passets->GetAssetIfExists(asset_name, asset))
+        if (!passets->GetAssetMetaDataIfExists(asset_name, asset))
             return NullUniValue;
 
         result.push_back(Pair("name", asset.strName));

--- a/src/test/assets/asset_reissue_tests.cpp
+++ b/src/test/assets/asset_reissue_tests.cpp
@@ -44,7 +44,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_reissue_tests, BasicTestingSetup)
 
     // Get the new asset data from the cache
     CNewAsset asset2;
-    BOOST_CHECK_MESSAGE(cache.GetAssetIfExists("RVNASSET", asset2), "Failed to get the asset2");
+    BOOST_CHECK_MESSAGE(cache.GetAssetMetaDataIfExists("RVNASSET", asset2), "Failed to get the asset2");
 
     // Chech the asset metadata
     BOOST_CHECK_MESSAGE(asset2.nReissuable == 1, "Asset2: Reissuable isn't 1");
@@ -60,7 +60,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_reissue_tests, BasicTestingSetup)
 
     // Get the asset data from the cache now that the reissuance was removed
     CNewAsset asset3;
-    BOOST_CHECK_MESSAGE(cache.GetAssetIfExists("RVNASSET", asset3), "Failed to get the asset3");
+    BOOST_CHECK_MESSAGE(cache.GetAssetMetaDataIfExists("RVNASSET", asset3), "Failed to get the asset3");
 
     // Chech the asset3 metadata and make sure all the changed from the reissue were removed
     BOOST_CHECK_MESSAGE(asset3.nReissuable == 1, "Asset3: Reissuable isn't 1");


### PR DESCRIPTION
- The asset wallet balance will now show the selected total from asset control. 
- The asset wallet balance will now show total of wallet asset balance, not what is in the cache
- Updated when assets show up the transfer asset dropdown (The asset shows up if the assets issuance is in the cache/database)
- Renamed GetAssetIfExists to GetAssetMetaDataIfExists because we are really retrieving the metadata from the cache or database and not so much the Asset. 