### PR TITLE
Fixing two of the functional - asset feature tests

### DIFF
--- a/test/functional/feature_assets.py
+++ b/test/functional/feature_assets.py
@@ -274,11 +274,12 @@ class AssetTest(RavenTestFramework):
 
         ########################################
         # bad hash (isn't a valid multihash sha2-256)
+        self.log.info("Testing issue asset with invalid IPFS...")
         try:
             n0.issue(asset_name=asset_name1, qty=1000, to_address=address1, change_address=address2, \
                      units=0, reissuable=True, has_ipfs=True, ipfs_hash=bad_hash)
         except JSONRPCException as e:
-            if "Invalid IPFS hash (doesn't start with 'Qm')" not in e.error['message']:
+            if "Invalid IPFS/Txid hash" not in e.error['message']:
                 raise AssertionError("Expected substring not found:" + e.error['message'])
         except Exception as e:
             raise AssertionError("Unexpected exception raised: " + type(e).__name__)
@@ -287,6 +288,7 @@ class AssetTest(RavenTestFramework):
 
         ########################################
         # no hash
+        self.log.info("Testing issue asset with no IPFS...")
         n0.issue(asset_name=asset_name2, qty=1000, to_address=address1, change_address=address2, \
                  units=0, reissuable=True, has_ipfs=False)
         n0.generate(1)
@@ -296,11 +298,12 @@ class AssetTest(RavenTestFramework):
 
         ########################################
         # reissue w/ bad hash
+        self.log.info("Testing re-issue asset with invalid IPFS...")
         try:
             n0.reissue(asset_name=asset_name2, qty=2000, to_address=address1, change_address=address2, \
                        reissuable=True, new_unit=-1, new_ipfs=bad_hash)
         except JSONRPCException as e:
-            if "Invalid IPFS hash (doesn't start with 'Qm')" not in e.error['message']:
+            if "Invalid IPFS/Txid hash" not in e.error['message']:
                 raise AssertionError("Expected substring not found:" + e.error['message'])
         except Exception as e:
             raise AssertionError("Unexpected exception raised: " + type(e).__name__)
@@ -309,6 +312,7 @@ class AssetTest(RavenTestFramework):
 
         ########################################
         # reissue w/ hash
+        self.log.info("Testing re-issue asset with valid IPFS...")
         n0.reissue(asset_name=asset_name2, qty=2000, to_address=address1, change_address=address2, \
                    reissuable=True, new_unit=-1, new_ipfs=ipfs_hash)
         n0.generate(1)

--- a/test/functional/feature_rawassettransactions.py
+++ b/test/functional/feature_rawassettransactions.py
@@ -693,7 +693,7 @@ class RawAssetTransactionsTest(RavenTestFramework):
                 }
             }
         }
-        assert_raises_rpc_error(-8, "Invalid parameter: ipfs_hash must start with 'Qm'.", n0.createrawtransaction, inputs, outputs)
+        assert_raises_rpc_error(-8, "Invalid parameter: ipfs_hash is not valid, or txid hash is not the right length", n0.createrawtransaction, inputs, outputs)
 
         ########################################
         # reissue
@@ -716,7 +716,7 @@ class RawAssetTransactionsTest(RavenTestFramework):
                 }
             }
         }
-        assert_raises_rpc_error(-8, "Invalid parameter: ipfs_hash must start with 'Qm'.", n0.createrawtransaction, inputs, outputs)
+        assert_raises_rpc_error(-8, "Invalid parameter: ipfs_hash is not valid, or txid hash is not the right length", n0.createrawtransaction, inputs, outputs)
 
 
     def issue_invalid_address_test(self):
@@ -1408,7 +1408,7 @@ class RawAssetTransactionsTest(RavenTestFramework):
                 tx.vout[n].scriptPubKey = hex_str_to_bytes(tampered_script)
         tx_bad_transfer = bytes_to_hex_str(tx.serialize())
         tx_bad_transfer_signed = n0.signrawtransaction(tx_bad_transfer)['hex']
-        assert_raises_rpc_error(-26, "bad-tx-inputs-outputs-mismatch Bad Transaction - Assets would be burnt TRANSFER_TX_TAMPERING",
+        assert_raises_rpc_error(-26, "bad-txns-transfer-not-valid Invalid parameter: asset amount can't be equal to or less than zero.",
                                 n0.sendrawtransaction, tx_bad_transfer_signed)
 
         signed_hex = n0.signrawtransaction(tx_transfer_hex)['hex']


### PR DESCRIPTION
Both of these tests were failing due to recent changes in the RPC error messages that were being returned. The text of the expected PRC error was changed in the tests to reflect the changes made in the code.