### PR TITLE
Fix Tarball Builds

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -201,6 +201,7 @@ RAVEN_QT_H = \
   qt/askpassphrasedialog.h \
   qt/assetcontroldialog.h \
   qt/assetcontroltreewidget.h \
+  qt/assetrecord.h \
   qt/assetsdialog.h \
   qt/createassetdialog.h \
   qt/bantablemodel.h \


### PR DESCRIPTION
missing .h file in the qtmakefile includes caused the file to be missing from source tarballs