### PR TITLE
Minor test fixes for asset_audit and functional test runner

### DIFF
--- a/assets/tools/asset_audit.py
+++ b/assets/tools/asset_audit.py
@@ -2,21 +2,28 @@
 # Script to audit the assets
 # Reads the asset (amount has all issuances)
 # Reads the balances in every address for the asset.
-# Compares the two numbers to checks that qty of all assets are accounted for
+# Compares the two numbers to checks that qty of all assets are accounted for#
+#
+# -- NOTE: 	This script requires Python, PIP, and bitcoin-rpc to be installed.
+# 		To install bitcoin-rpc run the following command from the terminal:
+#				pip install python-bitcoinrpc
+
 
 import subprocess
 import json
 
 
 #Set this to your raven-cli program
-cli = "raven-cli"
+cli = "./src/raven-cli"
 
-mode = "-testnet"
-rpc_port = 18766
+mode = "-main"
+rpc_port = 8767
+#mode = "-testnet"
+#rpc_port = 18770
 #mode =  "-regtest"
-#rpc_port = 18443
+#rpc_port = 18444
 
-#Set this information in your raven.conf file (in datadir, not testnet3)
+#Set this information in your raven.conf file (in datadir, not testnet6)
 rpc_user = 'rpcuser'
 rpc_pass = 'rpcpass555'
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -198,7 +198,7 @@ def main():
     parser.add_argument('--onlyextended', action='store_true', help='run only the extended test suite')
     parser.add_argument('--force', '-f', action='store_true', help='run tests even on platforms where they are disabled by default (e.g. windows).')
     parser.add_argument('--help', '-h', '-?', action='store_true', help='print help text and exit')
-    parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
+    parser.add_argument('--jobs', '-j', type=int, default=2, help='how many test scripts to run in parallel. Default=2.')
     parser.add_argument('--keepcache', '-k', action='store_true', help='the default behavior is to flush the cache directory on startup. --keepcache retains the cache from the previous testrun.')
     parser.add_argument('--quiet', '-q', action='store_true', help='only print results summary and failure logs')
     parser.add_argument('--tmpdirprefix', '-t', default=tempfile.gettempdir(), help="Root directory for datadirs")
@@ -502,7 +502,7 @@ def check_script_list(src_dir):
     python_files = set([t for t in os.listdir(script_dir) if t[-3:] == ".py"])
     missed_tests = list(python_files - set(map(lambda x: x.split()[0], ALL_SCRIPTS + NON_SCRIPTS)))
     if len(missed_tests) != 0:
-        print("%sWARNING!%s The following scripts are not being run: %s. Check the test lists in test_runner.py." % (BOLD[1], BOLD[0], str(missed_tests)))
+        print("%sWARNING!%s The following scripts are not being run:\n%s. \nCheck the test lists in test_runner.py." % (BOLD[1], BOLD[0], "\n".join(missed_tests)))
         if os.getenv('TRAVIS') == 'true':
             # On travis this warning is an error to prevent merging incomplete commits into master
             sys.exit(1)


### PR DESCRIPTION
issue #506 
The asset audit script did not include information for running main-net auditing, also the testnet and regtest port numbers were incorrect.  It also did not contain information about needing the bitcoin-rpc python-pip library to be able to run.  These are all now included. 
The functional test was still randomly failing certain tests.  I've found that if you run the tests with only one thread (default is 4) that the tests almost always run successfully.  It takes much longer with only 1 test running at a time, so as a compromise I've set it to only use 2-threads by default.  This can be overridden on the command line using the -j=n or --jobs=n.  An occasional false negative failure will still occur, but it is much less frequent - about 1.5 out of 10 times running the full extended test suite will result in a false-negative failure.