### PR TITLE
Repair OSX static builds

### DIFF
--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -211,7 +211,6 @@ def getFrameworks(binaryPath, verbose):
             raise RuntimeError("otool failed with return code %d" % otool.returncode)
 
     otoolLines = o_stdout.split("\n")
-    otoolLines.append(" /usr/local/opt/boost/lib/libboost_system-mt.dylib (compatibility version 0.0.0, current version 0.0.0)")
     otoolLines.pop(0) #     First line is the inspected binary
     if ".framework" in binaryPath or binaryPath.endswith(".dylib"):
         otoolLines.pop(0) # Frameworks and dylibs list themselves as a dependency.


### PR DESCRIPTION
Static and gitian builds fail due to the inclusion of non statically compiled, OS dependant, dependancies being included in the static build process.  This otools append is not required in a dmg build so long as the depends folder (aka static build or gitian build) process is followed, which is the reccommended method to generate reliable binaries. Please stop attempting to generate binaries with the existing methods. They generally fail to run in multiple ways.