### PR TITLE
Add ability to attach asset data to tag/freeze transactions

### DIFF
--- a/src/qt/forms/restrictedassignqualifier.ui
+++ b/src/qt/forms/restrictedassignqualifier.ui
@@ -43,12 +43,25 @@
      <property name="rightMargin">
       <number>10</number>
      </property>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelAssignType">
+       <property name="text">
+        <string>Select Type:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="assignTypeComboBox"/>
+     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="labelQualifier">
        <property name="text">
         <string>Select Qualifier:</string>
        </property>
       </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="assetComboBox"/>
      </item>
      <item row="4" column="0">
       <widget class="QLabel" name="labelAddress">
@@ -65,13 +78,20 @@
       </widget>
      </item>
      <item row="5" column="0">
+      <widget class="QLabel" name="labelAssetData">
+       <property name="text">
+        <string>IPFS / Hash:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
       <widget class="QCheckBox" name="checkBoxChangeAddress">
        <property name="text">
         <string>Custom Change Address</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="6" column="1">
       <widget class="QLineEdit" name="lineEditChangeAddress">
        <property name="enabled">
         <bool>false</bool>
@@ -81,18 +101,8 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="assetComboBox"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="labelAssignType">
-       <property name="text">
-        <string>Select Type:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="assignTypeComboBox"/>
+     <item row="5" column="1">
+      <widget class="QLineEdit" name="lineEditAssetData"/>
      </item>
     </layout>
    </item>

--- a/src/qt/forms/restrictedfreezeaddress.ui
+++ b/src/qt/forms/restrictedfreezeaddress.ui
@@ -64,14 +64,14 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QCheckBox" name="checkBoxChangeAddress">
        <property name="text">
         <string>Custom Change Address</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QLineEdit" name="lineEditChangeAddress">
        <property name="enabled">
         <bool>false</bool>
@@ -83,6 +83,16 @@
      </item>
      <item row="1" column="1">
       <widget class="QComboBox" name="assetComboBox"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelAssetData">
+       <property name="text">
+        <string>IPFS / Hash:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLineEdit" name="lineEditAssetData"/>
      </item>
     </layout>
    </item>

--- a/src/qt/restrictedassetsdialog.cpp
+++ b/src/qt/restrictedassetsdialog.cpp
@@ -180,6 +180,7 @@ void RestrictedAssetsDialog::freezeAddressClicked()
     std::string asset_name = widget->getUI()->assetComboBox->currentData(AssetTableModel::RoleIndex::AssetNameRole).toString().toStdString();
     std::string address = widget->getUI()->lineEditAddress->text().toStdString();
     std::string change_address = widget->getUI()->checkBoxChangeAddress->isChecked() ? widget->getUI()->lineEditChangeAddress->text().toStdString(): "";
+    std::string decodedAssetData = DecodeAssetData(widget->getUI()->lineEditAssetData->text().toStdString());
 
     // Get the single address options
     bool fFreezeAddress = widget->getUI()->radioButtonFreezeAddress->isChecked();
@@ -221,7 +222,7 @@ void RestrictedAssetsDialog::freezeAddressClicked()
     // We have to send the owner token for the asset in order to perform a restriction
     std::string asset_owner_token = RestrictedNameToOwnerName(asset_name);
 
-    vTransfers.emplace_back(std::make_pair(CAssetTransfer(asset_owner_token, 1 * COIN), change_address));
+    vTransfers.emplace_back(std::make_pair(CAssetTransfer(asset_owner_token, 1 * COIN, decodedAssetData), change_address));
 
     int flag = -1;
     if (fFreezeAddress || fUnfreezeAddress) {
@@ -319,6 +320,8 @@ void RestrictedAssetsDialog::freezeAddressClicked()
     std::string totalMsg = strprintf("%s: %s",sentMsg, txid);
     txidMsgBox.setText(QString::fromStdString(totalMsg));
     txidMsgBox.exec();
+
+    widget->clear();
 }
 
 void RestrictedAssetsDialog::assignQualifierClicked()
@@ -335,9 +338,9 @@ void RestrictedAssetsDialog::assignQualifierClicked()
     std::string address = widget->getUI()->lineEditAddress->text().toStdString();
     std::string asset_name = widget->getUI()->assetComboBox->currentData(AssetTableModel::RoleIndex::AssetNameRole).toString().toStdString();
     std::string change_address = widget->getUI()->checkBoxChangeAddress->isChecked() ? widget->getUI()->lineEditChangeAddress->text().toStdString(): "";
+    std::string decodedAssetData = DecodeAssetData(widget->getUI()->lineEditAssetData->text().toStdString());
 
     int flag = widget->getUI()->assignTypeComboBox->currentIndex() ? 0 : 1;
-    qDebug() << "current index " << flag;
 
     CReserveKey reservekey(model->getWallet());
     CWalletTx transaction;
@@ -364,7 +367,7 @@ void RestrictedAssetsDialog::assignQualifierClicked()
     std::vector< std::pair<CAssetTransfer, std::string> >vTransfers;
 
     // Always transfer 1 of the qualifier tokens to the change address
