### PR TITLE
Fix functional tests failing on verack

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -19,6 +19,8 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 31800;
 
 //! assetdata network request is allowed for this version
+//!!! Anytime this value is changed please also update the "MY_VERSION" value to match in the
+//!!! ./test/functional/test_framework/mininode.py file. Not doing so will cause verack to fail!
 static const int ASSETDATA_VERSION = 70017;
 
 //! disconnect from peers older than this proto version

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -41,7 +41,7 @@ from test_framework.siphash import siphash256
 from test_framework.util import hex_str_to_bytes, bytes_to_hex_str, wait_until
 
 BIP0031_VERSION = 60000
-MY_VERSION = 70014  # past bip-31 for ping/pong
+MY_VERSION = 70017  # This needs to match the ASSETDATA_VERSION in version.h!
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 


### PR DESCRIPTION
 The MIN_PEER_PROTO_VERSION was recently changed from using GETHEADERS_VERSION=31800 to using ASSETDATA_VERSION=700017.  This change fixes the tests to use the new version number. Also added a note version.h so future changes will hopefully remember to also update the test version to match.