### PR TITLE
Adding missing NSIS dependency to build instructions

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -57,7 +57,7 @@ installing the toolchain will be different.
 
 First, install the general dependencies:
 
-    sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl
+    sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl nsis
 
 A host toolchain (`build-essential`) is necessary because some dependency
 packages (such as `protobuf`) need to build host utilities that are used in the


### PR DESCRIPTION
In order to complete windows builds NSIS is used to package up the installer, but it wasn't in the instructions.  Now it is.