### PR TITLE
Update chainTxData

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -197,10 +197,11 @@ public:
 
         chainTxData = ChainTxData{
             // Update as we know more about the contents of the Raven chain
-            1509572692, // * UNIX timestamp of last known number of transactions
-            1,          // * total number of transactions between genesis and that timestamp
+            // Stats as of 000000000000a72545994ce72b25042ea63707fca169ca4deb7f9dab4f1b1798 window size 43200
+            1543817453, // * UNIX timestamp of last known number of transactions
+            2033711,    // * total number of transactions between genesis and that timestamp
                         //   (the tx=... number in the SetBestChain debug.log lines)
-            3.1         // * estimated number of transactions per second after that timestamp
+            0.1         // * estimated number of transactions per second after that timestamp
         };
 
         /** RVN Start **/
@@ -368,10 +369,11 @@ public:
 
         chainTxData = ChainTxData{
             // Update as we know more about the contents of the Raven chain
-            1513705170, // * UNIX timestamp of last known number of transactions
-            1,          // * total number of transactions between genesis and that timestamp
+            // Stats as of 00000023b66f46d74890287a7b1157dd780c7c5fdda2b561eb96684d2b39d62e window size 43200
+            1543633332, // * UNIX timestamp of last known number of transactions
+            146666,     // * total number of transactions between genesis and that timestamp
                         //   (the tx=... number in the SetBestChain debug.log lines)
-            3.1         // * estimated number of transactions per second after that timestamp
+            0.02        // * estimated number of transactions per second after that timestamp
         };
 
         /** RVN Start **/


### PR DESCRIPTION
Improves initial sync progress estimation, otherwise early sync progress is reported as extremely slow increase per hour with the final minutes seemingly increasing at a rate of ~500% per hour -- estimates were calculating 3 transactions per second rather than the actual 1 transaction per 10 seconds.

Mainnet as of block 475,000
```
getchaintxstats 43200 000000000000a72545994ce72b25042ea63707fca169ca4deb7f9dab4f1b1798
{
  "time": 1543817453,
  "txcount": 2033711,
  "window_block_count": 43200,
  "window_tx_count": 274083,
  "window_interval": 2611099,
  "txrate": 0.1049684443217205
}
```

Testnet as of block 90,000
```
getchaintxstats 43200 00000023b66f46d74890287a7b1157dd780c7c5fdda2b561eb96684d2b39d62e
{
  "time": 1543633332,
  "txcount": 146666,
  "window_block_count": 43200,
  "window_tx_count": 56233,
  "window_interval": 2826119,
  "txrate": 0.01989760516099994
}
```