### PR TITLE
Fixing build on Linux due to Long Int conversion error

### DIFF
--- a/src/qt/assettablemodel.cpp
+++ b/src/qt/assettablemodel.cpp
@@ -142,7 +142,7 @@ QVariant AssetTableModel::data(const QModelIndex &index, int role) const
     switch (role)
     {
         case AmountRole:
-            return rec->quantity;
+            return (unsigned long long) rec->quantity;
         case AssetNameRole:
             return QString::fromStdString(rec->name);
         case FormattedAmountRole:


### PR DESCRIPTION
fixing build error on Linux:
`qt/assettablemodel.cpp: In member function ‘virtual QVariant AssetTableModel::data(const QModelIndex&, int) const’:
qt/assettablemodel.cpp:145:25: error: conversion from ‘CAmount {aka long int}’ to ‘QVariant’ is ambiguous
            return rec->quantity;
                        ^~~~~~~~
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qabstractitemmodel.h:43:0,
                from /usr/include/x86_64-linux-gnu/qt5/QtCore/QAbstractTableModel:1,
                from qt/assettablemodel.h:11,
                from qt/assettablemodel.cpp:6:`