### PR TITLE
Add bitcoincore's license line back

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2016 The Raven Core developers
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2017 The Raven Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 


### PR DESCRIPTION
The MIT License states "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software." Removing Bitcoin Core's reference violates that.