### PR TITLE
[WIP][Feature] Add -txrelay which allows node to choose not broadcast transactions

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -590,6 +590,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE));
         strUsage += HelpMessageOpt("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT));
     }
+    strUsage += HelpMessageOpt("-txrelay=<n>", _("If this node should relay transactions (default: 1 (true))"));
 
     return strUsage;
 }
@@ -1466,6 +1467,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     // ********************************************************* Step 7: load block chain
 
     fReindex = gArgs.GetBoolArg("-reindex", false);
+
     bool fReindexChainState = gArgs.GetBoolArg("-reindex-chainstate", false);
 
     // block tree db settings

--- a/src/net.h
+++ b/src/net.h
@@ -90,6 +90,8 @@ static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
 static const unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24;  // Default 24-hour ban
 
+static const bool DEFAULT_TXRELAY = true;
+
 typedef int64_t NodeId;
 
 struct AddedNodeInfo

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -979,6 +979,11 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
 static void RelayTransaction(const CTransaction& tx, CConnman* connman)
 {
+    if (!gArgs.GetBoolArg("-txrelay", DEFAULT_TXRELAY)) {
+        LogPrint(BCLog::NET, "skipping transaction relay txrelay=0\n");
+        return;
+    }
+
     CInv inv(MSG_TX, tx.GetHash());
     connman->ForEachNode([&inv](CNode* pnode)
     {
@@ -3367,7 +3372,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
         // Resend wallet transactions that haven't gotten in a block yet
         // Except during reindex, importing and IBD, when old wallet
         // transactions become unconfirmed and spams other nodes.
-        if (!fReindex && !fImporting && !IsInitialBlockDownload())
+        if (!fReindex && !fImporting && !IsInitialBlockDownload() && gArgs.GetBoolArg("-txrelay", DEFAULT_TXRELAY))
         {
             GetMainSignals().Broadcast(nTimeBestReceived, connman);
         }


### PR DESCRIPTION
This update permits nodes to run in txrelay=0 while still accepting transactions from connected nodes. With this change, if txrelay=0 then it will accept transactions from peers but it will not relay them to other peers.