### PR TITLE
[WIP] Don't merge - Testing update for syncing (Connect Block asset cache)

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -959,31 +959,37 @@ CReissueAsset::CReissueAsset(const std::string &strAssetName, const CAmount &nAm
     this->nUnits = nUnits;
 }
 
-bool CReissueAsset::IsValid(std::string &strError, CAssetsCache& assetCache) const
-{
+bool CReissueAsset::IsValid(std::string &strError, CAssetsCache& assetCache, bool fForceCheckPrimaryAssetExists) const {
     strError = "";
 
-    CNewAsset asset;
-    if (!assetCache.GetAssetMetaDataIfExists(this->strName, asset)) {
-        strError = _("Unable to reissue asset: asset_name '") + strName + _("' doesn't exist in the database");
-        return false;
-    }
+    if (fForceCheckPrimaryAssetExists) {
+        CNewAsset asset;
+        if (!assetCache.GetAssetMetaDataIfExists(this->strName, asset)) {
+            strError = _("Unable to reissue asset: asset_name '") + strName + _("' doesn't exist in the database");
+            return false;
+        }
 
-    if (!asset.nReissuable) {
-        // Check to make sure the asset can be reissued
-        strError = _("Unable to reissue asset: reissuable is set to false");
-        return false;
-    }
+        if (!asset.nReissuable) {
+            // Check to make sure the asset can be reissued
+            strError = _("Unable to reissue asset: reissuable is set to false");
+            return false;
+        }
 
-    if (asset.nAmount + this->nAmount > MAX_MONEY) {
-        strError = _("Unable to reissue asset: asset_name '") + strName +
-                   _("' the amount trying to reissue is to large");
-        return false;
-    }
+        if (asset.nAmount + this->nAmount > MAX_MONEY) {
+            strError = _("Unable to reissue asset: asset_name '") + strName +
+                       _("' the amount trying to reissue is to large");
+            return false;
+        }
 
-    if (!CheckAmountWithUnits(nAmount, asset.units)) {
-        strError = _("Unable to reissue asset: amount must be divisible by the smaller unit assigned to the asset");
-        return false;
+        if (!CheckAmountWithUnits(nAmount, asset.units)) {
+            strError = _("Unable to reissue asset: amount must be divisible by the smaller unit assigned to the asset");
+            return false;
+        }
+
+        if (nUnits < asset.units && nUnits != -1) {
+            strError = _("Unable to reissue asset: unit must be larger than current unit selection");
+            return false;
+        }
     }
 
     if (strIPFSHash != "" && strIPFSHash.size() != 34) {
@@ -1003,11 +1009,6 @@ bool CReissueAsset::IsValid(std::string &strError, CAssetsCache& assetCache) con
 
     if (nUnits > MAX_UNIT || nUnits < -1) {
         strError = _("Unable to reissue asset: unit must be less than 8 and greater than -1");
-        return false;
-    }
-
-    if (nUnits < asset.units && nUnits != -1) {
-        strError = _("Unable to reissue asset: unit must be larger than current unit selection");
         return false;
     }
 
@@ -2103,27 +2104,28 @@ bool IsScriptTransferAsset(const CScript& scriptPubKey, int& nStartingIndex)
 
 void UpdatePossibleAssets()
 {
-    if (passets) {
-        for (auto item : passets->setPossiblyMineRemove) {
+    auto assCache = GetCurrentAssetCache();
+    if (assCache) {
+        for (auto item : assCache->setPossiblyMineRemove) {
             // If the CTxOut is mine add it to the list of unspent outpoints
             if (vpwallets[0]->IsMine(item.txOut) == ISMINE_SPENDABLE) {
-                if (!passets->TrySpendCoin(item.out, item.txOut)) // Boolean true means only change the in memory data. We will want to save at the same time that RVN coin saves its cache
+                if (!assCache->TrySpendCoin(item.out, item.txOut)) // Boolean true means only change the in memory data. We will want to save at the same time that RVN coin saves its cache
                     error("%s: Failed to add an asset I own to my Unspent Asset Database. asset %s",
                           __func__, item.assetName);
             }
         }
 
-        for (auto item : passets->setPossiblyMineAdd) {
+        for (auto item : assCache->setPossiblyMineAdd) {
             // If the CTxOut is mine add it to the list of unspent outpoints
             if (vpwallets[0]->IsMine(item.txOut) == ISMINE_SPENDABLE) {
-                if (!passets->AddToMyUnspentOutPoints(item.assetName, item.out)) // Boolean true means only change the in memory data. We will want to save at the same time that RVN coin saves its cache
+                if (!assCache->AddToMyUnspentOutPoints(item.assetName, item.out)) // Boolean true means only change the in memory data. We will want to save at the same time that RVN coin saves its cache
                     error("%s: Failed to add an asset I own to my Unspent Asset Database. asset %s",
                                  __func__, item.assetName);
             }
         }
 
         std::vector<std::pair<std::string, COutPoint> > toRemove;
-        for (auto item : passets->mapMyUnspentAssets) {
+        for (auto item : assCache->mapMyUnspentAssets) {
             for (auto out : item.second) {
                 if (pcoinsTip->AccessCoin(out).IsSpent())
                     toRemove.emplace_back(std::make_pair(item.first, out));
@@ -2131,7 +2133,7 @@ void UpdatePossibleAssets()
         }
 
         for (auto remove : toRemove) {
-            passets->mapMyUnspentAssets.at(remove.first).erase(remove.second);
+            assCache->mapMyUnspentAssets.at(remove.first).erase(remove.second);
         }
 
     }
@@ -2210,6 +2212,7 @@ bool CAssetsCache::GetAssetMetaDataIfExists(const std::string &name, CNewAsset &
 
     // Check the dirty caches first and see if it was recently added or removed
     if (setNewAssetsToRemove.count(cachedAsset)) {
+        LogPrintf("%s : Found in new assets to Remove - Returning False\n", __func__);
         return false;
     }
 
@@ -2246,6 +2249,7 @@ bool CAssetsCache::GetAssetMetaDataIfExists(const std::string &name, CNewAsset &
         }
     }
 
+    LogPrintf("%s : Didn't find asset meta data anywhere. Returning False\n", __func__);
     return false;
 }
 
@@ -2353,10 +2357,11 @@ void GetAllMyAssets(CWallet* pwallet, std::vector<std::string>& names, int nMinC
 
 void GetAllMyAssetsFromCache(std::vector<std::string>& names)
 {
-    if (!passets)
+    auto assCache = GetCurrentAssetCache();
+    if (!assCache)
         return;
 
-    for (auto owned : passets->mapMyUnspentAssets)
+    for (auto owned : assCache->mapMyUnspentAssets)
         names.emplace_back(owned.first);
 
 }
@@ -2548,10 +2553,11 @@ bool CreateAssetTransaction(CWallet* pwallet, CCoinControl& coinControl, const s
 {
     std::string change_address = EncodeDestination(coinControl.destChange);
 
+    auto assCache = GetCurrentAssetCache();
     // Validate the assets data
     std::string strError;
     for (auto asset : assets) {
-        if (!asset.IsValid(strError, *passets)) {
+        if (!asset.IsValid(strError, *assCache)) {
             error = std::make_pair(RPC_INVALID_PARAMETER, strError);
             return false;
         }
@@ -2695,7 +2701,8 @@ bool CreateReissueAssetTransaction(CWallet* pwallet, CCoinControl& coinControl, 
     }
 
     // passets and passetsCache need to be initialized
-    if (!passets) {
+    auto assCache = GetCurrentAssetCache();
+    if (!assCache) {
         error = std::make_pair(RPC_DATABASE_ERROR, std::string("passets isn't initialized"));
         return false;
     }
@@ -2707,7 +2714,7 @@ bool CreateReissueAssetTransaction(CWallet* pwallet, CCoinControl& coinControl, 
     }
 
     std::string strError;
-    if (!reissueAsset.IsValid(strError, *passets)) {
+    if (!reissueAsset.IsValid(strError, *assCache)) {
         error = std::make_pair(RPC_VERIFY_ERROR,
                                std::string("Failed to create reissue asset object. Error: ") + strError);
         return false;
@@ -2793,8 +2800,8 @@ bool CreateTransferAssetTransaction(CWallet* pwallet, const CCoinControl& coinCo
             error = std::make_pair(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Raven address: ") + address);
             return false;
         }
-
-        if (!passets) {
+        auto assCache = GetCurrentAssetCache();
+        if (!assCache) {
             error = std::make_pair(RPC_DATABASE_ERROR, std::string("passets isn't initialized"));
             return false;
         }

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -140,10 +140,11 @@ public :
 
     CAssetsCache(const CAssetsCache& cache) : CAssets(cache)
     {
-        this->mapMyUnspentAssets = cache.mapMyUnspentAssets;
-        this->mapAssetsAddressAmount = cache.mapAssetsAddressAmount;
-        this->mapAssetsAddresses = cache.mapAssetsAddresses;
-        this->mapReissuedAssetData = cache.mapReissuedAssetData;
+        // CAssets constructor does this already
+//        this->mapMyUnspentAssets = cache.mapMyUnspentAssets;
+//        this->mapAssetsAddressAmount = cache.mapAssetsAddressAmount;
+//        this->mapAssetsAddresses = cache.mapAssetsAddresses;
+//        this->mapReissuedAssetData = cache.mapReissuedAssetData;
 
         // Copy dirty cache also
         this->vSpentAssets = cache.vSpentAssets;
@@ -167,6 +168,10 @@ public :
 
         // Changed Outpoints Caches
         this->setChangeOwnedOutPoints = cache.setChangeOwnedOutPoints;
+
+        // Copy sets of possibilymine
+        this->setPossiblyMineAdd = cache.setPossiblyMineAdd;
+        this->setPossiblyMineRemove = cache.setPossiblyMineRemove;
     }
 
     CAssetsCache& operator=(const CAssetsCache& cache)
@@ -198,6 +203,10 @@ public :
 
         // Changed Outpoints Caches
         this->setChangeOwnedOutPoints = cache.setChangeOwnedOutPoints;
+
+        // Copy sets of possibilymine
+        this->setPossiblyMineAdd = cache.setPossiblyMineAdd;
+        this->setPossiblyMineRemove = cache.setPossiblyMineRemove;
 
         return *this;
     }

--- a/src/assets/assettypes.h
+++ b/src/assets/assettypes.h
@@ -224,7 +224,7 @@ public:
     }
 
     CReissueAsset(const std::string& strAssetName, const CAmount& nAmount, const int& nUnits, const int& nReissuable, const std::string& strIPFSHash);
-    bool IsValid(std::string& strError, CAssetsCache& assetCache) const;
+    bool IsValid(std::string& strError, CAssetsCache& assetCache, bool fForceCheckPrimaryAssetExists = true) const;
     void ConstructTransaction(CScript& script) const;
     bool IsNull() const;
 };

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -192,7 +192,7 @@ public:
 
         checkpointData = (CCheckpointData) {
             {
-
+                { 535721, uint256S("0x000000000001217f58a594ca742c8635ecaaaf695d1a63f6ab06979f1c159e04")},
             }
         };
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -287,8 +287,9 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, CAssetsCa
                 if (!ReissueAssetFromTransaction(tx, reissue, strAddress))
                     return state.DoS(100, false, REJECT_INVALID, "bad-txns-reissue-asset");
 
-                if (!reissue.IsValid(strError, *assetCache))
+                if (!reissue.IsValid(strError, *assetCache, false)) {
                     return state.DoS(100, false, REJECT_INVALID, "bad-txns-reissue-" + strError);
+                }
 
             } else if (tx.IsNewUniqueAsset()) {
 
@@ -427,6 +428,7 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, CValidationState& state, c
             else
                 totalOutputs.insert(make_pair(transfer.strName, transfer.nAmount));
 
+            auto assCache = GetCurrentAssetCache();
             if (!fRunningUnitTests) {
                 if (IsAssetNameAnOwner(transfer.strName)) {
                     if (transfer.nAmount != OWNER_ASSET_AMOUNT)
@@ -434,7 +436,7 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, CValidationState& state, c
                 } else {
                     // For all other types of assets, make sure they are sending the right type of units
                     CNewAsset asset;
-                    if (!passets->GetAssetMetaDataIfExists(transfer.strName, asset))
+                    if (!assCache->GetAssetMetaDataIfExists(transfer.strName, asset))
                         return state.DoS(100, false, REJECT_INVALID, "bad-txns-transfer-asset-not-exist");
 
                     if (asset.strName != transfer.strName)
@@ -451,8 +453,9 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, CValidationState& state, c
                 return state.DoS(100, false, REJECT_INVALID, "bad-tx-asset-reissue-bad-deserialize");
 
             if (!fRunningUnitTests) {
+                auto assCache = GetCurrentAssetCache();
                 std::string strError;
-                if (!reissue.IsValid(strError, *passets)) {
+                if (!reissue.IsValid(strError, *assCache)) {
                     return state.DoS(100, false, REJECT_INVALID,
                                      "bad-txns" + strError);
                 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -252,6 +252,8 @@ void Shutdown()
         pblocktree = nullptr;
         delete passets;
         passets = nullptr;
+        delete tmpAssetCache;
+        tmpAssetCache = nullptr;
         delete passetsdb;
         passetsdb = nullptr;
         delete passetsCache;
@@ -1448,8 +1450,10 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete passets;
                 delete passetsdb;
                 delete passetsCache;
+                delete tmpAssetCache;
                 passetsdb = new CAssetsDB(nBlockTreeDBCache, false, fReset);
                 passets = new CAssetsCache();
+                tmpAssetCache = new CAssetsCache();
                 passetsCache = new CLRUCache<std::string, CDatabasedAssetData>(MAX_CACHE_ASSETS_SIZE);
 
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1209,11 +1209,12 @@ void static ProcessAssetGetData(CNode* pfrom, const Consensus::Params& consensus
             }
 
             bool push = false;
-            if (passets) {
+            auto assCache = GetCurrentAssetCache();
+            if (assCache) {
                 CNewAsset asset;
                 int height;
                 uint256 hash;
-                if (passets->GetAssetMetaDataIfExists(inv.name, asset, height, hash)) {
+                if (assCache->GetAssetMetaDataIfExists(inv.name, asset, height, hash)) {
                     auto data = CDatabasedAssetData(asset, height, hash);
                     passetsCache->Put(inv.name, data);
                     connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::ASSETDATA, SerializedAssetData(data)));

--- a/src/qt/assettablemodel.cpp
+++ b/src/qt/assettablemodel.cpp
@@ -36,11 +36,12 @@ public:
     void refreshWallet() {
         qDebug() << "AssetTablePriv::refreshWallet";
         cachedBalances.clear();
-        if (passets) {
+        auto assCache = GetCurrentAssetCache();
+        if (assCache) {
             {
                 LOCK(cs_main);
                 std::map<std::string, CAmount> balances;
-                if (!GetMyAssetBalances(*passets, balances)) {
+                if (!GetMyAssetBalances(*assCache, balances)) {
                     qWarning("AssetTablePriv::refreshWallet: Error retrieving asset balances");
                     return;
                 }
@@ -57,7 +58,7 @@ public:
                     if (!IsAssetNameAnOwner(bal->first)) {
                         // Asset is not an administrator asset
                         CNewAsset assetData;
-                        if (!passets->GetAssetMetaDataIfExists(bal->first, assetData)) {
+                        if (!assCache->GetAssetMetaDataIfExists(bal->first, assetData)) {
                             qWarning("AssetTablePriv::refreshWallet: Error retrieving asset data");
                             return;
                         }

--- a/src/qt/createassetdialog.cpp
+++ b/src/qt/createassetdialog.cpp
@@ -535,9 +535,10 @@ void CreateAssetDialog::checkAvailabilityClicked()
     QString name = GetAssetName();
 
     LOCK(cs_main);
-    if (passets) {
+    auto assCache = GetCurrentAssetCache();
+    if (assCache) {
         CNewAsset asset;
-        if (passets->GetAssetMetaDataIfExists(name.toStdString(), asset)) {
+        if (assCache->GetAssetMetaDataIfExists(name.toStdString(), asset)) {
             ui->nameText->setStyleSheet(STYLE_INVALID);
             showMessage(tr("Invalid: Asset name already in use"));
             disableCreateButton();

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -448,7 +448,8 @@ void OverviewPage::handleAssetClicked(const QModelIndex &index)
             issueUnique->setDisabled(false);
             reissue->setDisabled(true);
             CNewAsset asset;
-            if (passets && passets->GetAssetMetaDataIfExists(name.toStdString(), asset))
+            auto assCache = GetCurrentAssetCache();
+            if (assCache && assCache->GetAssetMetaDataIfExists(name.toStdString(), asset))
                 if (asset.nReissuable)
                     reissue->setDisabled(false);
 

--- a/src/qt/reissueassetdialog.cpp
+++ b/src/qt/reissueassetdialog.cpp
@@ -574,8 +574,9 @@ void ReissueAssetDialog::onAssetSelected(int index)
         QString qstr_name = ui->comboBox->currentText();
 
         LOCK(cs_main);
+        auto assCache = GetCurrentAssetCache();
         // Get the asset data
-        if (!passets->GetAssetMetaDataIfExists(qstr_name.toStdString(), *asset)) {
+        if (!assCache->GetAssetMetaDataIfExists(qstr_name.toStdString(), *asset)) {
             CheckFormState();
             disableAll();
             asset->SetNull();

--- a/src/qt/sendassetsentry.cpp
+++ b/src/qt/sendassetsentry.cpp
@@ -326,10 +326,11 @@ void SendAssetsEntry::onAssetSelected(int index)
     }
 
     LOCK(cs_main);
+    auto assCache = GetCurrentAssetCache();
     CNewAsset asset;
 
     // Get the asset metadata if it exists. This isn't called on the administrator token because that doesn't have metadata
-    if (!passets->GetAssetMetaDataIfExists(name.toStdString(), asset)) {
+    if (!assCache->GetAssetMetaDataIfExists(name.toStdString(), asset)) {
         // This should only happen if the user, selected an asset that was issued from assetcontrol and tries to transfer it before it is mined.
         clear();
         ui->messageLabel->show();

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -295,9 +295,10 @@ QString TransactionDesc::toAssetHTML(CWallet *wallet, CWalletTx &wtx, Transactio
     strHTML += "<html><font face='verdana, arial, helvetica, sans-serif'>";
 
     CNewAsset asset;
+    auto assCache = GetCurrentAssetCache();
     if (IsAssetNameAnOwner(rec->assetName))
         rec->units = OWNER_UNITS;
-    else if (passets && passets->GetAssetMetaDataIfExists(rec->assetName, asset))
+    else if (assCache && assCache->GetAssetMetaDataIfExists(rec->assetName, asset))
         rec->units = asset.units;
     else
         rec->units = MAX_ASSET_UNITS;

--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -59,13 +59,15 @@ std::string AssetTypeToString(AssetType& assetType)
 
 UniValue UnitValueFromAmount(const CAmount& amount, const std::string asset_name)
 {
-    if (!passets)
+
+    auto assCache = GetCurrentAssetCache();
+    if (!assCache)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Asset cache isn't available.");
 
     uint8_t units = OWNER_UNITS;
     if (!IsAssetNameAnOwner(asset_name)) {
         CNewAsset assetData;
-        if (!passets->GetAssetMetaDataIfExists(asset_name, assetData))
+        if (!assCache->GetAssetMetaDataIfExists(asset_name, assetData))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't load asset from cache: " + asset_name);
 
         units = assetData.units;
@@ -403,17 +405,18 @@ UniValue listassetbalancesbyaddress(const JSONRPCRequest& request)
     LOCK(cs_main);
     UniValue result(UniValue::VOBJ);
 
-    if (!passets)
+    auto assCache = GetCurrentAssetCache();
+    if (!assCache)
         return NullUniValue;
 
     // Call get the best address amount on all assets that contain that address ( this update mapAssetsAddressAmount)
-    for (auto it : passets->mapAssetsAddresses) {
+    for (auto it : assCache->mapAssetsAddresses) {
         if (it.second.count(address))
-            GetBestAssetAddressAmount(*passets, it.first, address);
+            GetBestAssetAddressAmount(*assCache, it.first, address);
     }
 
     // Loop through the updated map, and get the results
-    for (auto it : passets->mapAssetsAddressAmount) {
+    for (auto it : assCache->mapAssetsAddressAmount) {
         if (address.compare(it.first.second) == 0) {
             result.push_back(Pair(it.first.first, UnitValueFromAmount(it.second, it.first.first)));
         }
@@ -453,9 +456,10 @@ UniValue getassetdata(const JSONRPCRequest& request)
     LOCK(cs_main);
     UniValue result (UniValue::VOBJ);
 
-    if (passets) {
+    auto assCache = GetCurrentAssetCache();
+    if (assCache) {
         CNewAsset asset;
-        if (!passets->GetAssetMetaDataIfExists(asset_name, asset))
+        if (!assCache->GetAssetMetaDataIfExists(asset_name, asset))
             return NullUniValue;
 
         result.push_back(Pair("name", asset.strName));
@@ -535,7 +539,8 @@ UniValue listmyassets(const JSONRPCRequest &request)
     ObserveSafeMode();
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    if (!passets)
+    auto assCache = GetCurrentAssetCache();
+    if (!assCache)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Asset cache unavailable.");
 
     std::string filter = "*";
@@ -564,22 +569,22 @@ UniValue listmyassets(const JSONRPCRequest &request)
     // retrieve balances
     std::map<std::string, CAmount> balances;
     if (filter == "*") {
-        if (!GetMyAssetBalances(*passets, balances))
+        if (!GetMyAssetBalances(*assCache, balances))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't get asset balances. For all assets");
     }
     else if (filter.back() == '*') {
         std::vector<std::string> assetNames;
         filter.pop_back();
-        if (!GetMyOwnedAssets(*passets, filter, assetNames))
+        if (!GetMyOwnedAssets(*assCache, filter, assetNames))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't get owned assets.");
-        if (!GetMyAssetBalances(*passets, assetNames, balances))
+        if (!GetMyAssetBalances(*assCache, assetNames, balances))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't get asset balances.");
     }
     else {
         if (!IsAssetNameValid(filter))
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid asset name.");
         CAmount balance;
-        if (!GetMyAssetBalance(*passets, filter, balance)) {
+        if (!GetMyAssetBalance(*assCache, filter, balance)) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, std::string("Couldn't get asset balances. For asset : ") + filter);
         }
         balances[filter] = balance;
@@ -602,7 +607,7 @@ UniValue listmyassets(const JSONRPCRequest &request)
             asset.push_back(Pair("balance", UnitValueFromAmount(bal->second, bal->first)));
 
             UniValue outpoints(UniValue::VARR);
-            for (auto const& out : passets->mapMyUnspentAssets[bal->first]) {
+            for (auto const& out : assCache->mapMyUnspentAssets[bal->first]) {
                 UniValue tempOut(UniValue::VOBJ);
                 tempOut.push_back(Pair("txid", out.hash.GetHex()));
                 tempOut.push_back(Pair("vout", (int)out.n));
@@ -685,20 +690,22 @@ UniValue listaddressesbyasset(const JSONRPCRequest &request)
 
     std::string asset_name = request.params[0].get_str();
 
-    if (!passets)
+    auto assCache = GetCurrentAssetCache();
+    if (!assCache)
         return NullUniValue;
 
-    if (!passets->mapAssetsAddresses.count(asset_name))
+    if (!assCache->mapAssetsAddresses.count(asset_name))
         return NullUniValue;
 
     UniValue addresses(UniValue::VOBJ);
 
-    auto setAddresses = passets->mapAssetsAddresses.at(asset_name);
+    auto setAddresses = assCache->mapAssetsAddresses.at(asset_name);
     for (auto it : setAddresses) {
         auto pair = std::make_pair(asset_name, it);
 
-        if (GetBestAssetAddressAmount(*passets, asset_name, it))
-            addresses.push_back(Pair(it, UnitValueFromAmount(passets->mapAssetsAddressAmount.at(pair), asset_name)));
+
+        if (GetBestAssetAddressAmount(*assCache, asset_name, it))
+            addresses.push_back(Pair(it, UnitValueFromAmount(assCache->mapAssetsAddressAmount.at(pair), asset_name)));
     }
 
     return addresses;
@@ -985,8 +992,8 @@ UniValue getcacheinfo(const JSONRPCRequest& request)
                 + HelpExampleCli("getcacheinfo", "")
         );
 
-
-    if (!passets)
+    auto assCache = GetCurrentAssetCache();
+    if (!assCache)
         throw JSONRPCError(RPC_VERIFY_ERROR, "asset cache is null");
 
     if (!pcoinsTip)
@@ -996,22 +1003,24 @@ UniValue getcacheinfo(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_VERIFY_ERROR, "asset metadata cache is nul");
 
 
+
+
     UniValue result(UniValue::VARR);
 
     UniValue info(UniValue::VOBJ);
     info.push_back(Pair("uxto cache size", (int)pcoinsTip->DynamicMemoryUsage()));
-    info.push_back(Pair("asset total (exclude dirty)", (int)passets->DynamicMemoryUsage()));
+    info.push_back(Pair("asset total (exclude dirty)", (int)assCache->DynamicMemoryUsage()));
 
     UniValue descendants(UniValue::VOBJ);
-    descendants.push_back(Pair("asset address map",  (int)memusage::DynamicUsage(passets->mapAssetsAddresses)));
-    descendants.push_back(Pair("asset address balance",   (int)memusage::DynamicUsage(passets->mapAssetsAddressAmount)));
-    descendants.push_back(Pair("my unspent asset",   (int)memusage::DynamicUsage(passets->mapMyUnspentAssets)));
-    descendants.push_back(Pair("reissue data",   (int)memusage::DynamicUsage(passets->mapReissuedAssetData)));
+    descendants.push_back(Pair("asset address map",  (int)memusage::DynamicUsage(assCache->mapAssetsAddresses)));
+    descendants.push_back(Pair("asset address balance",   (int)memusage::DynamicUsage(assCache->mapAssetsAddressAmount)));
+    descendants.push_back(Pair("my unspent asset",   (int)memusage::DynamicUsage(assCache->mapMyUnspentAssets)));
+    descendants.push_back(Pair("reissue data",   (int)memusage::DynamicUsage(assCache->mapReissuedAssetData)));
 
     info.push_back(Pair("asset data", descendants));
     info.push_back(Pair("asset metadata map",  (int)memusage::DynamicUsage(passetsCache->GetItemsMap())));
     info.push_back(Pair("asset metadata list (est)",  (int)passetsCache->GetItemsList().size() * (32 + 80))); // Max 32 bytes for asset name, 80 bytes max for asset data
-    info.push_back(Pair("dirty cache (est)",  (int)passets->GetCacheSize()));
+    info.push_back(Pair("dirty cache (est)",  (int)assCache->GetCacheSize()));
 
     result.push_back(info);
     return result;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -508,6 +508,8 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
         rawTx.vin.push_back(in);
     }
 
+    auto assCache = GetCurrentAssetCache();
+
     std::set<CTxDestination> destinations;
     std::vector<std::string> addrList = sendTo.getKeys();
     for (const std::string& name_ : addrList) {
@@ -585,7 +587,7 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
 
                     // Verify that data
                     std::string strError = "";
-                    if (!asset.IsValid(strError, *passets))
+                    if (!asset.IsValid(strError, *assCache))
                         throw JSONRPCError(RPC_INVALID_PARAMETER, strError);
 
                     // Construct the asset transaction
@@ -661,7 +663,7 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
 
                         // Verify that data
                         std::string strError = "";
-                        if (!asset.IsValid(strError, *passets))
+                        if (!asset.IsValid(strError, *assCache))
                             throw JSONRPCError(RPC_INVALID_PARAMETER, strError);
 
                         // Construct the asset transaction
@@ -721,7 +723,7 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
 
                     // Validate the the object is valid
                     std::string strError;
-                    if (!reissueObj.IsValid(strError, *passets))
+                    if (!reissueObj.IsValid(strError, *assCache))
                         throw JSONRPCError(RPC_INVALID_PARAMETER, strError);
 
 

--- a/src/test/test_raven.cpp
+++ b/src/test/test_raven.cpp
@@ -79,6 +79,7 @@ TestingSetup::TestingSetup(const std::string &chainName) : BasicTestingSetup(cha
     }
 
     passets = new CAssetsCache();
+    tmpAssetCache = new CAssetsCache();
     {
         CValidationState state;
         if (!ActivateBestChain(state, chainparams))
@@ -106,6 +107,8 @@ TestingSetup::~TestingSetup()
     delete pcoinsTip;
     delete pcoinsdbview;
     delete pblocktree;
+    delete passets;
+    delete tmpAssetCache;
     fs::remove_all(pathTemp);
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3021,6 +3021,8 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
+            if (assetCache)
+                delete assetCache;
             return error("ConnectTip(): ConnectBlock %s failed", pindexNew->GetBlockHash().ToString());
         }
         int64_t nTimeConnectDone = GetTimeMicros();

--- a/src/validation.h
+++ b/src/validation.h
@@ -290,6 +290,7 @@ void UnloadBlockIndex();
 void ThreadScriptCheck();
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
 bool IsInitialBlockDownload();
+bool IsInitialSyncSpeedUp();
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
 bool GetTransaction(const uint256 &hash, CTransactionRef &tx, const Consensus::Params& params, uint256 &hashBlock, bool fAllowSlow = false);
 /** Find the best known block, and make it the tip of the block chain */
@@ -490,6 +491,8 @@ extern CBlockTreeDB *pblocktree;
 extern CAssetsDB *passetsdb;
 /** Global variable that point to the active assets (protexted by cs_main) */
 extern CAssetsCache *passets;
+extern CAssetsCache *tmpAssetCache;
+extern int nBlockCount;
 /** Global variable that point to the assets LRU Cache (protexted by cs_main) */
 extern CLRUCache<std::string, CDatabasedAssetData> *passetsCache;
 /** RVN END */
@@ -529,6 +532,10 @@ bool LoadMempool();
 bool AreAssetsDeployed();
 
 bool IsDGWActive(unsigned int nBlockNumber);
+
+extern bool fSwitchFromInitialBlockDownload;
+extern bool fFirstStart;
+CAssetsCache* GetCurrentAssetCache();
 /** RVN END */
 
 #endif // RAVEN_VALIDATION_H


### PR DESCRIPTION
- Only affects blocks after asset activation 
- We have been seeing major issues with the sync speed of the chain
- The issue comes from the copying of the asset cache before a new block to connected to the chain, and again after a block is connected successfully. This process was taking some time to complete adding between half a second to a second for each block to connect. Meaning that at that best scenario it would take 13 hours to sync the last 100000 blocks of the chain. Most users where seeing it take days to weeks to sync the chain
- To fix this issue, Copying of the asset cache is batched in groups of 100 blocks. This significantly increased the sync speed until we are synced to 1 hour from the tip

Testing:
Testing with this change, I was able to do a complete sync from scratch in 2 hours and 10 minutes. This was performed on a Mac Book Pro with 16 GB of RAM. 

Edit:
- This sync is causing all sorts of banning of nodes. Investigation Required
- The banned nodes where being banned because when blocks are sent to clients, They are being processed then later on they are connected to the chain. When the blocks where being processed, we were checking to make sure certain items where in the database. This was throwing an error because these checks don't need to occur when a new block is being processed from the network. 