### PR TITLE
Update version bit checking to not look for initialblock version

### DIFF
--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -198,7 +198,7 @@ protected:
 
     bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const override
     {
-        return (((pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS) && (pindex->nVersion & Mask(params)) != 0);
+        return ((pindex->nVersion & Mask(params)) != 0);
     }
 
 public:


### PR DESCRIPTION
In Ravencoin, we increment our block versions by 1 when a new RIP is activated.
This change broke versionbit checking because it was using VERSIONBITS_TOP_BITS for the initial block version. 
This change removes that initial check and just checks the bits in the version to see if they are voting yes or no. 
