### PR TITLE
Add support to run with disable-wallet

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -3537,6 +3537,7 @@ bool GetAssetData(const CScript& script, CAssetOutputEntry& data)
     return false;
 }
 
+#ifdef ENABLE_WALLET
 void GetAllAdministrativeAssets(CWallet *pwallet, std::vector<std::string> &names, int nMinConf)
 {
     if(!pwallet)
@@ -3566,6 +3567,7 @@ void GetAllMyAssets(CWallet* pwallet, std::vector<std::string>& names, int nMinC
         }
     }
 }
+#endif
 
 CAmount GetIssueAssetBurnAmount()
 {
@@ -3710,6 +3712,7 @@ bool GetBestAssetAddressAmount(CAssetsCache& cache, const std::string& assetName
     return false;
 }
 
+#ifdef ENABLE_WALLET
 //! sets _balances_ with the total quantity of each owned asset
 bool GetAllMyAssetBalances(std::map<std::string, std::vector<COutput> >& outputs, std::map<std::string, CAmount>& amounts, const int confirmations, const std::string& prefix) {
 
@@ -3735,6 +3738,7 @@ bool GetAllMyAssetBalances(std::map<std::string, std::vector<COutput> >& outputs
 
     return true;
 }
+#endif
 
 // 46 char base58 --> 34 char KAW compatible
 std::string DecodeAssetData(std::string encoded)
@@ -3783,6 +3787,7 @@ std::string EncodeIPFS(std::string decoded){
     return EncodeBase58(unsignedCharData);
 };
 
+#ifdef ENABLE_WALLET
 bool CreateAssetTransaction(CWallet* pwallet, CCoinControl& coinControl, const CNewAsset& asset, const std::string& address, std::pair<int, std::string>& error, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRequired, std::string* verifier_string)
 {
     std::vector<CNewAsset> assets;
@@ -4321,6 +4326,8 @@ bool VerifyWalletHasAsset(const std::string& asset_name, std::pair<int, std::str
     pairError = std::make_pair(RPC_INVALID_REQUEST, strprintf("Wallet doesn't have asset: %s", asset_name));
     return false;
 }
+
+#endif
 
 // Return true if the amount is valid with the units passed in
 bool CheckAmountWithUnits(const CAmount& nAmount, const int8_t nUnits)

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -516,16 +516,16 @@ bool GetAssetData(const CScript& script, CAssetOutputEntry& data);
 
 bool GetBestAssetAddressAmount(CAssetsCache& cache, const std::string& assetName, const std::string& address);
 
-bool GetAllMyAssetBalances(std::map<std::string, std::vector<COutput> >& outputs, std::map<std::string, CAmount>& amounts, const int confirmations = 0, const std::string& prefix = "");
-
-/** Verifies that this wallet owns the give asset */
-bool VerifyWalletHasAsset(const std::string& asset_name, std::pair<int, std::string>& pairError);
 
 //! Decode and Encode IPFS hashes, or OIP hashes
 std::string DecodeAssetData(std::string encoded);
 std::string EncodeAssetData(std::string decoded);
 std::string DecodeIPFS(std::string encoded);
 std::string EncodeIPFS(std::string decoded);
+
+#ifdef ENABLE_WALLET
+
+bool GetAllMyAssetBalances(std::map<std::string, std::vector<COutput> >& outputs, std::map<std::string, CAmount>& amounts, const int confirmations = 0, const std::string& prefix = "");
 
 //! Creates new asset issuance transaction
 bool CreateAssetTransaction(CWallet* pwallet, CCoinControl& coinControl, const CNewAsset& asset, const std::string& address, std::pair<int, std::string>& error, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRequired, std::string* verifier_string = nullptr);
@@ -534,11 +534,16 @@ bool CreateAssetTransaction(CWallet* pwallet, CCoinControl& coinControl, const s
 //! Create a reissue asset transaction
 bool CreateReissueAssetTransaction(CWallet* pwallet, CCoinControl& coinControl, const CReissueAsset& asset, const std::string& address, std::pair<int, std::string>& error, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRequired, std::string* verifier_string = nullptr);
 
+
 //! Create a transfer asset transaction
 bool CreateTransferAssetTransaction(CWallet* pwallet, const CCoinControl& coinControl, const std::vector< std::pair<CAssetTransfer, std::string> >vTransfers, const std::string& changeAddress, std::pair<int, std::string>& error, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRequired, std::vector<std::pair<CNullAssetTxData, std::string> >* nullAssetTxData = nullptr, std::vector<CNullAssetTxData>* nullGlobalRestrictionData = nullptr);
 
 //! Send any type of asset transaction to the network
 bool SendAssetTransaction(CWallet* pwallet, CWalletTx& transaction, CReserveKey& reserveKey, std::pair<int, std::string>& error, std::string& txid);
+
+/** Verifies that this wallet owns the give asset */
+bool VerifyWalletHasAsset(const std::string& asset_name, std::pair<int, std::string>& pairError);
+#endif
 
 /** Helper method for extracting address bytes, asset name and amount from an asset script */
 bool ParseAssetScript(CScript scriptPubKey, uint160 &hashBytes, std::string &assetName, CAmount &assetAmount);

--- a/src/assets/messages.cpp
+++ b/src/assets/messages.cpp
@@ -186,6 +186,7 @@ void OrphanMessage(const CMessage& message)
     mapDirtyMessagesAdd.erase(message.out);
 }
 
+#ifdef ENABLE_WALLET
 bool ScanForMessageChannels(std::string& strError)
 {
     LOCK2(cs_messaging, cs_main);
@@ -263,6 +264,7 @@ bool ScanForMessageChannels(std::string& strError)
     LogPrintf("\n");
     return true;
 }
+#endif
 
 bool IsAddressSeen(const std::string &address)
 {

--- a/src/assets/messages.h
+++ b/src/assets/messages.h
@@ -46,7 +46,9 @@ void RemoveMessage(const COutPoint &out);
 void OrphanMessage(const CMessage &message);
 void OrphanMessage(const COutPoint &out);
 
+#ifdef ENABLE_WALLET
 bool ScanForMessageChannels(std::string& strError);
+#endif
 bool IsAddressSeen(const std::string &address); // Has this address already been sent an asset before
 void AddAddressSeen(const std::string &address);
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -277,6 +277,7 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, uint2
                                       tx.vout[i].ToString());
 
                         /** Subscribe to new message channels if they are sent to a new address, or they are the owner token or message channel */
+#ifdef ENABLE_WALLET
                         if (fMessaging && pMessageSubscribedChannelsCache) {
                             LOCK(cs_messaging);
                             if (vpwallets.size() && vpwallets[0]->IsMine(tx.vout[i]) == ISMINE_SPENDABLE) {
@@ -296,8 +297,10 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, uint2
                                 }
                             }
                         }
+#endif
                     } else if (assetData.type == TX_NEW_ASSET) {
                         /** Subscribe to new message channels if they are assets you created, or are new msgchannels of channels already being watched */
+#ifdef ENABLE_WALLET
                         if (fMessaging && pMessageSubscribedChannelsCache) {
                             LOCK(cs_messaging);
                             if (vpwallets.size()) {
@@ -320,6 +323,7 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, uint2
                                 }
                             }
                         }
+#endif
                     }
                 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1902,7 +1902,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
 #ifdef ENABLE_WALLET
     StartWallets(scheduler);
