### PR TITLE
Allow clear to update reissue asset list

### DIFF
--- a/src/qt/reissueassetdialog.cpp
+++ b/src/qt/reissueassetdialog.cpp
@@ -1222,6 +1222,8 @@ void ReissueAssetDialog::clear()
     disableAll();
     asset->SetNull();
     setDisplayedDataToNone();
+
+    updateAssetsList();
 }
 
 void ReissueAssetDialog::onClearButtonClicked()


### PR DESCRIPTION
- Managed assets weren't showing up after they were mined in the qt list of assets. 
- Clicking the clear button will now reset the list to include all newly mined coins