### PR TITLE
Resize asset dialog when opened to fix contents

### DIFF
--- a/src/qt/createassetdialog.cpp
+++ b/src/qt/createassetdialog.cpp
@@ -179,6 +179,8 @@ void CreateAssetDialog::setModel(WalletModel *_model)
             ui->confTargetSelector->setCurrentIndex(getIndexForConfTarget(model->getDefaultConfirmTarget()));
         else
             ui->confTargetSelector->setCurrentIndex(getIndexForConfTarget(settings.value("nConfTarget").toInt()));
+
+        adjustSize();
     }
 }
 

--- a/src/qt/forms/reissueassetdialog.ui
+++ b/src/qt/forms/reissueassetdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>936</width>
+    <width>861</width>
     <height>1185</height>
    </rect>
   </property>

--- a/src/qt/reissueassetdialog.cpp
+++ b/src/qt/reissueassetdialog.cpp
@@ -183,6 +183,7 @@ void ReissueAssetDialog::setModel(WalletModel *_model)
             ui->confTargetSelector->setCurrentIndex(getIndexForConfTarget(model->getDefaultConfirmTarget()));
         else
             ui->confTargetSelector->setCurrentIndex(getIndexForConfTarget(settings.value("nConfTarget").toInt()));
+        adjustSize();
     }
 }
 


### PR DESCRIPTION
- Sometimes when the mange assets or create assets was opened, the window was really large, this change should help resize the window to the contents of the screen. 
- When coin control and custom fee are turned on, the manage assets window is pretty large. But this should resize based on the monitor it is on.