### PR TITLE
Add ability to view asset issuance in the mempool

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -281,28 +281,9 @@ bool CNewAsset::IsValid(std::string& strError, CAssetsCache& assetCache, bool fC
     }
 
     if (fCheckMempool) {
-        for (const CTxMemPoolEntry &entry : mempool.mapTx) {
-            CTransaction tx = entry.GetTx();
-
-            bool fIsNewAsset = tx.IsNewAsset();
-            bool fIsNewUniqueAsset = false;
-            if (!fIsNewAsset)
-                fIsNewUniqueAsset = tx.IsNewUniqueAsset();
-
-            if (fIsNewAsset || fIsNewUniqueAsset) {
-                CNewAsset asset;
-                std::string address;
-
-                if (fIsNewAsset)
-                    AssetFromTransaction(tx, asset, address);
-                else
-                    UniqueAssetFromTransaction(tx, asset, address);
-
-                if (asset.strName == strName) {
-                    strError = _("Asset with this name is already in the mempool");
-                    return false;
-                }
-            }
+        if (mempool.mapAssetToHash.count(strName)) {
+            strError = _("Asset with this name is already in the mempool");
+            return false;
         }
     }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -467,6 +467,9 @@ public:
     mutable CCriticalSection cs;
     indexed_transaction_set mapTx;
 
+    std::map<std::string, uint256> mapAssetToHash;
+    std::map<uint256, std::string> mapHashToAsset;
+
     typedef indexed_transaction_set::nth_index<0>::type::iterator txiter;
     std::vector<std::pair<uint256, txiter> > vTxHashes; //!< All tx witness hashes/entries in mapTx, in random order
 
@@ -543,6 +546,7 @@ public:
     void removeRecursive(const CTransaction &tx, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
     void removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags);
     void removeConflicts(const CTransaction &tx);
+    void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight, std::set<CAssetCacheNewAsset>& setNewAssets );
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight);
 
     void clear();

--- a/test/functional/feature_assets_mempool.py
+++ b/test/functional/feature_assets_mempool.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Copyright (c) 2017-2018 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Testing asset mempool use cases
+
+"""
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import *
+
+
+import string
+
+class AssetMempoolTest(RavenTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+
+    def activate_assets(self):
+        self.log.info("Generating RVN and activating assets...")
+        n0, n1 = self.nodes[0], self.nodes[1]
+
+        n0.generate(1)
+        self.sync_all()
+        n0.generate(216)
+        self.sync_all()
+        n1.generate(216)
+        self.sync_all()
+        assert_equal("active", n0.getblockchaininfo()['bip9_softforks']['assets']['status'])
+
+
+    def issue_mempool_test(self):
+        self.log.info("Testing issue mempool...")
+
+        n0, n1 = self.nodes[0], self.nodes[1]
+
+        disconnect_all_nodes(self.nodes)
+
+        asset_name = "MEMPOOL"
+
+        # Issue asset on chain 1 and mine it into the blocks
+        n0.issue(asset_name)
+        n0.generate(15)
+
+        # Issue asset on chain 2 but keep it in the mempool. No mining
+        txid = n1.issue(asset_name)
+        print(txid)
+
+        connect_all_nodes_bi(self.nodes)
+
+        assert_equal(n0.getblockcount(), n1.getblockcount())
+        assert_equal(n0.getbestblockhash(), n1.getbestblockhash())
+
+    def run_test(self):
+        self.activate_assets()
+        self.issue_mempool_test()
+
+if __name__ == '__main__':
+    AssetMempoolTest().main()


### PR DESCRIPTION
- Remove heavy mempool check which was looping through the whole mempool to see if asset is unique. 
- Remove assets from map when that asset is added into a block

This fixes the case where a miners mempool can get into a state where it produces invalid block templates which will produce invalid blocks because it contains transactions which contain issuances which have already been mined. 