### PR TITLE
Fixing OSX build / link error

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -21,7 +21,6 @@ std::string COutPoint::ToSerializedString() const
 {
     CDataStream stream(PROTOCOL_VERSION, SER_DISK);
     stream << *this;
-    LogPrintf("Got a string COutPoint: %s\n", stream.str());
     return stream.str();
 }
 


### PR DESCRIPTION
A recent change caused the OSX compile to fail with a linker error.  Since the log print line isn't needed this is the easy way to resolve this error.