-    vTransfers.emplace_back(std::make_pair(CAssetTransfer(asset_name, 1 * COIN), change_address));
+    vTransfers.emplace_back(std::make_pair(CAssetTransfer(asset_name, 1 * COIN, decodedAssetData), change_address));
 
     // Add the asset data with the flag to remove or add the tag 1 = Add, 0 = Remove
     std::vector< std::pair<CNullAssetTxData, std::string> > vecAssetData;
@@ -436,6 +439,8 @@ void RestrictedAssetsDialog::assignQualifierClicked()
     std::string totalMsg = strprintf("%s: %s",sentMsg, txid);
     txidMsgBox.setText(QString::fromStdString(totalMsg));
     txidMsgBox.exec();
+
+    widget->clear();
 }
 
 

--- a/src/qt/restrictedassignqualifier.cpp
+++ b/src/qt/restrictedassignqualifier.cpp
@@ -33,10 +33,12 @@ AssignQualifier::AssignQualifier(const PlatformStyle *_platformStyle, QWidget *p
     ui->buttonSubmit->setDisabled(true);
     ui->lineEditAddress->installEventFilter(this);
     ui->lineEditChangeAddress->installEventFilter(this);
+    ui->lineEditAssetData->installEventFilter(this);
     connect(ui->buttonClear, SIGNAL(clicked()), this, SLOT(clear()));
     connect(ui->buttonCheck, SIGNAL(clicked()), this, SLOT(check()));
     connect(ui->lineEditAddress, SIGNAL(textChanged(QString)), this, SLOT(dataChanged()));
     connect(ui->lineEditChangeAddress, SIGNAL(textChanged(QString)), this, SLOT(dataChanged()));
+    connect(ui->lineEditAssetData, SIGNAL(textChanged(QString)), this, SLOT(dataChanged()));
     connect(ui->checkBoxChangeAddress, SIGNAL(stateChanged(int)), this, SLOT(dataChanged()));
     connect(ui->checkBoxChangeAddress, SIGNAL(stateChanged(int)), this, SLOT(changeAddressChanged(int)));
     connect(ui->assetComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(dataChanged()));
@@ -50,6 +52,9 @@ AssignQualifier::AssignQualifier(const PlatformStyle *_platformStyle, QWidget *p
 
     ui->labelAssignType->setStyleSheet(STRING_LABEL_COLOR);
     ui->labelAssignType ->setFont(GUIUtil::getTopLabelFont());
+
+    ui->labelAssetData->setStyleSheet(STRING_LABEL_COLOR);
+    ui->labelAssetData ->setFont(GUIUtil::getTopLabelFont());
 
     ui->checkBoxChangeAddress->setStyleSheet(QString(".QCheckBox{ %1; }").arg(STRING_LABEL_COLOR));
 
@@ -86,7 +91,7 @@ void AssignQualifier::setWalletModel(WalletModel *model)
 
 bool AssignQualifier::eventFilter(QObject* object, QEvent* event)
 {
-    if((object == ui->lineEditAddress || object == ui->lineEditChangeAddress) && event->type() == QEvent::FocusIn) {
+    if((object == ui->lineEditAddress || object == ui->lineEditChangeAddress || object == ui->lineEditAssetData) && event->type() == QEvent::FocusIn) {
         static_cast<QLineEdit*>(object)->setStyleSheet(STYLE_VALID);
         // bring up your custom edit
         return false; // lets the event continue to the edit
@@ -126,9 +131,12 @@ void AssignQualifier::hideWarning()
 void AssignQualifier::clear()
 {
     ui->lineEditAddress->clear();
+    ui->lineEditAssetData->clear();
+    ui->lineEditChangeAddress->clear();
     ui->buttonSubmit->setDisabled(true);
     ui->lineEditAddress->setStyleSheet(STYLE_VALID);
     ui->lineEditChangeAddress->setStyleSheet(STYLE_VALID);
+    ui->lineEditAssetData->setStyleSheet(STYLE_VALID);
     ui->assignTypeComboBox->setCurrentIndex(0);
     hideWarning();
 }
@@ -178,6 +186,15 @@ void AssignQualifier::check()
                 ui->lineEditChangeAddress->setStyleSheet(STYLE_INVALID);
                 failed = true;
             }
+        }
+    }
+
+    if (ui->lineEditAssetData->text().size()) {
+        std::string strAssetData = ui->lineEditAssetData->text().toStdString();
+
+        if (DecodeAssetData(strAssetData).empty()) {
+            ui->lineEditAssetData->setStyleSheet(STYLE_INVALID);
+            failed = true;
         }
     }
 

--- a/src/qt/restrictedassignqualifier.h
+++ b/src/qt/restrictedassignqualifier.h
@@ -50,6 +50,8 @@ public:
     AssetFilterProxy *assetFilterProxy;
     QCompleter* completer;
 
+    void clear();
+
 private:
     Ui::AssignQualifier *ui;
     ClientModel *clientModel;
@@ -57,7 +59,6 @@ private:
     const PlatformStyle *platformStyle;
 
 private Q_SLOTS:
-    void clear();
     void check();
     void dataChanged();
     void changeAddressChanged(int);

--- a/src/qt/restrictedfreezeaddress.cpp
+++ b/src/qt/restrictedfreezeaddress.cpp
@@ -33,10 +33,12 @@ FreezeAddress::FreezeAddress(const PlatformStyle *_platformStyle, QWidget *paren
     ui->buttonSubmit->setDisabled(true);
     ui->lineEditAddress->installEventFilter(this);
     ui->lineEditChangeAddress->installEventFilter(this);
+    ui->lineEditAssetData->installEventFilter(this);
     connect(ui->buttonClear, SIGNAL(clicked()), this, SLOT(clear()));
     connect(ui->buttonCheck, SIGNAL(clicked()), this, SLOT(check()));
     connect(ui->lineEditAddress, SIGNAL(textChanged(QString)), this, SLOT(dataChanged()));
     connect(ui->lineEditChangeAddress, SIGNAL(textChanged(QString)), this, SLOT(dataChanged()));
+    connect(ui->lineEditAssetData, SIGNAL(textChanged(QString)), this, SLOT(dataChanged()));
     connect(ui->radioButtonFreezeAddress, SIGNAL(clicked()), this, SLOT(dataChanged()));
     connect(ui->radioButtonUnfreezeAddress, SIGNAL(clicked()), this, SLOT(dataChanged()));
     connect(ui->radioButtonGlobalFreeze, SIGNAL(clicked()), this, SLOT(dataChanged()));
@@ -52,6 +54,9 @@ FreezeAddress::FreezeAddress(const PlatformStyle *_platformStyle, QWidget *paren
 
     ui->labelAddress->setStyleSheet(STRING_LABEL_COLOR);
     ui->labelAddress->setFont(GUIUtil::getTopLabelFont());
+
+    ui->labelAssetData->setStyleSheet(STRING_LABEL_COLOR);
+    ui->labelAssetData->setFont(GUIUtil::getTopLabelFont());
 
     ui->checkBoxChangeAddress->setStyleSheet(QString(".QCheckBox{ %1; }").arg(STRING_LABEL_COLOR));
 
@@ -85,7 +90,7 @@ void FreezeAddress::setWalletModel(WalletModel *model)
 
 bool FreezeAddress::eventFilter(QObject* object, QEvent* event)
 {
-    if((object == ui->lineEditAddress || object == ui->lineEditChangeAddress) && event->type() == QEvent::FocusIn) {
+    if((object == ui->lineEditAddress || object == ui->lineEditChangeAddress || object == ui->lineEditAssetData) && event->type() == QEvent::FocusIn) {
         static_cast<QLineEdit*>(object)->setStyleSheet(STYLE_VALID);
         // bring up your custom edit
         return false; // lets the event continue to the edit
@@ -125,9 +130,12 @@ void FreezeAddress::hideWarning()
 void FreezeAddress::clear()
 {
     ui->lineEditAddress->clear();
+    ui->lineEditChangeAddress->clear();
+    ui->lineEditAssetData->clear();
     ui->buttonSubmit->setDisabled(true);
     ui->lineEditAddress->setStyleSheet(STYLE_VALID);
     ui->lineEditChangeAddress->setStyleSheet(STYLE_VALID);
+    ui->lineEditAssetData->setStyleSheet(STYLE_VALID);
     ui->radioButtonFreezeAddress->setChecked(true);
     hideWarning();
 }
@@ -190,6 +198,15 @@ void FreezeAddress::check()
                 ui->lineEditChangeAddress->setStyleSheet(STYLE_INVALID);
                 failed = true;
             }
+        }
+    }
+
+    if (ui->lineEditAssetData->text().size()) {
+        std::string strAssetData = ui->lineEditAssetData->text().toStdString();
+
+        if (DecodeAssetData(strAssetData).empty()) {
+            ui->lineEditAssetData->setStyleSheet(STYLE_INVALID);
+            failed = true;
         }
     }
 

--- a/src/qt/restrictedfreezeaddress.h
+++ b/src/qt/restrictedfreezeaddress.h
@@ -50,6 +50,8 @@ public:
     AssetFilterProxy *assetFilterProxy;
     QCompleter* completer;
 
+    void clear();
+
 private:
     Ui::FreezeAddress *ui;
     ClientModel *clientModel;
@@ -57,7 +59,6 @@ private:
     const PlatformStyle *platformStyle;
 
 private Q_SLOTS:
-    void clear();
     void check();
     void dataChanged();
     void globalOptionSelected();


### PR DESCRIPTION
- updated rpc calls to allow asset data to be added to the transaction
- update gui to allow for asset data to be added to the transaction

![image](https://user-images.githubusercontent.com/8285518/66784691-6b0d8a80-ee98-11e9-98fe-8c801f5d29c0.png)

![image](https://user-images.githubusercontent.com/8285518/66784721-79f43d00-ee98-11e9-96f8-1825ec12a315.png)

