### PR TITLE
Add Wallet Repair tab to the debug window

### DIFF
--- a/src/init.h
+++ b/src/init.h
@@ -19,7 +19,7 @@ namespace boost
 } // namespace boost
 
 void StartShutdown();
-
+void StartRestart();
 bool ShutdownRequested();
 
 /** Interrupt threads */
@@ -66,6 +66,7 @@ bool AppInitLockDataDirectory();
  * @pre Parameters should be parsed and config file should be read, AppInitLockDataDirectory should have been called.
  */
 bool AppInitMain(boost::thread_group &threadGroup, CScheduler &scheduler);
+void PrepareShutdown();
 
 /** The help message mode determines what help message to show */
 enum HelpMessageMode

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1647,7 +1647,7 @@ void CConnman::ThreadDNSAddressSeed()
                     int nOneDay = 24*3600;
                     CAddress addr = CAddress(CService(ip, Params().GetDefaultPort()), requiredServiceBits);
                     LogPrintf("IP: %s\n", addr.ToString());
-                    
+
                     addr.nTime = GetTime() - 3*nOneDay - GetRand(4*nOneDay); // use a random age between 3 and 7 days old
                     vAdd.push_back(addr);
                     found++;
@@ -2398,6 +2398,14 @@ public:
     }
 }
 instance_of_cnetcleanup;
+
+void CExplicitNetCleanup::callCleanup()
+{
+    // Explicit call to destructor of CNetCleanup because it's not implicitly called
+    // when the wallet is restarted from within the wallet itself.
+    CNetCleanup *tmp = new CNetCleanup();
+    delete tmp;
+}
 
 void CConnman::Interrupt()
 {

--- a/src/net.h
+++ b/src/net.h
@@ -839,6 +839,11 @@ public:
     void MaybeSetAddrName(const std::string& addrNameIn);
 };
 
+class CExplicitNetCleanup
+{
+public:
+    static void callCleanup();
+};
 
 
 

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1416,6 +1416,166 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tab_repair">
+      <attribute name="title">
+       <string>&amp;Wallet Repair</string>
+      </attribute>
+      <widget class="QLabel" name="label_repair_header">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>15</y>
+         <width>711</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Wallet Repair Options</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_repair_helptext">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>35</y>
+         <width>850</width>
+         <height>41</height>
+        </rect>
+       </property>
+       <property name="font">
+        <font>
+         <weight>50</weight>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>The buttons below will restart the wallet with command-line options to recover missing transactions or rebuild corrupt blockchain files.</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="wallet_path">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>75</y>
+         <width>750</width>
+         <height>21</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Wallet Path</string>
+       </property>
+      </widget>
+      <widget class="QPushButton" name="btn_rescan">
+       <property name="geometry">
+        <rect>
+         <x>15</x>
+         <y>121</y>
+         <width>240</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Rescan blockchain files</string>
+       </property>
+      </widget>
+      <widget class="QPushButton" name="btn_zapwallettxes1">
+       <property name="geometry">
+        <rect>
+         <x>15</x>
+         <y>181</y>
+         <width>240</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Recover transactions</string>
+       </property>
+      </widget>
+      <widget class="QPushButton" name="btn_reindex">
+       <property name="geometry">
+        <rect>
+         <x>15</x>
+         <y>246</y>
+         <width>240</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Rebuild index</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_repair_rescan">
+       <property name="geometry">
+        <rect>
+         <x>260</x>
+         <y>120</y>
+         <width>700</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>-rescan: Rescan the blockchain files on disk for missing wallet transactions. (Short process)</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_repair_zap1">
+       <property name="geometry">
+        <rect>
+         <x>260</x>
+         <y>170</y>
+         <width>700</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>-zapwallettxes=1: Delete all wallet transactions and recover them with a rescan. (Keeps metadata)</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label2_repair_zap1">
+       <property name="geometry">
+        <rect>
+         <x>260</x>
+         <y>190</y>
+         <width>700</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Use to recover balance when transactions fail to broadcast to the network.</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_repair_reindex">
+       <property name="geometry">
+        <rect>
+         <x>260</x>
+         <y>235</y>
+         <width>700</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>-reindex: Rebuild chain state and block index from the blk00*.dat files on disk. (Long process)</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label2_repair_reindex">
+       <property name="geometry">
+        <rect>
+         <x>260</x>
+         <y>255</y>
+         <width>700</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Use after importing private keys or restoring a wallet.dat backup.</string>
+       </property>
+      </widget>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1444,7 +1444,7 @@
         <rect>
          <x>20</x>
          <y>35</y>
-         <width>850</width>
+         <width>950</width>
          <height>41</height>
         </rect>
        </property>
@@ -1513,7 +1513,7 @@
       <widget class="QLabel" name="label_repair_rescan">
        <property name="geometry">
         <rect>
