### PR TITLE
Fail checks on unique asset that are already in the mempool

### DIFF
--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -329,6 +329,7 @@ bool IsAssetUnitsValid(const CAmount& units);
 bool AssetFromTransaction(const CTransaction& tx, CNewAsset& asset, std::string& strAddress);
 bool OwnerFromTransaction(const CTransaction& tx, std::string& ownerName, std::string& strAddress);
 bool ReissueAssetFromTransaction(const CTransaction& tx, CReissueAsset& reissue, std::string& strAddress);
+bool UniqueAssetFromTransaction(const CTransaction& tx, CNewAsset& asset, std::string& strAddress);
 
 bool TransferAssetFromScript(const CScript& scriptPubKey, CAssetTransfer& assetTransfer, std::string& strAddress);
 bool AssetFromScript(const CScript& scriptPubKey, CNewAsset& asset, std::string& strAddress);


### PR DESCRIPTION
- The ability to create the same unique asset and submit it to the mempool was allowed. 
- Now, during the mempool check we make sure to check if it is already in the mempool or not and fail it is it. 