### PR TITLE
Adding release notes for 2.1.0, removing RBF tests

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -55,7 +55,7 @@ AFLOUT=$PWD/outputs
 
 Example inputs are available from:
 
-- https://download.visucore.com/raven/raven_fuzzy_in.tar.xz
+- https://download.visucore.com/bitcoin/bitcoin_fuzzy_in.tar.xz
 - http://strateman.ninja/fuzzing.tar.xz
 
 Extract these (or other starting inputs) into the `inputs` directory before starting fuzzing.

--- a/doc/release-notes/release-notes-2.1.0.md
+++ b/doc/release-notes/release-notes-2.1.0.md
@@ -1,0 +1,94 @@
+Raven Core version *2.1.0.0* is now available!!
+==============
+
+  <https://github.com/RavenProject/Ravencoin/releases/tag/v2.1.0>
+
+
+This is a major release containing bug fixes for 2.0.4.0/2.0.4.1.  It is highly recommended that users 
+upgrade to this version.  This is the final release for the phase 2 development (assets).
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/RavenProject/Ravencoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://ravencoin.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes for older versions), then run the 
+installer (on Windows) or just copy over `/Applications/Raven-Qt` (on Mac)
+or `ravend`/`raven-qt` (on Linux).
+
+The first time you run version 2.1.0 or higher, your chainstate database may
+be converted to a new format, which will take anywhere from a few minutes to
+half an hour, depending on the speed of your machine.
+
+Downgrading warning
+==============
+
+The chainstate database for this release is not compatible with previous
+releases, so if you run 2.1.0 and then decide to switch back to any
+older version, you will need to run the old release with the `-reindex-chainstate`
+option to rebuild the chainstate data structures in the old format.
+
+If your node has pruning enabled, this will entail re-downloading and
+processing the entire blockchain.
+
+It is not recommended that users downgrade their version.  This version contains
+changes that *will* fork the chain, users not running 2.1.0 (or later) will be not
+be able to participate in this fork process and will be left on the old chain which 
+will not be valid.
+
+Compatibility
+==============
+
+Raven Core is extensively tested on multiple operating systems using
+the Linux kernel, macOS 10.8+, and Windows Vista and later. 32-bit versions of Windows,
+and Windows XP are not supported.
+
+Raven Core should also work on most other Unix-like systems but is not
+frequently tested on them.
+
+Raven Core has been tested with macOS 10.14 Mojave, but it is recommended that developers
+do not update to Mojave.  There is an incompatibility with Berkeley-db 4.8.30 that causes
+the binaries to seg-fault.  There is a workaround, but as of this release users should
+not update to Mojave (see build-OSX.md for current status of this issue).  There are no
+known issues running the release binaries on Mojave.
+
+Notable changes
+==============
+
+- Mainnet asset activation (Voting begins October 30, 2018)
+- Double-spend attack mitigation
+- Many QT Wallet UI enhancement
+- Removed Replace by Fee (RBF)
+- Functional test overhaul, added tests for new features
+- Reissue with zero amount (with owner token)
+- Moved testnet to v6
+- Added asset transaction chaining
+- Chain synchronization stability
+
+2.1.0.0 Change log
+==============
+
+Changelog available here: <https://github.com/RavenProject/Ravencoin/commits/release_2.1.0>
+
+Credits
+==============
+
+Thanks to everyone who directly contributed to this release:
+
+- Most importantly - The Raven Community!
+- Tron Black
+- Jesse Empey
+- Jeremy Anderson
+- Corbin Fox
+- Daben Steele
+- Cade Call
+- @Roshii
+- @underdarkskies
+- Mark Ney

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -68,6 +68,7 @@ BASE_SCRIPTS= [
     # 'p2p_compactblocks.py',       TODO - refactor to assume segwit is always active
     # 'p2p_segwit.py',              TODO - refactor to assume segwit is always active
     # 'feature_csv_activation.py',  TODO - currently testing softfork activations, we need to test the features
+    #'wallet_bumpfee.py',           TODO - Now fails because we removed RBF
     # 'example_test.py',
     # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv Tests less than 2m vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     'wallet_backup.py',
@@ -90,7 +91,6 @@ BASE_SCRIPTS= [
     'rpc_rawtransaction.py',
     'rpc_addressindex.py',
     'wallet_dump.py',
-    'wallet_bumpfee.py',
     'mempool_persist.py',
     'rpc_timestampindex.py',
     'wallet_listreceivedby.py',

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -97,7 +97,8 @@ class ListTransactionsTest(RavenTestFramework):
                             {"category": "receive", "amount": Decimal("0.1")},
                             {"txid": txid, "account": "watchonly"})
 
-        self.run_rbf_opt_in_test()
+        # - This section of the test is removed since we are no longer supporting RBF (for now)
+        #self.run_rbf_opt_in_test()
 
     # Check that the opt-in-rbf flag works properly, for sent and received
     # transactions.


### PR DESCRIPTION
Release notes for 2.1.0.
Fixing functional tests that recently began to fail due to the removal of RBF
Fixing link for fuzz testing input file (using Bitcoin file)