-         <x>260</x>
+         <x>265</x>
          <y>120</y>
          <width>700</width>
          <height>28</height>
@@ -1526,7 +1526,7 @@
       <widget class="QLabel" name="label_repair_zap1">
        <property name="geometry">
         <rect>
-         <x>260</x>
+         <x>265</x>
          <y>170</y>
          <width>700</width>
          <height>28</height>
@@ -1539,7 +1539,7 @@
       <widget class="QLabel" name="label2_repair_zap1">
        <property name="geometry">
         <rect>
-         <x>260</x>
+         <x>265</x>
          <y>190</y>
          <width>700</width>
          <height>28</height>
@@ -1552,7 +1552,7 @@
       <widget class="QLabel" name="label_repair_reindex">
        <property name="geometry">
         <rect>
-         <x>260</x>
+         <x>265</x>
          <y>235</y>
          <width>700</width>
          <height>28</height>
@@ -1565,7 +1565,7 @@
       <widget class="QLabel" name="label2_repair_reindex">
        <property name="geometry">
         <rect>
-         <x>260</x>
+         <x>265</x>
          <y>255</y>
          <width>700</width>
          <height>28</height>

--- a/src/qt/raven.cpp
+++ b/src/qt/raven.cpp
@@ -15,6 +15,7 @@
 #include "guiconstants.h"
 #include "guiutil.h"
 #include "intro.h"
+#include "net.h"
 #include "networkstyle.h"
 #include "optionsmodel.h"
 #include "platformstyle.h"
@@ -48,6 +49,7 @@
 #include <QLibraryInfo>
 #include <QLocale>
 #include <QMessageBox>
+#include <QProcess>
 #include <QSettings>
 #include <QThread>
 #include <QTimer>
@@ -190,10 +192,11 @@ public:
 public Q_SLOTS:
     void initialize();
     void shutdown();
+    void restart(QStringList args);
 
 Q_SIGNALS:
     void initializeResult(bool success);
-    void shutdownResult();
+    void shutdownResult(bool success);
     void runawayException(const QString &message);
 
 private:
@@ -240,12 +243,13 @@ public:
 
 public Q_SLOTS:
     void initializeResult(bool success);
-    void shutdownResult();
+    void shutdownResult(bool success);
     /// Handle runaway exceptions. Shows a message box with the problem and quits the program.
     void handleRunawayException(const QString &message);
 
 Q_SIGNALS:
     void requestedInitialize();
+    void requestedRestart(QStringList args);
     void requestedShutdown();
     void stopThread();
     void splashFinished(QWidget *window);
@@ -315,6 +319,33 @@ void RavenCore::initialize()
     }
 }
 
+void RavenCore::restart(QStringList args)
+{
+    static bool executing_restart{false};
+
+    if(!executing_restart) { // Only restart 1x, no matter how often a user clicks on a restart-button
+        executing_restart = true;
+        try
+        {
+            qDebug() << __func__ << ": Running Restart in thread";
+            Interrupt(threadGroup);
+            threadGroup.join_all();
+            StartRestart();
+            PrepareShutdown();
+            qDebug() << __func__ << ": Shutdown finished";
+            Q_EMIT shutdownResult(true);
+            CExplicitNetCleanup::callCleanup();
+            QProcess::startDetached(QApplication::applicationFilePath(), args);
+            qDebug() << __func__ << ": Restart initiated...";
+            QApplication::quit();
+        } catch (std::exception& e) {
+            handleRunawayException(&e);
+        } catch (...) {
+            handleRunawayException(nullptr);
+        }
+    }
+}
+
 void RavenCore::shutdown()
 {
     try
@@ -324,7 +355,7 @@ void RavenCore::shutdown()
         threadGroup.join_all();
         Shutdown();
         qDebug() << __func__ << ": Shutdown finished";
-        Q_EMIT shutdownResult();
+        Q_EMIT shutdownResult(true);
     } catch (const std::exception& e) {
         handleRunawayException(&e);
     } catch (...) {
@@ -423,10 +454,11 @@ void RavenApplication::startThread()
 
     /*  communication to and from thread */
     connect(executor, SIGNAL(initializeResult(bool)), this, SLOT(initializeResult(bool)));
-    connect(executor, SIGNAL(shutdownResult()), this, SLOT(shutdownResult()));
+    connect(executor, SIGNAL(shutdownResult(bool)), this, SLOT(shutdownResult(bool)));
     connect(executor, SIGNAL(runawayException(QString)), this, SLOT(handleRunawayException(QString)));
     connect(this, SIGNAL(requestedInitialize()), executor, SLOT(initialize()));
     connect(this, SIGNAL(requestedShutdown()), executor, SLOT(shutdown()));
+    connect(window, SIGNAL(requestedRestart(QStringList)), executor, SLOT(restart(QStringList)));
     /*  make sure executor object is deleted in its own thread */
     connect(this, SIGNAL(stopThread()), executor, SLOT(deleteLater()));
     connect(this, SIGNAL(stopThread()), coreThread, SLOT(quit()));
@@ -532,8 +564,10 @@ void RavenApplication::initializeResult(bool success)
     }
 }
 
