### PR TITLE
Asset change support and smart type checking

### DIFF
--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -515,8 +515,8 @@ bool SendAssetTransaction(CWallet* pwallet, CWalletTx& transaction, CReserveKey&
 bool ParseAssetScript(CScript scriptPubKey, uint160 &hashBytes, std::string &assetName, CAmount &assetAmount);
 
 /** Helper method for extracting #TAGS from a verifier string */
-void ExtractVerifierStringQualifiers(const std::string& verifier, std::set<std::string>& qualifiers, bool fWithTag = true);
-bool CheckVerifierString(const std::string& verifier, std::set<std::string>& setFoundQualifiers, std::string& strError, bool fWithTags = false);
+void ExtractVerifierStringQualifiers(const std::string& verifier, std::set<std::string>& qualifiers);
+bool CheckVerifierString(const std::string& verifier, std::set<std::string>& setFoundQualifiers, std::string& strError);
 std::string GetStrippedVerifierString(const std::string& verifier);
 
 /** Helper methods that validate changes to null asset data transaction databases */
@@ -534,7 +534,7 @@ bool CheckReissueAsset(const CReissueAsset& asset, std::string& strError);
 bool ContextualCheckNullAssetTxOut(const CTxOut& txout, CAssetsCache* assetCache, std::string& strError);
 bool ContextualCheckGlobalAssetTxOut(const CTxOut& txout, CAssetsCache* assetCache, std::string& strError);
 bool ContextualCheckVerifierAssetTxOut(const CTxOut& txout, CAssetsCache* assetCache, std::string& strError);
-bool ContextualCheckVerifierString(CAssetsCache* cache, const std::string& verifier, const std::string& check_address, std::string& strError, bool fWithTags = false);
+bool ContextualCheckVerifierString(CAssetsCache* cache, const std::string& verifier, const std::string& check_address, std::string& strError);
 bool ContextualCheckNewAsset(CAssetsCache* assetCache, const CNewAsset& asset, std::string& strError, bool fCheckMempool = false);
 bool ContextualCheckTransferAsset(CAssetsCache* assetCache, const CAssetTransfer& transfer, const std::string& address, std::string& strError);
 bool ContextualCheckReissueAsset(CAssetsCache* assetCache, const CReissueAsset& reissue_asset, std::string& strError, const CTransaction& tx);

--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -1100,9 +1100,9 @@ UniValue listaddressesbyasset(const JSONRPCRequest &request)
 
 UniValue transfer(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !AreAssetsDeployed() || request.params.size() < 3 || request.params.size() > 6)
+    if (request.fHelp || !AreAssetsDeployed() || request.params.size() < 3 || request.params.size() > 7)
         throw std::runtime_error(
-                "transfer \"asset_name\" qty \"to_address\" \"message\" expire_time \"change_address\"\n"
+                "transfer \"asset_name\" qty \"to_address\" \"message\" expire_time \"change_address\" \"asset_change_address\"\n"
                 + AssetActivationWarning() +
                 "\nTransfers a quantity of an owned asset to a given address"
 
@@ -1112,7 +1112,8 @@ UniValue transfer(const JSONRPCRequest& request)
                 "3. \"to_address\"               (string, required) address to send the asset to\n"
                 "4. \"message\"                  (string, optional) Once RIP5 is voted in ipfs hash or txid hash to send along with the transfer\n"
                 "5. \"expire_time\"              (numeric, optional) UTC timestamp of when the message expires\n"
-                "6. \"change_address\"           (string, optional, default = \"\") the transaction change will be sent to this address\n"
+                "6. \"change_address\"       (string, optional, default = \"\") the transactions RVN change will be sent to this address\n"
+                "7. \"asset_change_address\"     (string, optional, default = \"\") the transactions Asset change will be sent to this address\n"
 
                 "\nResult:\n"
                 "txid"
@@ -1172,17 +1173,23 @@ UniValue transfer(const JSONRPCRequest& request)
     if (fMessageCheck)
         CheckIPFSTxidMessage(message, expireTime);
 
-    std::string change_address = "";
-    if(request.params.size() > 5) {
-        change_address = request.params[5].get_str();
-
-        if (!change_address.empty()) {
-            CTxDestination change_dest = DecodeDestination(change_address);
-            if (!IsValidDestination(change_dest)) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid Raven address: ") + change_address);
-            }
-        }
+    std::string rvn_change_address = "";
+    if (request.params.size() > 6) {
+        rvn_change_address = request.params[6].get_str();
     }
+
+    std::string asset_change_address = "";
+    if (request.params.size() > 7) {
+        asset_change_address = request.params[7].get_str();
+    }
+
+    CTxDestination rvn_change_dest = DecodeDestination(rvn_change_address);
+    if (!rvn_change_address.empty() && !IsValidDestination(rvn_change_dest))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("RVN change address must be a valid address. Invalid address: ") + rvn_change_address);
+
+    CTxDestination asset_change_dest = DecodeDestination(asset_change_address);
+    if (!asset_change_address.empty() && !IsValidDestination(asset_change_dest))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Asset change address must be a valid address. Invalid address: ") + asset_change_address);
 
     std::pair<int, std::string> error;
     std::vector< std::pair<CAssetTransfer, std::string> >vTransfers;
@@ -1195,7 +1202,8 @@ UniValue transfer(const JSONRPCRequest& request)
     CAmount nRequiredFee;
 
     CCoinControl ctrl;
-    ctrl.destChange = DecodeDestination(change_address);
+    ctrl.destChange = rvn_change_dest;
+    ctrl.assetDestChange = asset_change_dest;
 
     // Create the Transaction
     if (!CreateTransferAssetTransaction(pwallet, ctrl, vTransfers, "", error, transaction, reservekey, nRequiredFee))
@@ -1217,9 +1225,9 @@ UniValue transfer(const JSONRPCRequest& request)
 
 UniValue transferfromaddresses(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !AreAssetsDeployed() || request.params.size() < 4 || request.params.size() > 6)
+    if (request.fHelp || !AreAssetsDeployed() || request.params.size() < 4 || request.params.size() > 8)
         throw std::runtime_error(
-            "transferfromaddresses \"asset_name\" [\"from_addresses\"] qty \"to_address\" \"message\" expire_time\n"
+            "transferfromaddresses \"asset_name\" [\"from_addresses\"] qty \"to_address\" \"message\" expire_time \"rvn_change_address\" \"asset_change_address\"\n"
             + AssetActivationWarning() +
             "\nTransfer a quantity of an owned asset in specific address(es) to a given address"
 
@@ -1230,6 +1238,8 @@ UniValue transferfromaddresses(const JSONRPCRequest& request)
             "4. \"to_address\"               (string, required) address to send the asset to\n"
             "5. \"message\"                  (string, optional) Once RIP5 is voted in ipfs hash or txid hash to send along with the transfer\n"
             "6. \"expire_time\"              (numeric, optional) UTC timestamp of when the message expires\n"
+            "7. \"rvn_change_address\"       (string, optional, default = \"\") the transactions RVN change will be sent to this address\n"
+            "8. \"asset_change_address\"     (string, optional, default = \"\") the transactions Asset change will be sent to this address\n"
 
             "\nResult:\n"
             "txid"
@@ -1279,8 +1289,9 @@ UniValue transferfromaddresses(const JSONRPCRequest& request)
     bool fMessageCheck = false;
     std::string message = "";
     if (request.params.size() > 4) {
-        fMessageCheck = true;
         message = request.params[4].get_str();
+        if (!message.empty())
+            fMessageCheck = true;
     }
 
     int64_t expireTime = 0;
@@ -1293,6 +1304,24 @@ UniValue transferfromaddresses(const JSONRPCRequest& request)
     if (fMessageCheck)
         CheckIPFSTxidMessage(message, expireTime);
 
+    std::string rvn_change_address = "";
+    if (request.params.size() > 6) {
+        rvn_change_address = request.params[6].get_str();
+    }
+
+    std::string asset_change_address = "";
+    if (request.params.size() > 7) {
+        asset_change_address = request.params[7].get_str();
+    }
+
+    CTxDestination rvn_change_dest = DecodeDestination(rvn_change_address);
+    if (!rvn_change_address.empty() && !IsValidDestination(rvn_change_dest))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("RVN change address must be a valid address. Invalid address: ") + rvn_change_address);
+
+    CTxDestination asset_change_dest = DecodeDestination(asset_change_address);
+    if (!asset_change_address.empty() && !IsValidDestination(asset_change_dest))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Asset change address must be a valid address. Invalid address: ") + asset_change_address);
+
     std::pair<int, std::string> error;
     std::vector< std::pair<CAssetTransfer, std::string> >vTransfers;
 
@@ -1304,6 +1333,10 @@ UniValue transferfromaddresses(const JSONRPCRequest& request)
     CCoinControl ctrl;
     std::map<std::string, std::vector<COutput> > mapAssetCoins;
     pwallet->AvailableAssets(mapAssetCoins);
+
+    // Set the change addresses
+    ctrl.destChange = rvn_change_dest;
+    ctrl.assetDestChange = asset_change_dest;
 
     if (!mapAssetCoins.count(asset_name)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Wallet doesn't own the asset_name: " + asset_name));
@@ -1345,9 +1378,9 @@ UniValue transferfromaddresses(const JSONRPCRequest& request)
 
 UniValue transferfromaddress(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !AreAssetsDeployed() || request.params.size() < 4 || request.params.size() > 6)
+    if (request.fHelp || !AreAssetsDeployed() || request.params.size() < 4 || request.params.size() > 8)
         throw std::runtime_error(
-                "transferfromaddress \"asset_name\" \"from_address\" qty \"to_address\" \"message\" expire_time\n"
+                "transferfromaddress \"asset_name\" \"from_address\" qty \"to_address\" \"message\" expire_time \"rvn_change_address\" \"asset_change_address\"\n"
                 + AssetActivationWarning() +
                 "\nTransfer a quantity of an owned asset in a specific address to a given address"
 
@@ -1358,6 +1391,8 @@ UniValue transferfromaddress(const JSONRPCRequest& request)
                 "4. \"to_address\"               (string, required) address to send the asset to\n"
                 "5. \"message\"                  (string, optional) Once RIP5 is voted in ipfs hash or txid hash to send along with the transfer\n"
                 "6. \"expire_time\"              (numeric, optional) UTC timestamp of when the message expires\n"
+                "7. \"rvn_change_address\"       (string, optional, default = \"\") the transaction RVN change will be sent to this address\n"
+                "8. \"asset_change_address\"     (string, optional, default = \"\") the transaction Asset change will be sent to this address\n"
 
                 "\nResult:\n"
                 "txid"
@@ -1397,8 +1432,10 @@ UniValue transferfromaddress(const JSONRPCRequest& request)
     bool fMessageCheck = false;
     std::string message = "";
     if (request.params.size() > 4) {
-        fMessageCheck = true;
+
         message = request.params[4].get_str();
+        if (!message.empty())
+            fMessageCheck = true;
     }
 
     int64_t expireTime = 0;
@@ -1411,6 +1448,25 @@ UniValue transferfromaddress(const JSONRPCRequest& request)
     if (fMessageCheck)
         CheckIPFSTxidMessage(message, expireTime);
 
+    std::string rvn_change_address = "";
+    if (request.params.size() > 6) {
+        rvn_change_address = request.params[6].get_str();
+    }
+
+    std::string asset_change_address = "";
+    if (request.params.size() > 7) {
+        asset_change_address = request.params[7].get_str();
+    }
+
+    CTxDestination rvn_change_dest = DecodeDestination(rvn_change_address);
+    if (!rvn_change_address.empty() && !IsValidDestination(rvn_change_dest))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("RVN change address must be a valid address. Invalid address: ") + rvn_change_address);
+
+    CTxDestination asset_change_dest = DecodeDestination(asset_change_address);
+    if (!asset_change_address.empty() && !IsValidDestination(asset_change_dest))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Asset change address must be a valid address. Invalid address: ") + asset_change_address);
+
+
     std::pair<int, std::string> error;
     std::vector< std::pair<CAssetTransfer, std::string> >vTransfers;
 
@@ -1422,6 +1478,10 @@ UniValue transferfromaddress(const JSONRPCRequest& request)
     CCoinControl ctrl;
     std::map<std::string, std::vector<COutput> > mapAssetCoins;
     pwallet->AvailableAssets(mapAssetCoins);
+
+    // Set the change addresses
+    ctrl.destChange = rvn_change_dest;
+    ctrl.assetDestChange = asset_change_dest;
 
     if (!mapAssetCoins.count(asset_name)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Wallet doesn't own the asset_name: " + asset_name));
@@ -2643,9 +2703,9 @@ static const CRPCCommand commands[] =
     { "assets",   "getassetdata",               &getassetdata,               {"asset_name"}},
     { "assets",   "listmyassets",               &listmyassets,               {"asset", "verbose", "count", "start", "confs"}},
     { "assets",   "listaddressesbyasset",       &listaddressesbyasset,       {"asset_name", "onlytotal", "count", "start"}},
-    { "assets",   "transferfromaddress",        &transferfromaddress,        {"asset_name", "from_address" "qty", "to_address", "message", "expire_time"}},
-    { "assets",   "transferfromaddresses",      &transferfromaddresses,      {"asset_name", "from_addresses" "qty", "to_address", "message", "expire_time"}},
-    { "assets",   "transfer",                   &transfer,                   {"asset_name", "qty", "to_address", "message", "expire_time", "change_address"}},
+    { "assets",   "transferfromaddress",        &transferfromaddress,        {"asset_name", "from_address", "qty", "to_address", "message", "expire_time", "rvn_change_address", "asset_change_address"}},
+    { "assets",   "transferfromaddresses",      &transferfromaddresses,      {"asset_name", "from_addresses", "qty", "to_address", "message", "expire_time", "rvn_change_address", "asset_change_address"}},
+    { "assets",   "transfer",                   &transfer,                   {"asset_name", "qty", "to_address", "message", "expire_time", "change_address", "asset_change_address"}},
     { "assets",   "reissue",                    &reissue,                    {"asset_name", "qty", "to_address", "change_address", "reissuable", "new_unit", "new_ipfs"}},
     { "assets",   "listassets",                 &listassets,                 {"asset", "verbose", "count", "start"}},
     { "assets",   "getcacheinfo",               &getcacheinfo,               {}},

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -37,6 +37,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "issuerestrictedasset", 5, "units" },
     { "issuerestrictedasset", 6, "reissuable" },
     { "issuerestrictedasset", 7, "has_ipfs" },
+    { "issuequalifierasset", 1,  "qty"},
+    { "issuequalifierasset", 4, "has_ipfs" },
     { "reissuerestrictedasset", 1, "qty" },
     { "reissuerestrictedasset", 3, "change_verifier" },
     { "reissuerestrictedasset", 6, "new_unit" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -947,7 +947,7 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
 
                     // Check the restricted asset destination address, and make sure it validates with the verifier string
                     std::string strError = "";
-                    if (!ContextualCheckVerifierString(currentActiveAssetCache, strippedVerifierString, EncodeDestination(destination), strError, false))
+                    if (!ContextualCheckVerifierString(currentActiveAssetCache, strippedVerifierString, EncodeDestination(destination), strError))
                         throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parmeter, verifier string is not. Please check the syntax. Error Msg - " + strError));
 
 

--- a/src/test/assets/asset_tests.cpp
+++ b/src/test/assets/asset_tests.cpp
@@ -352,7 +352,8 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
         std::string valid_verifier_syntax = "((#KYC & !#ABC) | #DEF & #GHI & #RET) | (#TEST)";
 
         std::set<std::string> setQualifiers;
-        ExtractVerifierStringQualifiers(valid_verifier_syntax, setQualifiers);
+        std::string stripped_valid_verifier_syntax  = GetStrippedVerifierString(valid_verifier_syntax);
+        ExtractVerifierStringQualifiers(stripped_valid_verifier_syntax, setQualifiers);
 
         vals.clear();
 
@@ -360,7 +361,7 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
             vals.insert(make_pair(item, true));
         }
 
-        BOOST_CHECK(LibBoolEE::resolve(valid_verifier_syntax, vals));
+        BOOST_CHECK(LibBoolEE::resolve(stripped_valid_verifier_syntax, vals));
 
         // Clear the vals, and insert them with false, this should make the resolve return false
         vals.clear();
@@ -368,103 +369,116 @@ BOOST_FIXTURE_TEST_SUITE(asset_tests, BasicTestingSetup)
             vals.insert(make_pair(item, false));
         }
 
-        BOOST_CHECK(!LibBoolEE::resolve(valid_verifier_syntax, vals));
+        BOOST_CHECK(!LibBoolEE::resolve(stripped_valid_verifier_syntax, vals));
 
         vals.clear();
         setQualifiers.clear();
 
         //! Check for invalid syntax #DEF#XXX won't work
-        std::string not_valid_qualifier = "((#KYC & !#ABC) | #DEF#XXX & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_qualifier, setQualifiers);
+        std::string not_valid_qualifier = "((#KYC & !#ABC) | #DEF$XXX & #GHI & #RET)";
+        std::string stripped_not_valid_qualifier  = GetStrippedVerifierString(not_valid_qualifier);
+        ExtractVerifierStringQualifiers(stripped_not_valid_qualifier, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
 
-        BOOST_CHECK_THROW(LibBoolEE::resolve(not_valid_qualifier, vals), std::runtime_error);
+        BOOST_CHECK_THROW(LibBoolEE::resolve(stripped_not_valid_qualifier, vals), std::runtime_error);
 
         vals.clear();
         setQualifiers.clear();
 
         //! Check for invalid syntax, missing a parenthesis '(' at the beginning
         std::string not_valid_missing_parenthesis = "(#KYC & !#ABC) | #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_missing_parenthesis, setQualifiers);
+        std::string stripped_not_valid_missing_parenthesis  = GetStrippedVerifierString(not_valid_missing_parenthesis);
+        ExtractVerifierStringQualifiers(stripped_not_valid_missing_parenthesis, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
 
-        BOOST_CHECK_THROW(LibBoolEE::resolve(not_valid_missing_parenthesis, vals), std::runtime_error);
+        BOOST_CHECK_THROW(LibBoolEE::resolve(stripped_not_valid_missing_parenthesis, vals), std::runtime_error);
 
         vals.clear();
         setQualifiers.clear();
 
         //! Check for invalid syntax, has two & in a row
         std::string not_valid_double_and = "((#KYC && !#ABC) | #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_double_and, setQualifiers);
+        std::string stripped_not_valid_double_and = GetStrippedVerifierString(not_valid_double_and);
+        ExtractVerifierStringQualifiers(stripped_not_valid_double_and, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
 
-        BOOST_CHECK_THROW(LibBoolEE::resolve(not_valid_double_and, vals), std::runtime_error);
+        BOOST_CHECK_THROW(LibBoolEE::resolve(stripped_not_valid_double_and, vals), std::runtime_error);
 
         vals.clear();
         setQualifiers.clear();
 
         //! Check for invalid syntax, has two | in a row
         std::string not_valid_double_or = "((#KYC & !#ABC) || #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_double_or, setQualifiers);
+        std::string stripped_not_valid_double_or = GetStrippedVerifierString(not_valid_double_or);
+        ExtractVerifierStringQualifiers(stripped_not_valid_double_or, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
 
-        BOOST_CHECK_THROW(LibBoolEE::resolve(not_valid_double_or, vals), std::runtime_error);
+        BOOST_CHECK_THROW(LibBoolEE::resolve(stripped_not_valid_double_or, vals), std::runtime_error);
 
         vals.clear();
         setQualifiers.clear();
 
         //! Check for invalid syntax, has & | without a qualifier inbetween
         std::string not_valid_missing_qualifier = "((#KYC & | !#ABC) | #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_missing_qualifier, setQualifiers);
+        std::string stripped_not_valid_missing_qualifier = GetStrippedVerifierString(not_valid_missing_qualifier);
+        ExtractVerifierStringQualifiers(stripped_not_valid_missing_qualifier, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
 
-        BOOST_CHECK_THROW(LibBoolEE::resolve(not_valid_missing_qualifier, vals), std::runtime_error);
+        BOOST_CHECK_THROW(LibBoolEE::resolve(stripped_not_valid_missing_qualifier, vals), std::runtime_error);
 
         vals.clear();
         setQualifiers.clear();
 
         //! Check for invalid syntax, has () without qualifier inside them
         std::string not_valid_open_close = "()((#KYC & !#ABC) | #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_open_close, setQualifiers);
+
+        std::string stripped_not_valid_open_close = GetStrippedVerifierString(not_valid_open_close);
+        ExtractVerifierStringQualifiers(stripped_not_valid_open_close, setQualifiers);
+
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
 
-        BOOST_CHECK_THROW(LibBoolEE::resolve(not_valid_open_close, vals), std::runtime_error);
+        BOOST_CHECK_THROW(LibBoolEE::resolve(stripped_not_valid_open_close, vals), std::runtime_error);
 
         vals.clear();
         setQualifiers.clear();
 
         //! Check for invalid syntax, has (#YES) followed by no comparator
         std::string not_valid_open_close_no_comparator = "((#KYC & !#ABC) | (#YES) #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_open_close_no_comparator, setQualifiers);
+        std::string stripped_not_valid_open_close_no_comparator = GetStrippedVerifierString(not_valid_open_close_no_comparator);
+        ExtractVerifierStringQualifiers(stripped_not_valid_open_close_no_comparator, setQualifiers);
+
+        ExtractVerifierStringQualifiers(stripped_not_valid_open_close_no_comparator, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
 
-        BOOST_CHECK_THROW(LibBoolEE::resolve(not_valid_open_close_no_comparator, vals), std::runtime_error);
+        BOOST_CHECK_THROW(LibBoolEE::resolve(stripped_not_valid_open_close_no_comparator, vals), std::runtime_error);
 
         vals.clear();
         setQualifiers.clear();
 
         //! Check for invalid syntax, could return true on the #KYC, but is missing a ending parenthesis
         std::string bad_syntax_after_true_statement = "((#KYC) | #GHI";
-        ExtractVerifierStringQualifiers(bad_syntax_after_true_statement, setQualifiers);
+
+        std::string stripped_bad_syntax_after_true_statement = GetStrippedVerifierString(bad_syntax_after_true_statement);
+        ExtractVerifierStringQualifiers(stripped_bad_syntax_after_true_statement, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
 
-        BOOST_CHECK_THROW(LibBoolEE::resolve(bad_syntax_after_true_statement, vals), std::runtime_error);
+        BOOST_CHECK_THROW(LibBoolEE::resolve(stripped_bad_syntax_after_true_statement, vals), std::runtime_error);
     }
 
     BOOST_AUTO_TEST_CASE(asset_valid_check_tests)

--- a/src/test/assets/verifier_string_tests.cpp
+++ b/src/test/assets/verifier_string_tests.cpp
@@ -14,7 +14,8 @@
 
 #include "LibBoolEE.h"
 
-BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(
+        , BasicTestingSetup)
 
     BOOST_AUTO_TEST_CASE(boolean_expression_evaluator_test)
     {
@@ -28,8 +29,10 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
         //! Check for valid syntax
         std::string valid_verifier_syntax = "((#KYC & !#ABC) | #DEF & #GHI & #RET) | (#TEST)";
 
+        std::string stripped_valid_verifier_syntax = GetStrippedVerifierString(valid_verifier_syntax);
+
         std::set<std::string> setQualifiers;
-        ExtractVerifierStringQualifiers(valid_verifier_syntax, setQualifiers);
+        ExtractVerifierStringQualifiers(stripped_valid_verifier_syntax, setQualifiers);
 
         vals.clear();
 
@@ -37,7 +40,7 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
             vals.insert(make_pair(item, true));
         }
 
-        BOOST_CHECK(LibBoolEE::resolve(valid_verifier_syntax, vals));
+        BOOST_CHECK(LibBoolEE::resolve(stripped_valid_verifier_syntax, vals));
 
         // Clear the vals, and insert them with false, this should make the resolve return false
         vals.clear();
@@ -45,14 +48,15 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
             vals.insert(make_pair(item, false));
         }
 
-        BOOST_CHECK(!LibBoolEE::resolve(valid_verifier_syntax, vals));
+        BOOST_CHECK(!LibBoolEE::resolve(stripped_valid_verifier_syntax, vals));
 
         vals.clear();
         setQualifiers.clear();
 
         //! Check for invalid syntax #DEF#XXX won't work
-        std::string not_valid_qualifier = "((#KYC & !#ABC) | #DEF#XXX & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_qualifier, setQualifiers);
+        std::string not_valid_qualifier = "((#KYC & !#ABC) | #DEF#XXX~ & #GHI & #RET)";
+        std::string stripped_not_valid_qualifier = GetStrippedVerifierString(not_valid_qualifier);
+        ExtractVerifierStringQualifiers(stripped_not_valid_qualifier, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
@@ -64,19 +68,23 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
 
         //! Check for invalid syntax, missing a parenthesis '(' at the beginning
         std::string not_valid_missing_parenthesis = "(#KYC & !#ABC) | #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_missing_parenthesis, setQualifiers);
+
+        std::string stripped_not_valid_missing_parenthesis = GetStrippedVerifierString(not_valid_missing_parenthesis);
+        ExtractVerifierStringQualifiers(stripped_not_valid_missing_parenthesis, setQualifiers);
+
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
 
-        BOOST_CHECK_THROW(LibBoolEE::resolve(not_valid_missing_parenthesis, vals), std::runtime_error);
+        BOOST_CHECK_THROW(LibBoolEE::resolve(stripped_not_valid_missing_parenthesis, vals), std::runtime_error);
 
         vals.clear();
         setQualifiers.clear();
 
         //! Check for invalid syntax, has two & in a row
         std::string not_valid_double_and = "((#KYC && !#ABC) | #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_double_and, setQualifiers);
+        std::string stripped_not_valid_double_and = GetStrippedVerifierString(not_valid_double_and);
+        ExtractVerifierStringQualifiers(stripped_not_valid_double_and, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
@@ -88,7 +96,8 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
 
         //! Check for invalid syntax, has two | in a row
         std::string not_valid_double_or = "((#KYC & !#ABC) || #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_double_or, setQualifiers);
+        std::string stripped_not_valid_double_or = GetStrippedVerifierString(not_valid_double_or);
+        ExtractVerifierStringQualifiers(stripped_not_valid_double_or, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
@@ -100,7 +109,8 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
 
         //! Check for invalid syntax, has & | without a qualifier inbetween
         std::string not_valid_missing_qualifier = "((#KYC & | !#ABC) | #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_missing_qualifier, setQualifiers);
+        std::string stripped_not_valid_missing_qualifier = GetStrippedVerifierString(not_valid_missing_qualifier);
+        ExtractVerifierStringQualifiers(stripped_not_valid_missing_qualifier, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
@@ -112,7 +122,8 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
 
         //! Check for invalid syntax, has () without qualifier inside them
         std::string not_valid_open_close = "()((#KYC & !#ABC) | #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_open_close, setQualifiers);
+        std::string stripped_not_valid_open_close = GetStrippedVerifierString(not_valid_open_close);
+        ExtractVerifierStringQualifiers(stripped_not_valid_open_close, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
@@ -124,7 +135,8 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
 
         //! Check for invalid syntax, has (#YES) followed by no comparator
         std::string not_valid_open_close_no_comparator = "((#KYC & !#ABC) | (#YES) #DEF & #GHI & #RET)";
-        ExtractVerifierStringQualifiers(not_valid_open_close_no_comparator, setQualifiers);
+        std::string stripped_not_valid_open_close_no_comparator = GetStrippedVerifierString(not_valid_open_close_no_comparator);
+        ExtractVerifierStringQualifiers(stripped_not_valid_open_close_no_comparator, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
@@ -136,7 +148,8 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
 
         //! Check for invalid syntax, could return true on the #KYC, but is missing a ending parenthesis
         std::string bad_syntax_after_true_statement = "((#KYC) | #GHI";
-        ExtractVerifierStringQualifiers(bad_syntax_after_true_statement, setQualifiers);
+        std::string stripped_bad_syntax_after_true_statement = GetStrippedVerifierString(bad_syntax_after_true_statement);
+        ExtractVerifierStringQualifiers(stripped_bad_syntax_after_true_statement, setQualifiers);
         for (auto item : setQualifiers) {
             vals.insert(make_pair(item, true));
         }
@@ -193,91 +206,91 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
         /// Check invalid verifier strings ///
         {
             std::string invalid_verifier = "";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, false), "Invalid Verifier String Test 1 didn't fail - " + invalid_verifier);
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 1 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "(#KYC";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 2 didn't fail - " + invalid_verifier);
+            invalid_verifier = "(KYC";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 2 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "(#KYC)(";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 3 didn't fail - " + invalid_verifier);
+            invalid_verifier = "(KYC)(";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 3 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "(#KYC)(&";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 4 didn't fail - " + invalid_verifier);
+            invalid_verifier = "(KYC)(&";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 4 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "(#KYC)(|";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 5 didn't fail - " + invalid_verifier);
+            invalid_verifier = "(KYC)(|";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 5 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "(#KYC)(|)";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 6 didn't fail - " + invalid_verifier);
+            invalid_verifier = "(KYC)(|)";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 6 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "(#KYC)(&)";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 7 didn't fail - " + invalid_verifier);
+            invalid_verifier = "(KYC)(&)";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 7 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "(#KYC)()";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 8 didn't fail - " + invalid_verifier);
+            invalid_verifier = "(KYC)()";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 8 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "#KYC)";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 9 didn't fail - " + invalid_verifier);
+            invalid_verifier = "KYC)";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 9 didn't fail - " + invalid_verifier);
 
             invalid_verifier = "$KYC";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 10 didn't fail - " + invalid_verifier);
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 10 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "#KYC/SUB";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 11 didn't fail - " + invalid_verifier);
+            invalid_verifier = "KYC/SUB";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 11 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "#KYC#UNIQUE";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 12 didn't fail - " + invalid_verifier);
+            invalid_verifier = "KYC$UNIQUE";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 12 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "#KYC~MSGCHANNEL";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 13 didn't fail - " + invalid_verifier);
+            invalid_verifier = "KYC~MSGCHANNEL";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 13 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "#KYC._";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 14 didn't fail - " + invalid_verifier);
+            invalid_verifier = "KYC._";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 14 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "#KYC.|";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 15 didn't fail - " + invalid_verifier);
+            invalid_verifier = "KYC.|";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 15 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "#KYC &";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 16 didn't fail - " + invalid_verifier);
+            invalid_verifier = "KYC &";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 16 didn't fail - " + invalid_verifier);
 
             invalid_verifier = "&";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 17 didn't fail - " + invalid_verifier);
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 17 didn't fail - " + invalid_verifier);
 
             invalid_verifier = "(!)";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 18 didn't fail - " + invalid_verifier);
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 18 didn't fail - " + invalid_verifier);
 
             invalid_verifier = "KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC81";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 19 didn't fail - " + invalid_verifier);
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 19 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "(#KYC && #TEST)";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 20 didn't fail - " + invalid_verifier);
+            invalid_verifier = "(KYC && TEST)";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 20 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "(#KYC || #TEST)";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 21 didn't fail - " + invalid_verifier);
+            invalid_verifier = "(KYC || TEST)";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 21 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "(#KYC |& #TEST)";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 22 didn't fail - " + invalid_verifier);
+            invalid_verifier = "(KYC |& TEST)";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 22 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "(#KYC &| #TEST)";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 23 didn't fail - " + invalid_verifier);
+            invalid_verifier = "(KYC &| TEST)";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 23 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "#KYC & | #TEST";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 24 didn't fail - " + invalid_verifier);
+            invalid_verifier = "KYC & | TEST";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 24 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "#KYC () #TEST";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 25 didn't fail - " + invalid_verifier);
+            invalid_verifier = "KYC () TEST";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 25 didn't fail - " + invalid_verifier);
 
-            invalid_verifier = "#KYC ( ) #TEST";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 26 didn't fail - " + invalid_verifier);
+            invalid_verifier = "KYC ( ) TEST";
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 26 didn't fail - " + invalid_verifier);
 
             invalid_verifier = "(true)";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 27 didn't fail - " + invalid_verifier);
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 27 didn't fail - " + invalid_verifier);
 
             invalid_verifier = "!@#$%^&*()";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 28 didn't fail - " + invalid_verifier);
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 28 didn't fail - " + invalid_verifier);
 
             invalid_verifier = "()";
-            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error, true), "Invalid Verifier String Test 29 didn't fail - " + invalid_verifier);
+            BOOST_CHECK_MESSAGE(!CheckVerifierString(invalid_verifier, setFoundQualifiers, error), "Invalid Verifier String Test 29 didn't fail - " + invalid_verifier);
 
         }
 
@@ -289,40 +302,40 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
             BOOST_CHECK_MESSAGE(setFoundQualifiers.empty(), "Qualifier set was not empty");
 
             setFoundQualifiers.clear();
-            verifier = "(#KYC & !#TEST & #YMC) | (#TAG & #SKIP)";
-            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error, true), "Verifier String Test 1 failed - " + verifier + " - " + error);
+            verifier = "(KYC & !TEST & YMC) | (TAG & SKIP)";
+            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error), "Verifier String Test 1 failed - " + verifier + " - " + error);
             BOOST_CHECK(setFoundQualifiers.size() == 5);
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#KYC"), "TEST 1 set didn't have #KYC");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#TEST"), "TEST 1 set didn't have #TEST");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#YMC"), "TEST 1 set didn't have #YMC");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#TAG"), "TEST 1 set didn't have #TAG");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#SKIP"), "TEST 1 set didn't have #SKIP");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("KYC"), "TEST 1 set didn't have #KYC");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("TEST"), "TEST 1 set didn't have #TEST");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("YMC"), "TEST 1 set didn't have #YMC");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("TAG"), "TEST 1 set didn't have #TAG");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("SKIP"), "TEST 1 set didn't have #SKIP");
 
             setFoundQualifiers.clear();
-            verifier = "#KYC & !#TEST & #YMC | #TAG & #SKIP";
-            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error, true), "Verifier String Test 2 failed - " + verifier + " - " + error);
+            verifier = "KYC & !TEST & YMC | TAG & SKIP";
+            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error), "Verifier String Test 2 failed - " + verifier + " - " + error);
             BOOST_CHECK(setFoundQualifiers.size() == 5);
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#KYC"), "TEST 2 set didn't have #KYC");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#TEST"), "TEST 2 set didn't have #TEST");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#YMC"), "TEST 2 set didn't have #YMC");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#TAG"), "TEST 2 set didn't have #TAG");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#SKIP"), "TEST 2 set didn't have #SKIP");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("KYC"), "TEST 2 set didn't have #KYC");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("TEST"), "TEST 2 set didn't have #TEST");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("YMC"), "TEST 2 set didn't have #YMC");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("TAG"), "TEST 2 set didn't have #TAG");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("SKIP"), "TEST 2 set didn't have #SKIP");
 
             setFoundQualifiers.clear();
