### PR TITLE
Correct typo in build-osx.md

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -40,7 +40,7 @@ Raven Core" has already been followed).  Uninstall Berkeley-db 4.8.3, install th
 incompatible-bdb flag:
 
     brew remove berkeley-db@4
-    brew install bekeley-db
+    brew install berkeley-db
     ./autogen.sh
     ./configure --with-incompatible-bdb
     make


### PR DESCRIPTION
Just noticed when updating ZelCore' binaries and backend