### PR TITLE
Unique Assets Functional Test Could Use Invalid Character

### DIFF
--- a/test/functional/feature_unique_assets.py
+++ b/test/functional/feature_unique_assets.py
@@ -24,7 +24,7 @@ def gen_root_asset_name():
     return name
 
 def gen_unique_asset_name(root):
-    tag_ab = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@$%&*()[]{}_.?\\:"
+    tag_ab = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@$%&*()[]{}_.?-:"
     name = root + "#"
     tag_size = random.randint(1, 15)
     for _ in range(1, tag_size+1):


### PR DESCRIPTION
Noticed today that the test/functional/feature_unique_assets.py script could generate an invalid asset.  The array used to create random asset names included the forward-slash (\) and was missing the dash (-).  This would cause the test to randomly fail.