-            verifier = "(#KYC & !#TEST & #YMC | #TAG & #SKIP) | (#TAG & #KYC & #TEST)";
-            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error, true), "Verifier String Test 3 failed - " + verifier + " - " + error);
+            verifier = "(KYC & !TEST & YMC | TAG & SKIP) | (TAG & KYC & TEST)";
+            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error), "Verifier String Test 3 failed - " + verifier + " - " + error);
             BOOST_CHECK(setFoundQualifiers.size() == 5);
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#KYC"), "TEST 3 set didn't have #KYC");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#TEST"), "TEST 3 set didn't have #TEST");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#YMC"), "TEST 3 set didn't have #YMC");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#TAG"), "TEST 3 set didn't have #TAG");
-            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("#SKIP"), "TEST 3 set didn't have #SKIP");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("KYC"), "TEST 3 set didn't have #KYC");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("TEST"), "TEST 3 set didn't have #TEST");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("YMC"), "TEST 3 set didn't have #YMC");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("TAG"), "TEST 3 set didn't have #TAG");
+            BOOST_CHECK_MESSAGE(setFoundQualifiers.count("SKIP"), "TEST 3 set didn't have #SKIP");
 
 
 
             setFoundQualifiers.clear();
             verifier = "(KYC&!TEST&YMC|TAG&SKIP)|(TAG&KYC&TEST)";