-void RavenApplication::shutdownResult()
+void RavenApplication::shutdownResult(bool success)
 {
+    returnValue = success ? EXIT_SUCCESS : EXIT_FAILURE;
+    qDebug() << __func__ << ": Shutdown result: " << returnValue;
     quit(); // Exit main loop after shutdown finished
 }
 

--- a/src/qt/ravengui.h
+++ b/src/qt/ravengui.h
@@ -112,6 +112,7 @@ private:
     QAction *changePassphraseAction;
     QAction *aboutQtAction;
     QAction *openRPCConsoleAction;
+    QAction *openWalletRepairAction;
     QAction *openAction;
     QAction *showHelpMessageAction;
 
@@ -171,12 +172,16 @@ private:
 Q_SIGNALS:
     /** Signal raised when a URI was entered or dragged to the GUI */
     void receivedURI(const QString &uri);
+    /** Restart handling */
+    void requestedRestart(QStringList args);
 
 public Q_SLOTS:
     /** Set number of connections shown in the UI */
     void setNumConnections(int count);
     /** Set network state shown in the UI */
     void setNetworkActive(bool networkActive);
+    /** Get restart command-line parameters and request restart */
+    void handleRestart(QStringList args);
     /** Set number of blocks and last block date shown in the UI */
     void setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, bool headers);
 
@@ -248,6 +253,8 @@ private Q_SLOTS:
     void showDebugWindow();
     /** Show debug window and set focus to the console */
     void showDebugWindowActivateConsole();
+    /** Show debug window and set focus to the wallet repair tab */
+    void showWalletRepair();
     /** Show help message dialog */
     void showHelpMessageClicked();
 #ifndef Q_OS_MAC
@@ -265,7 +272,7 @@ private Q_SLOTS:
 
     /** Show progress dialog e.g. for verifychain */
     void showProgress(const QString &title, int nProgress);
-    
+
     /** When hideTrayIcon setting is changed in OptionsModel hide or show the icon accordingly. */
     void setTrayIconVisible(bool);
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -9,6 +9,7 @@
 
 #include "rpcconsole.h"
 #include "ui_debugwindow.h"
+#include "sendcoinsdialog.h"
 
 #include "bantablemodel.h"
 #include "clientmodel.h"
@@ -737,7 +738,19 @@ void RPCConsole::walletZaptxes1()
 /** Restart wallet with "-reindex" */
 void RPCConsole::walletReindex()
 {
-    buildParameterlist(REINDEX);
+  QString questionString = tr("Are you sure you want to reindex?");
+  questionString.append(QString("<br /><br />This process may take a few hours."));
+
+  SendConfirmationDialog confirmationDialog(tr("Confirm reindex"), questionString, 0, this);
+  confirmationDialog.exec();
+  QMessageBox::StandardButton retval = (QMessageBox::StandardButton)confirmationDialog.result();
+
+  if(retval != QMessageBox::Yes)
+  {
+      return;
+  }
+
+  buildParameterlist(REINDEX);
 }
 
 /** Build command-line parameter list for restart */

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -56,7 +56,8 @@ public:
         TAB_INFO = 0,
         TAB_CONSOLE = 1,
         TAB_GRAPH = 2,
-        TAB_PEERS = 3
+        TAB_PEERS = 3,
+        TAB_REPAIR = 4
     };
 
 protected:
@@ -89,6 +90,12 @@ public Q_SLOTS:
     void fontBigger();
     void fontSmaller();
     void setFontSize(int newSize);
+
+    /** Wallet repair options */
+    void walletRescan();
+    void walletZaptxes1();
+    void walletReindex();
+
     /** Append the message to the message widget */
     void message(int category, const QString &message, bool html = false);
     /** Set number of connections shown in the UI */
@@ -122,10 +129,14 @@ Q_SIGNALS:
     // For RPC command executor
     void stopExecutor();
     void cmdRequest(const QString &command);
+    /** Get restart command-line parameters and handle restart */
+    void handleRestart(QStringList args);
 
 private:
     void startExecutor();
     void setTrafficGraphRange(int mins);
+    /** Build parameter list for restart */
+    void buildParameterlist(QString arg);
     /** show detailed information on ui about selected node */
     void updateNodeDetail(const CNodeCombinedStats *stats);
 


### PR DESCRIPTION
This adds a Wallet Repair tab to the debug window. It also adds a Wallet Repair menu item to the Help menu. The general functionality was extracted from a similar implementation in Dash.

The repairs are accomplished by automatically restarting Raven Core with one of three options: rescan, zapwallettxes=1 or reindex.