### PR TITLE
Add custom fee as a setting that can be turned off/on

### DIFF
--- a/src/qt/assetsdialog.cpp
+++ b/src/qt/assetsdialog.cpp
@@ -170,10 +170,13 @@ void AssetsDialog::setModel(WalletModel *_model)
         connect(_model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(assetControlUpdateLabels()));
         connect(_model->getOptionsModel(), SIGNAL(coinControlFeaturesChanged(bool)), this, SLOT(assetControlFeatureChanged(bool)));
 
+        // Custom Fee Control
+        connect(_model->getOptionsModel(), SIGNAL(customFeeFeaturesChanged(bool)), this, SLOT(customFeeFeatureChanged(bool)));
+
 
         ui->frameAssetControl->setVisible(false);
-        //TODO Turn on the coin control features for assets
         ui->frameAssetControl->setVisible(_model->getOptionsModel()->getCoinControlFeatures());
+        ui->frameFee->setVisible(_model->getOptionsModel()->getCustomFeeFeatures());
         assetControlUpdateLabels();
 
         // fee section
@@ -758,6 +761,11 @@ void AssetsDialog::assetControlFeatureChanged(bool checked)
         AssetControlDialog::assetControl->SetNull();
 
     assetControlUpdateLabels();
+}
+
+void AssetsDialog::customFeeFeatureChanged(bool checked)
+{
+    ui->frameFee->setVisible(checked);
 }
 
 // Coin Control: button inputs -> show actual coin control dialog

--- a/src/qt/assetsdialog.h
+++ b/src/qt/assetsdialog.h
@@ -95,6 +95,8 @@ private Q_SLOTS:
     void updateMinFeeLabel();
     void updateSmartFeeLabel();
 
+    void customFeeFeatureChanged(bool);
+
     /** RVN START */
     void createAssetButtonClicked();
     void ressieAssetButtonClicked();

--- a/src/qt/createassetdialog.cpp
+++ b/src/qt/createassetdialog.cpp
@@ -109,6 +109,8 @@ CreateAssetDialog::CreateAssetDialog(const PlatformStyle *_platformStyle, QWidge
     setUpValues();
 
     format = "%1<font color=green>%2%3</font>";
+
+    adjustSize();
 }
 
 void CreateAssetDialog::setClientModel(ClientModel *_clientModel)
@@ -137,6 +139,9 @@ void CreateAssetDialog::setModel(WalletModel *_model)
         connect(_model->getOptionsModel(), SIGNAL(coinControlFeaturesChanged(bool)), this, SLOT(coinControlFeatureChanged(bool)));
         ui->frameCoinControl->setVisible(_model->getOptionsModel()->getCoinControlFeatures());
         coinControlUpdateLabels();
+
+        // Custom Fee Control
+        ui->frameFee->setVisible(_model->getOptionsModel()->getCustomFeeFeatures());
 
         // fee section
         for (const int &n : confTargets) {

--- a/src/qt/forms/createassetdialog.ui
+++ b/src/qt/forms/createassetdialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1147</width>
+    <width>930</width>
     <height>875</height>
    </rect>
   </property>
@@ -1375,15 +1375,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QValidatedLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qvalidatedlineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>RavenAmountField</class>
    <extends>QLineEdit</extends>
    <header>ravenamountfield.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qvalidatedlineedit.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>560</width>
+    <width>617</width>
     <height>440</height>
    </rect>
   </property>
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tabMain">
       <attribute name="title">
@@ -150,6 +150,13 @@
             </property>
             <property name="text">
              <string>Enable coin &amp;control features</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="customFeeFeatures">
+            <property name="text">
+             <string>Enable fee control features</string>
             </property>
            </widget>
           </item>

--- a/src/qt/forms/reissueassetdialog.ui
+++ b/src/qt/forms/reissueassetdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1454</width>
+    <width>936</width>
     <height>1185</height>
    </rect>
   </property>
@@ -1448,15 +1448,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QValidatedLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qvalidatedlineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>RavenAmountField</class>
    <extends>QLineEdit</extends>
    <header>ravenamountfield.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QValidatedLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qvalidatedlineedit.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -180,6 +180,7 @@ void OptionsDialog::setMapper()
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
+    mapper->addMapping(ui->customFeeFeatures, OptionsModel::CustomFeeFeatures);
 
     /* Network */
     mapper->addMapping(ui->mapPortUpnp, OptionsModel::MapPortUPnP);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -82,6 +82,10 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("fCoinControlFeatures", false);
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
 
+    if (!settings.contains("fCustomFeeFeatures"))
+        settings.setValue("fCustomFeeFeatures", false);
+    fCustomFeeFeatures = settings.value("fCustomFeeFeatures", false).toBool();
+
     // These are shared with the core or have a command-line parameter
     // and we want command-line parameters to overwrite the GUI settings.
     //
@@ -270,6 +274,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return settings.value("nThreadsScriptVerif");
         case Listen:
             return settings.value("fListen");
+        case CustomFeeFeatures:
+            return fCustomFeeFeatures;
         default:
             return QVariant();
         }