-            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error, false), "Verifier String Test 4 failed - " + verifier + " - " + error);
+            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error), "Verifier String Test 4 failed - " + verifier + " - " + error);
             BOOST_CHECK(setFoundQualifiers.size() == 5);
             BOOST_CHECK_MESSAGE(setFoundQualifiers.count("KYC"), "TEST 4 set didn't have #KYC");
             BOOST_CHECK_MESSAGE(setFoundQualifiers.count("TEST"), "TEST 4 set didn't have #TEST");
@@ -334,7 +347,7 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
             // 80 character limit on stripped strings
             setFoundQualifiers.clear();
             verifier = "KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KYC&KY80";
-            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error, false), "Verifier String Test 5 failed - " + verifier + " - " + error);
+            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error), "Verifier String Test 5 failed - " + verifier + " - " + error);
             BOOST_CHECK(setFoundQualifiers.size() == 2);
             BOOST_CHECK_MESSAGE(setFoundQualifiers.count("KYC"), "TEST 5 set didn't have #KYC");
             BOOST_CHECK_MESSAGE(setFoundQualifiers.count("KY80"), "TEST 5 set didn't have #KY80");
@@ -342,13 +355,13 @@ BOOST_FIXTURE_TEST_SUITE(verifier_string_tests, BasicTestingSetup)
 
             setFoundQualifiers.clear();
             verifier = "((((((((((((((((((((((((((((((((((((TTT))))))))))))))))))))))))))))))))))))";
