### PR TITLE
Fix Compiler Warning [-Wswitch]

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -180,6 +180,7 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey,
 
             switch (type) {
                 case TX_NEW_ASSET:
+                  {
                     if (IsAssetNameAnOwner(name)) {
                         // pwnd n00b
                     } else {
@@ -193,22 +194,30 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey,
                         }
                     }
                     break;
+                  }
                 case TX_TRANSFER_ASSET:
+                  {
                     break;
+                  }
                 case TX_REISSUE_ASSET:
-                    CReissueAsset asset;
-                    if (ReissueAssetFromScript(scriptPubKey, asset, _assetAddress)) {
-                        if (asset.nUnits >= 0) {
-                            assetInfo.pushKV("units", asset.nUnits);
-                        }
+                    {
+                      CReissueAsset asset;
+                      if (ReissueAssetFromScript(scriptPubKey, asset, _assetAddress)) {
+                          if (asset.nUnits >= 0) {
+                              assetInfo.pushKV("units", asset.nUnits);
+                          }
                         assetInfo.pushKV("reissuable", asset.nReissuable > 0 ? true : false);
                         if (!asset.strIPFSHash.empty()) {
-                            assetInfo.pushKV("ipfs_hash", EncodeAssetData(asset.strIPFSHash));
+                          assetInfo.pushKV("ipfs_hash", EncodeAssetData(asset.strIPFSHash));
                         }
-                    }
+                      }
                     break;
+                  }
+                default:
+                    {
+                      break;
+                    }
             }
-        }
 
         out.pushKV("asset", assetInfo);
     }


### PR DESCRIPTION
When compiling, I encountered this warning:
```
core_write.cpp:181:20: warning: enumeration value ‘TX_NONSTANDARD’ not handled in switch [-Wswitch]
             switch (type) {
                    ^
core_write.cpp:181:20: warning: enumeration value ‘TX_PUBKEY’ not handled in switch [-Wswitch]
core_write.cpp:181:20: warning: enumeration value ‘TX_PUBKEYHASH’ not handled in switch [-Wswitch]
core_write.cpp:181:20: warning: enumeration value ‘TX_SCRIPTHASH’ not handled in switch [-Wswitch]
core_write.cpp:181:20: warning: enumeration value ‘TX_MULTISIG’ not handled in switch [-Wswitch]
core_write.cpp:181:20: warning: enumeration value ‘TX_NULL_DATA’ not handled in switch [-Wswitch]
core_write.cpp:181:20: warning: enumeration value ‘TX_WITNESS_V0_SCRIPTHASH’ not handled in switch [-Wswitch]
core_write.cpp:181:20: warning: enumeration value ‘TX_WITNESS_V0_KEYHASH’ not handled in switch [-Wswitch]
core_write.cpp:181:20: warning: enumeration value ‘TX_RESTRICTED_ASSET_DATA’ not handled in switch [-Wswitch]
```
Adding a default case silences it. I also removed a case that does the same as the default, and made each case more explicit with curly braces.