### PR TITLE
fix subsidy height on miner_tests.cpp

### DIFF
--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -519,8 +519,8 @@ BOOST_FIXTURE_TEST_SUITE(miner_tests, TestingSetup)
 
         // subsidy changing
         int nHeight = chainActive.Height();
-        // Create an actual 209999-long block chain (without valid blocks).
-        while (chainActive.Tip()->nHeight < 209999)
+        // Create an actual 2099999-long block chain (without valid blocks).
+        while (chainActive.Tip()->nHeight < 2099999)
         {
             CBlockIndex *prev = chainActive.Tip();
             CBlockIndex *next = new CBlockIndex();
@@ -532,8 +532,8 @@ BOOST_FIXTURE_TEST_SUITE(miner_tests, TestingSetup)
             chainActive.SetTip(next);
         }
         BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
-        // Extend to a 210000-long block chain.
-        while (chainActive.Tip()->nHeight < 210000)
+        // Extend to a 2100000-long block chain.
+        while (chainActive.Tip()->nHeight < 2100000)
         {
             CBlockIndex *prev = chainActive.Tip();
             CBlockIndex *next = new CBlockIndex();


### PR DESCRIPTION
https://github.com/RavenProject/Ravencoin/blob/a01dd7b69722441a719468626af152dc68c5eaa5/src/chainparams.cpp#L121

As you know, Raven's `nSubsidyHalvingInterval` is 

`2100000` 

But here it is 10 times smaller.

`210000`

I am glad if it helps. :smiley: