### PR TITLE
Update IPFS hash examples in placeholders

### DIFF
--- a/src/qt/forms/createassetdialog.ui
+++ b/src/qt/forms/createassetdialog.ui
@@ -799,7 +799,7 @@
              <number>46</number>
             </property>
             <property name="placeholderText">
-             <string>The IPFS Hash that is associated with the asset being created (e.g 6D3Ef76Sl10HQ....)</string>
+             <string>The IPFS Hash that is associated with the asset being created (e.g. QmU4h365LYMHx...)</string>
             </property>
            </widget>
           </item>

--- a/src/qt/forms/reissueassetdialog.ui
+++ b/src/qt/forms/reissueassetdialog.ui
@@ -744,7 +744,7 @@
              <number>46</number>
             </property>
             <property name="placeholderText">
-             <string>The IPFS Hash that is associated with the asset being created (e.g 6D3Ef76Sl10HQ....)</string>
+             <string>The IPFS Hash that is associated with the asset being created (e.g. QmU4h365LYMHx...)</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Supported IPFS hashes will always start with "Qm" so this updates the input placeholders with more appropriate examples.