@@ -417,6 +423,11 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
                 settings.setValue("fListen", value);
                 setRestartRequired(true);
             }
+            break;
+        case CustomFeeFeatures:
+            fCustomFeeFeatures = value.toBool();
+            settings.setValue("fCustomFeeFeatures", fCustomFeeFeatures);
+            Q_EMIT customFeeFeaturesChanged(fCustomFeeFeatures);
             break;
         default:
             break;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -47,6 +47,7 @@ public:
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
         Listen,                 // bool
+        CustomFeeFeatures,      // bool
         OptionIDRowCount,
     };
 
@@ -67,6 +68,7 @@ public:
     QString getThirdPartyTxUrls() const { return strThirdPartyTxUrls; }
     bool getProxySettings(QNetworkProxy& proxy) const;
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
+    bool getCustomFeeFeatures() const { return fCustomFeeFeatures; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
 
     /* Restart flag helper */
@@ -82,6 +84,9 @@ private:
     int nDisplayUnit;
     QString strThirdPartyTxUrls;
     bool fCoinControlFeatures;
+    /** RVN START*/
+    bool fCustomFeeFeatures;
+    /** RVN END*/
     /* settings that were overridden by command-line */
     QString strOverriddenByCommandLine;
 
@@ -93,6 +98,7 @@ private:
 Q_SIGNALS:
     void displayUnitChanged(int unit);
     void coinControlFeaturesChanged(bool);
+    void customFeeFeaturesChanged(bool);
     void hideTrayIconChanged(bool);
 };
 

--- a/src/qt/reissueassetdialog.cpp
+++ b/src/qt/reissueassetdialog.cpp
@@ -113,6 +113,8 @@ ReissueAssetDialog::ReissueAssetDialog(const PlatformStyle *_platformStyle, QWid
 
     formatGreen = "%1%2 <font color=green><b>%3</b></font>";
     formatBlack = "%1%2 <font color=black><b>%3</b></font>";
+
+    adjustSize();
 }
 
 void ReissueAssetDialog::setClientModel(ClientModel *_clientModel)
@@ -141,6 +143,9 @@ void ReissueAssetDialog::setModel(WalletModel *_model)
         connect(_model->getOptionsModel(), SIGNAL(coinControlFeaturesChanged(bool)), this, SLOT(coinControlFeatureChanged(bool)));
         ui->frameCoinControl->setVisible(_model->getOptionsModel()->getCoinControlFeatures());
         coinControlUpdateLabels();
+
+        // Custom Fee Control
+        ui->frameFee->setVisible(_model->getOptionsModel()->getCustomFeeFeatures());
 
         // fee section
         for (const int &n : confTargets) {


### PR DESCRIPTION
- Update the size of the createassetdialog, and reissueassetdialog (Made them smaller)
- Added a setting that allows you to turn on custom fee on the asset tabs 
  - You can turn this on by navigating to the settings and enabling it. Just like coin control

P.S. This doesn't remove the custom fee from the send RVN page. That is always active

![screen shot 2018-09-27 at 5 29 57 pm](https://user-images.githubusercontent.com/8285518/46179958-fb236680-c27a-11e8-8c2a-b85531dee644.png)
