### PR TITLE
Fixing link in Windows readme to the Ravencoin wiki page

### DIFF
--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -19,5 +19,5 @@ depending on the speed of your computer and network connection, the synchronizat
 process can take anywhere from a few hours to a day or more.
 
 See the raven wiki at:
-  https://en.raven.it/wiki/Main_Page
+  https://raven.wiki/wiki/Ravencoin_Wiki
 for more help and information.


### PR DESCRIPTION
In testing Windows build stuffs today I noticed the link to the RVN wiki was incorrect in the Windows readme file.