-            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error, false), "Verifier String Test 6 failed - " + verifier + " - " + error);
+            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error), "Verifier String Test 6 failed - " + verifier + " - " + error);
             BOOST_CHECK(setFoundQualifiers.size() == 1);
             BOOST_CHECK_MESSAGE(setFoundQualifiers.count("TTT"), "TEST 6 set didn't have #TTT");
 
             setFoundQualifiers.clear();
             verifier = "TEST&!TEST";
-            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error, false), "Verifier String Test 7 failed - " + verifier + " - " + error);
+            BOOST_CHECK_MESSAGE(CheckVerifierString(verifier, setFoundQualifiers, error), "Verifier String Test 7 failed - " + verifier + " - " + error);
             BOOST_CHECK(setFoundQualifiers.size() == 1);
             BOOST_CHECK_MESSAGE(setFoundQualifiers.count("TEST"), "TEST 7 set didn't have #TEST");
         }

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -18,6 +18,10 @@ class CCoinControl
 {
 public:
     CTxDestination destChange;
+
+    //! If set, all asset change will be sent to this address, if not destChange will be used
+    CTxDestination assetDestChange;
+
     //! If false, allows unselected inputs, but requires all selected inputs be used
     bool fAllowOtherInputs;
     //! Includes watch only addresses which match the ISMINE_WATCH_SOLVABLE criteria
@@ -46,6 +50,7 @@ public:
     void SetNull()
     {
         destChange = CNoDestination();
+        assetDestChange = CNoDestination();
         fAllowOtherInputs = false;
         fAllowWatchOnly = false;
         setSelected.clear();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3227,6 +3227,7 @@ bool CWallet::CreateTransactionAll(const std::vector<CRecipient>& vecSend, CWall
             // TODO: pass in scriptChange instead of reservekey so
             // change transaction isn't always pay-to-raven-address
             CScript scriptChange;
+            CScript assetScriptChange;
 
             // coin control: send change to custom address
             if (!boost::get<CNoDestination>(&coin_control.destChange)) {
@@ -3240,6 +3241,14 @@ bool CWallet::CreateTransactionAll(const std::vector<CRecipient>& vecSend, CWall
 
                 scriptChange = GetScriptForDestination(keyID);
             }
+
+            /** RVN START */
+            if (!boost::get<CNoDestination>(&coin_control.assetDestChange)) {
+                assetScriptChange = GetScriptForDestination(coin_control.assetDestChange);
+            } else {
+                assetScriptChange = scriptChange;
+            }
+            /** RVN END */
 
             CTxOut change_prototype_txout(0, scriptChange);
             size_t change_prototype_size = GetSerializeSize(change_prototype_txout, SER_DISK, 0);
@@ -3355,7 +3364,7 @@ bool CWallet::CreateTransactionAll(const std::vector<CRecipient>& vecSend, CWall
 
                                 // Get the change address
                                 CTxDestination dest;
-                                if (!ExtractDestination(scriptChange, dest)) {
+                                if (!ExtractDestination(assetScriptChange, dest)) {
                                     strFailReason = _("Failed to extract destination from change script");
                                     return false;
                                 }
@@ -3395,7 +3404,7 @@ bool CWallet::CreateTransactionAll(const std::vector<CRecipient>& vecSend, CWall
                                     }
                                 } else  {
                                     fFoundValueChangeAddress = true;
-                                    CScript scriptAssetChange = scriptChange;
+                                    CScript scriptAssetChange = assetScriptChange;
                                     CAssetTransfer assetTransfer(assetChange.first, assetChange.second);
 
                                     assetTransfer.ConstructTransaction(scriptAssetChange);
@@ -3408,7 +3417,7 @@ bool CWallet::CreateTransactionAll(const std::vector<CRecipient>& vecSend, CWall
                                     return false;
                                 }
                             } else {
-                                CScript scriptAssetChange = scriptChange;
+                                CScript scriptAssetChange = assetScriptChange;
                                 CAssetTransfer assetTransfer(assetChange.first, assetChange.second);
 
                                 assetTransfer.ConstructTransaction(scriptAssetChange);

--- a/test/functional/rpc_assettransfer.py
+++ b/test/functional/rpc_assettransfer.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test transferring assets rpc calls
+#
+
+import time
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+import binascii
+
+class AssetTransferTest(RavenTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def setup_network(self):
+        self.add_nodes(2, [
+            # Nodes 0/1 are "wallet" nodes
+            ["-debug", "-assetindex"],
+            ["-debug", "-assetindex"]])
+
+        self.start_nodes()
+
+        connect_all_nodes_bi(self.nodes)
+
+        self.sync_all()
+
+    def run_test(self):
+        print("Mining blocks...")
+        self.nodes[0].generate(250)
+        self.sync_all()
+        self.nodes[1].generate(250)
+        self.sync_all()
+
+        chain_height_0 = self.nodes[0].getblockcount()
+        chain_height_1 = self.nodes[1].getblockcount()
+        assert_equal(chain_height_0, 500)
+        assert_equal(chain_height_1, 500)
+
+        n0, n1 = self.nodes[0], self.nodes[1]
+
+        print("Calling issue()...")
+        address0 = n0.getnewaddress()
+        ipfs_hash = "QmcvyefkqQX3PpjpY5L8B2yMd47XrVwAipr6cxUt2zvYU8"
+        n0.issue(asset_name="TRANSFER_TEST", qty=1000, to_address=address0, change_address="", \
+                 units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
+
+        n0.generate(1);
+
+        self.sync_all();
+
+        print("Testing transfer with dedicated asset change address...")
+
+        n1_address = n1.getnewaddress()
+
+        n0_rvn_change = n0.getnewaddress()
+        n0_asset_change = n0.getnewaddress()
+
+        n0.transfer(asset_name="TRANSFER_TEST", qty=200, to_address=n1_address, message='', expire_time=0, change_address=n0_rvn_change, asset_change_address=n0_asset_change)
+
+        n0.generate(1)
+        self.sync_all()
+
+        assert_equal(n0.listassetbalancesbyaddress(n1_address)["TRANSFER_TEST"], 200)
+        assert_equal(n0.listassetbalancesbyaddress(n0_asset_change)["TRANSFER_TEST"], 800)
+
+        print("Testing transferfromaddress with dedicated asset change address...")
+
+        n0_from_address = n0_asset_change
+        n1_already_received_address = n1_address
+
+        n1_address = n1.getnewaddress()
+        n0_rvn_change = n0.getnewaddress()
+        n0_asset_change = n0.getnewaddress()
+
+        n0.transferfromaddress(asset_name="TRANSFER_TEST", from_address=n0_from_address, qty=200, to_address=n1_address, message='', expire_time=0, rvn_change_address=n0_rvn_change, asset_change_address=n0_asset_change)
+
+        n0.generate(1)
+        self.sync_all()
+
+        assert_equal(n0.listassetbalancesbyaddress(n1_already_received_address)["TRANSFER_TEST"], 200)
+        assert_equal(n0.listassetbalancesbyaddress(n1_address)["TRANSFER_TEST"], 200)
+        assert_equal(n0.listassetbalancesbyaddress(n0_asset_change)["TRANSFER_TEST"], 600)
+
+        print("Testing transferfromaddresses with dedicated asset change address...")
+
+        # transfer some assets into another address node0 controls
+        n0_new_address = n0.getnewaddress()
+        n0.transfer(asset_name="TRANSFER_TEST", qty=200, to_address=n0_new_address, message='', expire_time=0, change_address=n0_rvn_change, asset_change_address=n0_asset_change)
+
+        n0.generate(1)
+        self.sync_all()
+
+        n0_from_addresses = [n0_asset_change, n0_new_address]
+
+        n0_from_address = n0_asset_change
+        n1_already_received_address_2 = n1_address
+
+        n1_address = n1.getnewaddress()
+        n0_rvn_change = n0.getnewaddress()
+        n0_asset_change = n0.getnewaddress()
+
+        n0.transferfromaddresses(asset_name="TRANSFER_TEST", from_addresses=n0_from_addresses, qty=450, to_address=n1_address, message='', expire_time=0, rvn_change_address=n0_rvn_change, asset_change_address=n0_asset_change)
+
+        n0.generate(1)
+        self.sync_all()
+
+        assert_equal(n0.listassetbalancesbyaddress(n1_already_received_address)["TRANSFER_TEST"], 200)
+        assert_equal(n0.listassetbalancesbyaddress(n1_already_received_address_2)["TRANSFER_TEST"], 200)
+        assert_equal(n0.listassetbalancesbyaddress(n1_address)["TRANSFER_TEST"], 450)
+        assert_equal(n0.listassetbalancesbyaddress(n0_asset_change)["TRANSFER_TEST"], 150)
+
+        print("Testing transferfromaddresses with not enough funds...")
+
+        # Add the address the only contain 150 TRANSFER_TEST assets
+        n0_from_addresses = [n0_asset_change]
+
+        assert_raises_rpc_error(-25, "Insufficient asset funds", \
+                                n0.transferfromaddresses, "TRANSFER_TEST", n0_from_addresses, 450, n1_address, '', 0, n0_rvn_change, n0_asset_change)
+
+        # Verify that the failed transaction doesn't change the already mined address values on the wallet
+        assert_equal(n0.listassetbalancesbyaddress(n1_already_received_address)["TRANSFER_TEST"], 200)
+        assert_equal(n0.listassetbalancesbyaddress(n1_already_received_address_2)["TRANSFER_TEST"], 200)
+        assert_equal(n0.listassetbalancesbyaddress(n1_address)["TRANSFER_TEST"], 450)
+        assert_equal(n0.listassetbalancesbyaddress(n0_asset_change)["TRANSFER_TEST"], 150)
+
+
+
+        # Verify that node 1 has the same values
+        assert_equal(n1.listassetbalancesbyaddress(n1_already_received_address)["TRANSFER_TEST"], 200)
+        assert_equal(n1.listassetbalancesbyaddress(n1_already_received_address_2)["TRANSFER_TEST"], 200)
+        assert_equal(n1.listassetbalancesbyaddress(n1_address)["TRANSFER_TEST"], 450)
+        assert_equal(n1.listassetbalancesbyaddress(n0_asset_change)["TRANSFER_TEST"], 150)
+
+        print("Passed\n")
+
+
+if __name__ == '__main__':
+    AssetTransferTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -154,6 +154,7 @@ BASE_SCRIPTS= [
     'p2p_mempool.py',
     'rpc_named_arguments.py',
     'rpc_uptime.py',
+    'rpc_assettransfer.py'
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
 ]


### PR DESCRIPTION
- Add ability to specify a asset change address as well as a raven change address in the transfer rpc calls
- Allow users to use the console commands without having to add the special characters for qualifier and restricted assets. (#,$)
- Add functional tests to verify that the asset change support works correctly
- Updated units to work with the special character changes