### PR TITLE
Disable transaction relay if walletbroadcast=0

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -979,6 +979,11 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
 static void RelayTransaction(const CTransaction& tx, CConnman* connman)
 {
+    if (gArgs.GetArg("-walletbroadcast", 1) == 0) {
+        LogPrintf("walletbroadcast=0, skipping transaction relay\n");
+        return;
+    }
+
     CInv inv(MSG_TX, tx.GetHash());
     connman->ForEachNode([&inv](CNode* pnode)
     {
@@ -3367,7 +3372,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
         // Resend wallet transactions that haven't gotten in a block yet
         // Except during reindex, importing and IBD, when old wallet
         // transactions become unconfirmed and spams other nodes.
-        if (!fReindex && !fImporting && !IsInitialBlockDownload())
+        if (!fReindex && !fImporting && !IsInitialBlockDownload() && gArgs.GetArg("-walletbroadcast", 1) != 0)
         {
             GetMainSignals().Broadcast(nTimeBestReceived, connman);
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1678,8 +1678,11 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
 void CWallet::ReacceptWalletTransactions()
 {
     // If transactions aren't being broadcasted, don't let them into local mempool either
-    if (!fBroadcastTransactions)
-        return;
+    // Commented out. There are circumstances where you want to accept transactions but you don't
+    // want to forward them along.
+
+    // if (!fBroadcastTransactions)
+    //    return;
     LOCK2(cs_main, cs_wallet);
     std::map<int64_t, CWalletTx*> mapSorted;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1678,11 +1678,9 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
 void CWallet::ReacceptWalletTransactions()
 {
     // If transactions aren't being broadcasted, don't let them into local mempool either
-    // Commented out. There are circumstances where you want to accept transactions but you don't
-    // want to forward them along.
+    if (!fBroadcastTransactions && gArgs.GetArg("-walletbroadcast", 1) != 0)
+        return;
 
-    // if (!fBroadcastTransactions)
-    //    return;
     LOCK2(cs_main, cs_wallet);
     std::map<int64_t, CWalletTx*> mapSorted;
 


### PR DESCRIPTION
This update permits nodes to run in walletbroadcast=0 while still accepting transactions from connected nodes. With this change, if walletbroadcast=0 then it will accept transactions from peers but it will not relay them to other peers.