### PR TITLE
Fixing OSX cross compile build problem on Linux (static build pulling dynamic Boost library)

### DIFF
--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -211,7 +211,6 @@ def getFrameworks(binaryPath, verbose):
             raise RuntimeError("otool failed with return code %d" % otool.returncode)
 
     otoolLines = o_stdout.split("\n")
-    otoolLines.append(" /usr/local/opt/boost/lib/libboost_system-mt.dylib (compatibility version 0.0.0, current version 0.0.0)")
     otoolLines.pop(0) #     First line is the inspected binary
     if ".framework" in binaryPath or binaryPath.endswith(".dylib"):
         otoolLines.pop(0) # Frameworks and dylibs list themselves as a dependency.


### PR DESCRIPTION
Cross-compiling OSX version of RVN in Docker was failing to compile when it was trying to find the dynamic library version of libboost_system-mt.dylib.  RVN is compiled as static so this dynamic library isn't needed.  Verified using the Docker image for release building and manually on a standalone AWS Linux machine.  Tested on a "clean" (non-development configured) Macbook.