### PR TITLE
Extend asset list to the bottom of the screen

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>799</width>
-    <height>570</height>
+    <width>1000</width>
+    <height>608</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -541,17 +541,23 @@
            </widget>
           </item>
           <item>
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
+           <widget class="QWidget" name="assetVeriticalSpaceWidget" native="true">
+            <layout class="QVBoxLayout" name="verticalLayout">
+             <item>
+              <spacer name="assetVerticalSpacer">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -301,11 +301,17 @@ void OverviewPage::showAssets()
         ui->assetBalanceLabel->show();
         ui->labelAssetStatus->show();
         ui->labelAssetAdministrator->show();
+
+        // Disable the vertical space so that listAssets goes to the bottom of the screen
+        ui->assetVeriticalSpaceWidget->hide();
     } else {
         ui->assetBalanceLabel->hide();
         ui->labelAssetStatus->hide();
         ui->listAssets->hide();
         ui->labelAssetAdministrator->hide();
+
+        // This keeps the RVN balance grid from expanding and looking terrible when asset balance is hidden
+        ui->assetVeriticalSpaceWidget->show();
     }
 
     displayAssetInfo();


### PR DESCRIPTION
- Allow asset list to go to the bottom of the page ( Used to go to the middle of the page)

**_Before_**
![screen shot 2018-09-28 at 12 17 37 pm](https://user-images.githubusercontent.com/8285518/46226108-843cab00-c318-11e8-9f74-391dd8e7a88f.png)

**_After_**
![screen shot 2018-09-28 at 12 15 59 pm](https://user-images.githubusercontent.com/8285518/46226057-4f305880-c318-11e8-829d-5df945e3ec24.png)
