### PR TITLE
Update messaging rpc calls

### DIFF
--- a/src/rpc/messages.cpp
+++ b/src/rpc/messages.cpp
@@ -207,7 +207,7 @@ UniValue subscribetochannel(const JSONRPCRequest& request) {
         channel_name += "!";
         if (!IsAssetNameValid(channel_name, type))
         throw JSONRPCError(
-                RPC_INVALID_PARAMETER, "Channel Name is not valid after adding !.");
+                RPC_INVALID_PARAMETER, "Channel Name is not valid.");
     }
     
     if (type != AssetType::OWNER && type != AssetType::MSGCHANNEL)
@@ -250,7 +250,7 @@ UniValue unsubscribefromchannel(const JSONRPCRequest& request) {
     AssetType type;
     if (!IsAssetNameValid(channel_name, type))
         throw JSONRPCError(
-                RPC_INVALID_PARAMETER, "Channel Name is not valid after adding !.");
+                RPC_INVALID_PARAMETER, "Channel Name is not valid.");
 
     // if the given asset name is a root of sub asset, subscribe to that assets owner token
     if (type == AssetType::ROOT || type == AssetType::SUB) {

--- a/src/rpc/messages.cpp
+++ b/src/rpc/messages.cpp
@@ -202,13 +202,18 @@ UniValue subscribetochannel(const JSONRPCRequest& request) {
         throw JSONRPCError(
                 RPC_INVALID_PARAMETER, "Channel Name is not valid.");
 
+    // if the given asset name is a root of sub asset, subscribe to that assets owner token
+    if (type == AssetType::ROOT || type == AssetType::SUB) {
+        channel_name += "!";
+    }
+
     if (type != AssetType::OWNER && type != AssetType::MSGCHANNEL)
         throw JSONRPCError(
-                RPC_INVALID_PARAMETER, "Channel Name must must a owner asset, or a message channel asset e.g OWNER!, MSG_CHANNEL~123.");
+                RPC_INVALID_PARAMETER, "Channel Name must be a owner asset, or a message channel asset e.g OWNER!, MSG_CHANNEL~123.");
 
     AddChannel(channel_name);
 
-    return NullUniValue;
+    return "Subscribed to channel: " + channel_name;
 }
 
 
@@ -244,13 +249,18 @@ UniValue unsubscribefromchannel(const JSONRPCRequest& request) {
         throw JSONRPCError(
                 RPC_INVALID_PARAMETER, "Channel Name is not valid.");
 
+    // if the given asset name is a root of sub asset, subscribe to that assets owner token
+    if (type == AssetType::ROOT || type == AssetType::SUB) {
+        channel_name += "!";
+    }
+
     if (type != AssetType::OWNER && type != AssetType::MSGCHANNEL)
         throw JSONRPCError(
-                RPC_INVALID_PARAMETER, "Channel Name must must a owner asset, or a message channel asset e.g OWNER!, MSG_CHANNEL~123.");
+                RPC_INVALID_PARAMETER, "Channel Name must be a owner asset, or a message channel asset e.g OWNER!, MSG_CHANNEL~123.");
 
     RemoveChannel(channel_name);
 
-    return NullUniValue;
+    return "Unsubscribed from channel: " + channel_name;
 }
 
 UniValue clearmessages(const JSONRPCRequest& request) {

--- a/src/rpc/messages.cpp
+++ b/src/rpc/messages.cpp
@@ -205,8 +205,11 @@ UniValue subscribetochannel(const JSONRPCRequest& request) {
     // if the given asset name is a root of sub asset, subscribe to that assets owner token
     if (type == AssetType::ROOT || type == AssetType::SUB) {
         channel_name += "!";
+        if (!IsAssetNameValid(channel_name, type))
+        throw JSONRPCError(
+                RPC_INVALID_PARAMETER, "Channel Name is not valid after adding !.");
     }
-
+    
     if (type != AssetType::OWNER && type != AssetType::MSGCHANNEL)
         throw JSONRPCError(
                 RPC_INVALID_PARAMETER, "Channel Name must be a owner asset, or a message channel asset e.g OWNER!, MSG_CHANNEL~123.");
@@ -247,11 +250,15 @@ UniValue unsubscribefromchannel(const JSONRPCRequest& request) {
     AssetType type;
     if (!IsAssetNameValid(channel_name, type))
         throw JSONRPCError(
-                RPC_INVALID_PARAMETER, "Channel Name is not valid.");
+                RPC_INVALID_PARAMETER, "Channel Name is not valid after adding !.");
 
     // if the given asset name is a root of sub asset, subscribe to that assets owner token
     if (type == AssetType::ROOT || type == AssetType::SUB) {
         channel_name += "!";
+        
+        if (!IsAssetNameValid(channel_name, type))
+        throw JSONRPCError(
+                RPC_INVALID_PARAMETER, "Channel Name is not valid.");
     }
 
     if (type != AssetType::OWNER && type != AssetType::MSGCHANNEL)


### PR DESCRIPTION
- Allow the input of normal Root and Sub Asset name, and convert them to owner tokens
- Update rpc error messages