-#endif
+
 
     // ********************************************************* Step 12: Init Msg Channel list
     if (!fReindex && fLoaded && fMessaging && pmessagechanneldb && !gArgs.GetBoolArg("-disablewallet", false)) {
@@ -1915,6 +1915,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             pmessagechanneldb->WriteFlag("init", true);
         }
     }
+#endif
 
     // ********************************************************* Step 13: finished
     uiInterface.InitMessage(_("Done Loading"));

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -498,6 +498,7 @@ static bool ProcessBlockFound(const CBlock* pblock, const CChainParams& chainpar
 }
 
 CWallet *GetFirstWallet() {
+#ifdef ENABLE_WALLET
     while(vpwallets.size() == 0){
         MilliSleep(100);
 
@@ -505,6 +506,8 @@ CWallet *GetFirstWallet() {
     if (vpwallets.size() == 0)
         return(NULL);
     return(vpwallets[0]);
+#endif
+    return(NULL);
 }
 
 void static RavenMiner(const CChainParams& chainparams)
@@ -518,13 +521,14 @@ void static RavenMiner(const CChainParams& chainparams)
 
     CWallet * pWallet = NULL;
 
-    #ifdef ENABLE_WALLET
-        pWallet = GetFirstWallet();
-    #endif
+#ifdef ENABLE_WALLET
+    pWallet = GetFirstWallet();
+
 
     if (!EnsureWalletIsAvailable(pWallet, false)) {
         LogPrintf("RavenMiner -- Wallet not available\n");
     }
+#endif
 
     if (pWallet == NULL)
     {
@@ -561,6 +565,7 @@ void static RavenMiner(const CChainParams& chainparams)
                 // Busy-wait for the network to come online so we don't waste time mining
                 // on an obsolete chain. In regtest mode we expect to fly solo.
                 do {
+                    break;
                     if ((g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) > 0) && !IsInitialBlockDownload()) {
                         break;
                     }

--- a/src/qt/assettablemodel.cpp
+++ b/src/qt/assettablemodel.cpp
@@ -35,6 +35,7 @@ public:
     QList<AssetRecord> cachedBalances;
 
     // loads all current balances into cache
+#ifdef ENABLE_WALLET
     void refreshWallet() {
         qDebug() << "AssetTablePriv::refreshWallet";
         cachedBalances.clear();
@@ -86,6 +87,7 @@ public:
             }
         }
     }
+#endif
 
 
     int size() {
@@ -107,8 +109,9 @@ AssetTableModel::AssetTableModel(WalletModel *parent) :
         priv(new AssetTablePriv(this))
 {
     columns << tr("Name") << tr("Quantity");
-
+#ifdef ENABLE_WALLET
     priv->refreshWallet();
+#endif
 };
 
 AssetTableModel::~AssetTableModel()
@@ -120,7 +123,9 @@ void AssetTableModel::checkBalanceChanged() {
     qDebug() << "AssetTableModel::CheckBalanceChanged";
     // TODO: optimize by 1) updating cache incrementally; and 2) emitting more specific dataChanged signals
     Q_EMIT layoutAboutToBeChanged();
+#ifdef ENABLE_WALLET
     priv->refreshWallet();
+#endif
     Q_EMIT dataChanged(index(0, 0, QModelIndex()), index(priv->size(), columns.length()-1, QModelIndex()));
     Q_EMIT layoutChanged();
 }

--- a/src/qt/ravengui.cpp
+++ b/src/qt/ravengui.cpp
@@ -732,7 +732,9 @@ void RavenGUI::createToolBars()
         // Create the layout for widget to the right of the tool bar
         QVBoxLayout* mainFrameLayout = new QVBoxLayout(mainWalletWidget);
         mainFrameLayout->addWidget(headerWidget);
+#ifdef ENABLE_WALLET
         mainFrameLayout->addWidget(walletFrame);
+#endif
         mainFrameLayout->setDirection(QBoxLayout::TopToBottom);
         mainFrameLayout->setContentsMargins(QMargins());
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -723,6 +723,7 @@ void RPCConsole::setFontSize(int newSize)
     ui->messagesWidget->verticalScrollBar()->setValue(oldPosFactor * ui->messagesWidget->verticalScrollBar()->maximum());
 }
 
+#ifdef ENABLE_WALLET
 /** Restart wallet with "-rescan" */
 void RPCConsole::walletRescan()
 {
@@ -752,6 +753,7 @@ void RPCConsole::walletReindex()
 
   buildParameterlist(REINDEX);
 }
+#endif
 
 /** Build command-line parameter list for restart */
 void RPCConsole::buildParameterlist(QString arg)

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -92,9 +92,11 @@ public Q_SLOTS:
     void setFontSize(int newSize);
 
     /** Wallet repair options */
+#ifdef ENABLE_WALLET
     void walletRescan();
     void walletZaptxes1();
     void walletReindex();
+#endif
 
     /** Append the message to the message widget */
     void message(int category, const QString &message, bool html = false);

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -129,10 +129,12 @@ public Q_SLOTS:
 
     /** RVN START */
     /** Switch to assets page */
+
     void gotoAssetsPage();
     void gotoCreateAssetsPage();
     void gotoManageAssetsPage();
     void gotoRestrictedAssetsPage();
+
     /** RVN END */
 
 Q_SIGNALS:

--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -139,6 +139,7 @@ UniValue UnitValueFromAmount(const CAmount& amount, const std::string asset_name
     return ValueFromAmount(amount, units);
 }
 
+#ifdef ENABLE_WALLET
 UniValue UpdateAddressTag(const JSONRPCRequest &request, const int8_t &flag)
 {
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
@@ -318,6 +319,7 @@ UniValue UpdateAddressRestriction(const JSONRPCRequest &request, const int8_t &f
     result.push_back(txid);
     return result;
 }
+
 
 UniValue UpdateGlobalRestrictedAsset(const JSONRPCRequest &request, const int8_t &flag)
 {
@@ -715,6 +717,7 @@ UniValue issueunique(const JSONRPCRequest& request)
     result.push_back(txid);
     return result;
 }
+#endif
 
 UniValue listassetbalancesbyaddress(const JSONRPCRequest& request)
 {
@@ -869,6 +872,7 @@ void safe_advance(Iter& curr, const Iter& end, Incr n)
     std::advance(curr, n);
 };
 
+#ifdef ENABLE_WALLET
 UniValue listmyassets(const JSONRPCRequest &request)
 {
     if (request.fHelp || !AreAssetsDeployed() || request.params.size() > 5)
@@ -1045,6 +1049,8 @@ UniValue listmyassets(const JSONRPCRequest &request)
     return result;
 }
 
+#endif
+
 UniValue listaddressesbyasset(const JSONRPCRequest &request)
 {
     if (!fAssetIndex) {
@@ -1117,6 +1123,7 @@ UniValue listaddressesbyasset(const JSONRPCRequest &request)
 
     return result;
 }
+#ifdef ENABLE_WALLET
 
 UniValue transfer(const JSONRPCRequest& request)
 {
@@ -1641,6 +1648,7 @@ UniValue reissue(const JSONRPCRequest& request)
     result.push_back(txid);
     return result;
 }
+#endif
 
 UniValue listassets(const JSONRPCRequest& request)
 {
@@ -1804,6 +1812,7 @@ UniValue getcacheinfo(const JSONRPCRequest& request)
     return result;
 }
 
+#ifdef ENABLE_WALLET
 UniValue addtagtoaddress(const JSONRPCRequest& request)
 {
     if (request.fHelp || !AreRestrictedAssetsDeployed() || request.params.size() < 2 || request.params.size() > 3)
@@ -1963,6 +1972,7 @@ UniValue unfreezerestrictedasset(const JSONRPCRequest& request)
     // 0 = Unfreeze all trading
     return UpdateGlobalRestrictedAsset(request, 0);
 }
+#endif
 
 UniValue listtagsforaddress(const JSONRPCRequest &request)
 {
@@ -2288,6 +2298,8 @@ UniValue checkglobalrestriction(const JSONRPCRequest& request)
 
     return passets->CheckForGlobalRestriction(restricted_name, true);
 }
+
+#ifdef ENABLE_WALLET
 
 UniValue issuequalifierasset(const JSONRPCRequest& request)
 {
@@ -2841,6 +2853,7 @@ UniValue transferqualifier(const JSONRPCRequest& request)
     result.push_back(txid);
     return result;
 }
+#endif
 
 UniValue isvalidverifierstring(const JSONRPCRequest& request)
 {
@@ -2884,19 +2897,24 @@ UniValue isvalidverifierstring(const JSONRPCRequest& request)
 static const CRPCCommand commands[] =
 { //  category    name                          actor (function)             argNames
   //  ----------- ------------------------      -----------------------      ----------
+#ifdef ENABLE_WALLET
     { "assets",   "issue",                      &issue,                      {"asset_name","qty","to_address","change_address","units","reissuable","has_ipfs","ipfs_hash"} },
     { "assets",   "issueunique",                &issueunique,                {"root_name", "asset_tags", "ipfs_hashes", "to_address", "change_address"}},
+    { "assets",   "listmyassets",               &listmyassets,               {"asset", "verbose", "count", "start", "confs"}},
+#endif
     { "assets",   "listassetbalancesbyaddress", &listassetbalancesbyaddress, {"address", "onlytotal", "count", "start"} },
     { "assets",   "getassetdata",               &getassetdata,               {"asset_name"}},
-    { "assets",   "listmyassets",               &listmyassets,               {"asset", "verbose", "count", "start", "confs"}},
     { "assets",   "listaddressesbyasset",       &listaddressesbyasset,       {"asset_name", "onlytotal", "count", "start"}},
+#ifdef ENABLE_WALLET
     { "assets",   "transferfromaddress",        &transferfromaddress,        {"asset_name", "from_address", "qty", "to_address", "message", "expire_time", "rvn_change_address", "asset_change_address"}},
     { "assets",   "transferfromaddresses",      &transferfromaddresses,      {"asset_name", "from_addresses", "qty", "to_address", "message", "expire_time", "rvn_change_address", "asset_change_address"}},
     { "assets",   "transfer",                   &transfer,                   {"asset_name", "qty", "to_address", "message", "expire_time", "change_address", "asset_change_address"}},
     { "assets",   "reissue",                    &reissue,                    {"asset_name", "qty", "to_address", "change_address", "reissuable", "new_unit", "new_ipfs"}},
+#endif
     { "assets",   "listassets",                 &listassets,                 {"asset", "verbose", "count", "start"}},
     { "assets",   "getcacheinfo",               &getcacheinfo,               {}},
 
+#ifdef ENABLE_WALLET
     { "restricted assets",   "transferqualifier",          &transferqualifier,          {"qualifier_name", "qty", "to_address", "change_address", "message", "expire_time"}},
     { "restricted assets",   "issuerestrictedasset",       &issuerestrictedasset,       {"asset_name","qty","verifier","to_address","change_address","units","reissuable","has_ipfs","ipfs_hash"} },
     { "restricted assets",   "issuequalifierasset",        &issuequalifierasset,        {"asset_name","qty","to_address","change_address","has_ipfs","ipfs_hash"} },
@@ -2907,6 +2925,7 @@ static const CRPCCommand commands[] =
     { "restricted assets",   "unfreezeaddress",            &unfreezeaddress,            {"asset_name", "address", "change_address"}},
     { "restricted assets",   "freezerestrictedasset",      &freezerestrictedasset,      {"asset_name", "change_address"}},
     { "restricted assets",   "unfreezerestrictedasset",    &unfreezerestrictedasset,    {"asset_name", "change_address"}},
+#endif
     { "restricted assets",   "listaddressesfortag",        &listaddressesfortag,        {"tag_name"}},
     { "restricted assets",   "listtagsforaddress",         &listtagsforaddress,         {"address"}},
     { "restricted assets",   "listaddressrestrictions",    &listaddressrestrictions,    {"address"}},

--- a/src/rpc/messages.cpp
+++ b/src/rpc/messages.cpp
@@ -304,6 +304,7 @@ UniValue clearmessages(const JSONRPCRequest& request) {
     return "Erased " + std::to_string(count) + " Messages from the database and cache";
 }
 
+#ifdef ENABLE_WALLET
 UniValue sendmessage(const JSONRPCRequest& request) {
     if (request.fHelp || !AreMessagesDeployed() || request.params.size() < 2 || request.params.size() > 3)
         throw std::runtime_error(
@@ -396,6 +397,7 @@ UniValue sendmessage(const JSONRPCRequest& request) {
     result.push_back(txid);
     return result;
 }
+#endif
 
 static const CRPCCommand commands[] =
     {           //  category    name                          actor (function)             argNames
@@ -404,7 +406,9 @@ static const CRPCCommand commands[] =
             { "messages",       "viewallmessagechannels",     &viewallmessagechannels,     {}},
             { "messages",       "subscribetochannel",         &subscribetochannel,         {"channel_name"}},
             { "messages",       "unsubscribefromchannel",     &unsubscribefromchannel,     {"channel_name"}},
+#ifdef ENABLE_WALLET
             { "messages",       "sendmessage",                &sendmessage,                {"channel", "ipfs_hash", "expire_time"}},
+#endif
             { "messages",       "clearmessages",              &clearmessages,              {}},
     };
 


### PR DESCRIPTION
With these changes you can now configure the raven coin daemon to not use a wallet. 
./configure --disable-wallet
