### PR TITLE
Add support for wallets restricted address DB/Qt

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -133,7 +133,7 @@ RAVEN_CORE_H = \
   assets/assetdb.h \
   assets/assettypes.h \
   assets/messages.h \
-  assets/messagedb.h \
+  assets/myassetsdb.h \
   assets/restricteddb.h \
   base58.h \
   bloom.h \
@@ -263,7 +263,7 @@ libraven_server_a_SOURCES = \
   assets/assetdb.cpp \
   assets/assettypes.cpp \
   assets/messages.cpp \
-  assets/messagedb.cpp \
+  assets/myassetsdb.cpp \
   assets/restricteddb.cpp \
   policy/fees.cpp \
   policy/policy.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -152,6 +152,7 @@ QT_MOC_CPP = \
   qt/moc_optionsmodel.cpp \
   qt/moc_assettablemodel.cpp \
   qt/moc_overviewpage.cpp \
+  qt/moc_myrestrictedassettablemodel.cpp \
   qt/moc_peertablemodel.cpp \
   qt/moc_paymentserver.cpp \
   qt/moc_qvalidatedlineedit.cpp \
@@ -231,6 +232,8 @@ RAVEN_QT_H = \
   qt/macdockiconhandler.h \
   qt/macnotificationhandler.h \
   qt/modaloverlay.h \
+  qt/myrestrictedassettablemodel.h \
+  qt/myrestrictedassetrecord.h \
   qt/networkstyle.h \
   qt/notificator.h \
   qt/openuridialog.h \
@@ -420,6 +423,8 @@ RAVEN_QT_WALLET_CPP = \
   qt/editaddressdialog.cpp \
   qt/openuridialog.cpp \
   qt/overviewpage.cpp \
+  qt/myrestrictedassettablemodel.cpp \
+  qt/myrestrictedassetrecord.cpp \
   qt/paymentrequestplus.cpp \
   qt/paymentserver.cpp \
   qt/receivecoinsdialog.cpp \

--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -5006,7 +5006,7 @@ bool CheckVerifierAssetTxOut(const CTxOut& txout, std::string& strError)
     return true;
 }
 ///////////////
-bool ContextualCheckNullAssetTxOut(const CTxOut& txout, CAssetsCache* assetCache, std::string& strError)
+bool ContextualCheckNullAssetTxOut(const CTxOut& txout, CAssetsCache* assetCache, std::string& strError, std::vector<std::pair<std::string, CNullAssetTxData>>* myNullAssetData)
 {
     // Get the data from the script
     CNullAssetTxData data;
@@ -5031,6 +5031,14 @@ bool ContextualCheckNullAssetTxOut(const CTxOut& txout, CAssetsCache* assetCache
             return false;
         }
     }
+
+#ifdef ENABLE_WALLET
+    if (myNullAssetData && vpwallets.size()) {
+        if (IsMine(*vpwallets[0], DecodeDestination(address)) & ISMINE_ALL) {
+            myNullAssetData->emplace_back(std::make_pair(address, data));
+        }
+    }
+#endif
     return true;
 }
 

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -565,7 +565,7 @@ bool CheckNewAsset(const CNewAsset& asset, std::string& strError);
 bool CheckReissueAsset(const CReissueAsset& asset, std::string& strError);
 
 //// Contextual Check functions
-bool ContextualCheckNullAssetTxOut(const CTxOut& txout, CAssetsCache* assetCache, std::string& strError);
+bool ContextualCheckNullAssetTxOut(const CTxOut& txout, CAssetsCache* assetCache, std::string& strError, std::vector<std::pair<std::string, CNullAssetTxData>>* myNullAssetData = nullptr);
 bool ContextualCheckGlobalAssetTxOut(const CTxOut& txout, CAssetsCache* assetCache, std::string& strError);
 bool ContextualCheckVerifierAssetTxOut(const CTxOut& txout, CAssetsCache* assetCache, std::string& strError);
 bool ContextualCheckVerifierString(CAssetsCache* cache, const std::string& verifier, const std::string& check_address, std::string& strError, ErrorReport* errorReport = nullptr);

--- a/src/assets/messages.cpp
+++ b/src/assets/messages.cpp
@@ -8,7 +8,7 @@
 #include <script/ismine.h>
 #include <base58.h>
 #include "messages.h"
-#include "messagedb.h"
+#include "myassetsdb.h"
 #include <primitives/block.h>
 
 

--- a/src/assets/myassetsdb.h
+++ b/src/assets/myassetsdb.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef RAVENCOIN_MESSAGEDB_H
-#define RAVENCOIN_MESSAGEDB_H
+#ifndef RAVENCOIN_MYASSETSDB_H
+#define RAVENCOIN_MYASSETSDB_H
 
 #include <dbwrapper.h>
 
@@ -56,5 +56,27 @@ public:
     bool Flush();
 };
 
+class CMyRestrictedDB : public CDBWrapper {
+public:
+    explicit CMyRestrictedDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 
-#endif //RAVENCOIN_MESSAGEDB_H
+    CMyRestrictedDB(const CMyRestrictedDB&) = delete;
+    CMyRestrictedDB& operator=(const CMyRestrictedDB&) = delete;
+
+    bool WriteTaggedAddress(const std::string& address, const std::string& tag_name, const bool fAdd, const uint32_t& nHeight);
+    bool ReadTaggedAddress(const std::string& address, const std::string& tag_name, bool& fAdd, uint32_t& nHeight);
+    bool EraseTaggedAddress(const std::string& address, const std::string& tag_name);
+    bool LoadMyTaggedAddresses(std::vector<std::tuple<std::string, std::string, bool, uint32_t> >& vecTaggedAddresses);
+
+    bool WriteRestrictedAddress(const std::string& address, const std::string& tag_name, const bool fAdd, const uint32_t& nHeight);
+    bool ReadRestrictedAddress(const std::string& address, const std::string& tag_name, bool& fAdd, uint32_t& nHeight);
+    bool EraseRestrictedAddress(const std::string& address, const std::string& tag_name);
+    bool LoadMyRestrictedAddresses(std::vector<std::tuple<std::string, std::string, bool, uint32_t> >& vecRestrictedAddresses);
+
+    // Write / Read Database flags
+    bool WriteFlag(const std::string &name, bool fValue);
+    bool ReadFlag(const std::string &name, bool &fValue);
+};
+
+
+#endif //RAVENCOIN_MYASSETSDB_H

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -568,7 +568,7 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
 }
 
 //! Check to make sure that the inputs and outputs CAmount match exactly.
-bool Consensus::CheckTxAssets(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, CAssetsCache* assetCache, bool fCheckMempool, std::vector<std::pair<std::string, uint256> >& vPairReissueAssets, const bool fRunningUnitTests, std::set<CMessage>* setMessages, int64_t nBlocktime)
+bool Consensus::CheckTxAssets(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, CAssetsCache* assetCache, bool fCheckMempool, std::vector<std::pair<std::string, uint256> >& vPairReissueAssets, const bool fRunningUnitTests, std::set<CMessage>* setMessages, int64_t nBlocktime,   std::vector<std::pair<std::string, CNullAssetTxData>>* myNullAssetData)
 {
     // are the actual inputs available?
     if (!inputs.HaveInputs(tx)) {
@@ -633,7 +633,7 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, CValidationState& state, c
                                      "bad-tx-null-asset-data-before-restricted-assets-activated");
 
                 if (txout.scriptPubKey.IsNullAssetTxDataScript()) {
-                    if (!ContextualCheckNullAssetTxOut(txout, assetCache, strError))
+                    if (!ContextualCheckNullAssetTxOut(txout, assetCache, strError, myNullAssetData))
                         return state.DoS(100, false, REJECT_INVALID, strError);
                 } else if (txout.scriptPubKey.IsNullGlobalRestrictionAssetTxDataScript()) {
                     if (!ContextualCheckGlobalAssetTxOut(txout, assetCache, strError))

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -21,6 +21,7 @@ class CAssetsCache;
 class CTxOut;
 class uint256;
 class CMessage;
+class CNullAssetTxData;
 
 /** Transaction validation functions */
 
@@ -37,7 +38,7 @@ namespace Consensus {
 bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int nSpendHeight, CAmount& txfee);
 
 /** RVN START */
-bool CheckTxAssets(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, CAssetsCache* assetCache, bool fCheckMempool, std::vector<std::pair<std::string, uint256> >& vPairReissueAssets, const bool fRunningUnitTests = false, std::set<CMessage>* setMessages = nullptr, int64_t nBlocktime = 0);
+bool CheckTxAssets(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, CAssetsCache* assetCache, bool fCheckMempool, std::vector<std::pair<std::string, uint256> >& vPairReissueAssets, const bool fRunningUnitTests = false, std::set<CMessage>* setMessages = nullptr, int64_t nBlocktime = 0,  std::vector<std::pair<std::string, CNullAssetTxData>>* myNullAssetData = nullptr);
 /** RVN END */
 } // namespace Consensus
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -285,6 +285,9 @@ void PrepareShutdown()
         delete pmessagedb;
         pmessagedb = nullptr;
 
+        delete pmyrestricteddb;
+        pmyrestricteddb = nullptr;
+
         delete passetsVerifierCache;
         passetsVerifierCache = nullptr;
 
@@ -1523,6 +1526,9 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     delete pMessagesSeenAddressCache;
                     delete pMessageSubscribedChannelsCache;
 
+                    // My restricted assets
+                    delete pmyrestricteddb;
+
                     // Restricted assets
                     delete prestricteddb;
                     delete passetsVerifierCache;
@@ -1541,6 +1547,9 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     pMessagesSeenAddressCache = new CLRUCache<std::string, int>(1000);
                     pmessagedb = new CMessageDB(nBlockTreeDBCache, false, false);
                     pmessagechanneldb = new CMessageChannelDB(nBlockTreeDBCache, false, false);
+
+                    // My restricted assets
+                    pmyrestricteddb = new CMyRestrictedDB(nBlockTreeDBCache, false, false);
 
                     // Restricted assets
                     prestricteddb = new CRestrictedDB(nBlockTreeDBCache, false, fReset);

--- a/src/qt/forms/restrictedassetsdialog.ui
+++ b/src/qt/forms/restrictedassetsdialog.ui
@@ -167,7 +167,7 @@
            </layout>
           </item>
           <item>
-           <widget class="QListView" name="addressList"/>
+           <widget class="QTableView" name="myAddressList"/>
           </item>
          </layout>
         </item>

--- a/src/qt/myrestrictedassetrecord.cpp
+++ b/src/qt/myrestrictedassetrecord.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2011-2016 The Bitcoin Core developers
+// Copyright (c) 2017-2019 The Raven Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "myrestrictedassetrecord.h"
+
+#include "assets/assets.h"
+#include "base58.h"
+#include "consensus/consensus.h"
+#include "validation.h"
+#include "timedata.h"
+#include "wallet/wallet.h"
+
+#include <stdint.h>
+
+#include <QDebug>
+
+
+/* Return positive answer if transaction should be shown in list.
+ */
+bool MyRestrictedAssetRecord::showTransaction(const CWalletTx &wtx)
+{
+    // There are currently no cases where we hide transactions, but
+    // we may want to use this in the future for things like RBF.
+    return true;
+}
+
+
+/*
+ * Decompose CWallet transaction to model transaction records.
+ */
+QList<MyRestrictedAssetRecord> MyRestrictedAssetRecord::decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx)
+{
+    QList<MyRestrictedAssetRecord> parts;
+    int64_t nTime = wtx.GetTxTime();
+    uint256 hash = wtx.GetHash();
+    std::map<std::string, std::string> mapValue = wtx.mapValue;
+
+    for(unsigned int i = 0; i < wtx.tx->vout.size(); i++) {
+        const CTxOut &txout = wtx.tx->vout[i];
+        isminetype mine = ISMINE_NO;
+
+        if (txout.scriptPubKey.IsNullAssetTxDataScript()) {
+            CNullAssetTxData data;
+            std::string address;
+            if (!AssetNullDataFromScript(txout.scriptPubKey, data, address)) {
+                continue;
+            }
+            mine = IsMine(*wallet, DecodeDestination(address));
+            if (mine & ISMINE_ALL) {
+                MyRestrictedAssetRecord sub(hash, nTime);
+                sub.involvesWatchAddress = mine & ISMINE_SPENDABLE ? false : true;
+                sub.assetName = data.asset_name;
+                sub.address = address;
+
+                if (IsAssetNameAQualifier(data.asset_name)) {
+                    if (data.flag == (int) QualifierType::ADD_QUALIFIER) {
+                        sub.type = MyRestrictedAssetRecord::Type::Tagged;
+                    } else {
+                        sub.type = MyRestrictedAssetRecord::Type::UnTagged;
+                    }
+                } else if (IsAssetNameAnRestricted(data.asset_name)) {
+                    if (data.flag == (int) RestrictedType::FREEZE_ADDRESS) {
+                        sub.type = MyRestrictedAssetRecord::Type::Frozen;
+                    } else {
+                        sub.type = MyRestrictedAssetRecord::Type::UnFrozen;
+                    }
+                }
+                parts.append(sub);
+            }
+        }
+    }
+    return parts;
+}
+QString MyRestrictedAssetRecord::getTxID() const
+{
+    return QString::fromStdString(hash.ToString());
+}
+
+int MyRestrictedAssetRecord::getOutputIndex() const
+{
+    return idx;
+}

--- a/src/qt/myrestrictedassetrecord.h
+++ b/src/qt/myrestrictedassetrecord.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2011-2016 The Bitcoin Core developers
+// Copyright (c) 2017-2019 The Raven Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef RAVEN_QT_MYRESTRICTEDASSETRECORD_H
+#define RAVEN_QT_MYRESTRICTEDASSETRECORD
+
+#include "amount.h"
+#include "uint256.h"
+
+#include <QList>
+#include <QString>
+
+class CWallet;
+class CWalletTx;
+
+/** UI model for a transaction. A core transaction can be represented by multiple UI transactions if it has
+    multiple outputs.
+ */
+class MyRestrictedAssetRecord
+{
+public:
+    enum Type
+    {
+        Other,
+        Frozen,
+        UnFrozen,
+        Tagged,
+        UnTagged,
+    };
+
+    /** Number of confirmation recommended for accepting a transaction */
+    static const int RecommendedNumConfirmations = 6;
+
+    MyRestrictedAssetRecord():
+            hash(), time(0), type(Other), address(""), assetName("RVN"), idx(0)
+    {
+    }
+
+    MyRestrictedAssetRecord(uint256 _hash, qint64 _time):
+            hash(_hash), time(_time), type(Other), address(""), assetName("RVN"), idx(0)
+    {
+    }
+
+    MyRestrictedAssetRecord(uint256 _hash, qint64 _time,
+                      Type _type, const std::string &_address,
+                      const CAmount& _debit, const CAmount& _credit):
+            hash(_hash), time(_time), type(_type), address(_address),
+            assetName("RVN"), idx(0)
+    {
+    }
+
+    /** Decompose CWallet transaction to model transaction records.
+     */
+    static bool showTransaction(const CWalletTx &wtx);
+    static QList<MyRestrictedAssetRecord> decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx);
+
+    /** @name Immutable transaction attributes
+      @{*/
+    uint256 hash;
+    qint64 time;
+    Type type;
+    std::string address;
+    std::string assetName;
+    /**@}*/
+
+    /** Subtransaction index, for sort key */
+    int idx;
+
+    /** Whether the transaction was sent/received with a watch-only address */
+    bool involvesWatchAddress;
+
+    /** Return the unique identifier for this transaction (part) */
+    QString getTxID() const;
+
+    /** Return the output index of the subtransaction  */
+    int getOutputIndex() const;
+
+};
+
+#endif // RAVEN_QT_TRANSACTIONRECORD_H

--- a/src/qt/myrestrictedassettablemodel.cpp
+++ b/src/qt/myrestrictedassettablemodel.cpp
@@ -1,0 +1,547 @@
+// Copyright (c) 2011-2016 The Bitcoin Core developers
+// Copyright (c) 2017-2019 The Raven Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "myrestrictedassettablemodel.h"
+
+#include "addresstablemodel.h"
+#include "guiconstants.h"
+#include "guiutil.h"
+#include "optionsmodel.h"
+#include "platformstyle.h"
+#include "transactiondesc.h"
+#include "myrestrictedassetrecord.h"
+#include "walletmodel.h"
+
+#include "core_io.h"
+#include "validation.h"
+#include "sync.h"
+#include "uint256.h"
+#include "util.h"
+#include "wallet/wallet.h"
+
+#include <QColor>
+#include <QDateTime>
+#include <QDebug>
+#include <QIcon>
+#include <QList>
+
+// Amount column is right-aligned it contains numbers
+static int column_alignments[] = {
+        Qt::AlignLeft|Qt::AlignVCenter, /* date */
+        Qt::AlignLeft|Qt::AlignVCenter, /* type */
+        Qt::AlignLeft|Qt::AlignVCenter, /* address */
+        Qt::AlignLeft|Qt::AlignVCenter /* assetName */
+};
+
+// Comparison operator for sort/binary search of model tx list
+struct TxLessThan
+{
+    bool operator()(const MyRestrictedAssetRecord &a, const MyRestrictedAssetRecord &b) const
+    {
+        return a.hash < b.hash;
+    }
+    bool operator()(const MyRestrictedAssetRecord &a, const uint256 &b) const
+    {
+        return a.hash < b;
+    }
+    bool operator()(const uint256 &a, const MyRestrictedAssetRecord &b) const
+    {
+        return a < b.hash;
+    }
+};
+
+// Private implementation
+class MyRestrictedAssetsTablePriv
+{
+public:
+    MyRestrictedAssetsTablePriv(CWallet *_wallet, MyRestrictedAssetsTableModel *_parent) :
+            wallet(_wallet),
+            parent(_parent)
+    {
+    }
+
+    CWallet *wallet;
+    MyRestrictedAssetsTableModel *parent;
+
+    /* Local cache of wallet.
+     * As it is in the same order as the CWallet, by definition
+     * this is sorted by sha256.
+     */
+    QMap<QPair<QString,QString>,MyRestrictedAssetRecord> cacheMyAssetData;
+    QList<QPair<QString, QString> > vectAssetData;
+
+    /* Query entire wallet anew from core.
+     */
+    void refreshWallet()
+    {
+        qDebug() << "MyRestrictedAssetsTablePriv::refreshWallet";
+        cacheMyAssetData.clear();
+        vectAssetData.clear();
+        {
+            std::vector<std::tuple<std::string, std::string, bool, uint32_t> > myTaggedAddresses;
+            std::vector<std::tuple<std::string, std::string, bool, uint32_t> > myRestrictedAddresses;
+            pmyrestricteddb->LoadMyTaggedAddresses(myTaggedAddresses);
+            pmyrestricteddb->LoadMyRestrictedAddresses(myRestrictedAddresses);
+            myTaggedAddresses.insert(myTaggedAddresses.end(), myRestrictedAddresses.begin(), myRestrictedAddresses.end());
+            if(myTaggedAddresses.size()) {
+                for (auto item : myTaggedAddresses) {
+                    MyRestrictedAssetRecord sub;
+                    sub.address = std::get<0>(item);
+                    sub.assetName = std::get<1>(item);
+                    sub.time = std::get<3>(item);
+                    if (IsAssetNameAQualifier(sub.assetName))
+                        sub.type = std::get<2>(item) ? MyRestrictedAssetRecord::Type::Tagged : MyRestrictedAssetRecord::Type::UnTagged;
+                    else if (IsAssetNameAnRestricted(sub.assetName))
+                        sub.type = std::get<2>(item) ? MyRestrictedAssetRecord::Type::Frozen : MyRestrictedAssetRecord::Type::UnFrozen;
+                    sub.involvesWatchAddress = IsMine(*this->wallet, DecodeDestination(sub.address)) & ISMINE_WATCH_ONLY;
+                    vectAssetData.push_back(qMakePair(QString::fromStdString(std::get<0>(item)), QString::fromStdString(std::get<1>(item))));
+                    cacheMyAssetData[qMakePair(QString::fromStdString(std::get<0>(item)), QString::fromStdString(std::get<1>(item)))] = sub;
+                }
+            }
+        }
+    }
+
+    void updateMyRestrictedAssets(const QString &address, const QString& asset_name, const int type, const qint64& date) {
+        MyRestrictedAssetRecord rec;
+
+        if (IsAssetNameAQualifier(asset_name.toStdString())) {
+            rec.type = type ? MyRestrictedAssetRecord::Tagged : MyRestrictedAssetRecord::UnTagged;
+        } else {
+            rec.type = type ? MyRestrictedAssetRecord::Frozen : MyRestrictedAssetRecord::UnFrozen;
+        }
+
+        rec.time = date;
+        rec.assetName = asset_name.toStdString();
+        rec.address = address.toStdString();
+
+        QPair<QString, QString> pair(address, asset_name);
+        if (cacheMyAssetData.contains(pair)) {
+            rec.involvesWatchAddress = cacheMyAssetData[pair].involvesWatchAddress;
+            cacheMyAssetData[pair] = rec;
+        } else {
+            rec.involvesWatchAddress =
+                    IsMine(*this->wallet, DecodeDestination(address.toStdString())) & ISMINE_WATCH_ONLY ? true : false;
+            parent->beginInsertRows(QModelIndex(), 0, 0);
+            cacheMyAssetData[pair] = rec;
+            vectAssetData.push_front(pair);
+            parent->endInsertRows();
+        }
+    }
+
+    int size()
+    {
+        return cacheMyAssetData.size();
+    }
+
+    MyRestrictedAssetRecord *index(int idx)
+    {
+        if(idx >= 0 && idx < vectAssetData.size())
+        {
+            auto pair = vectAssetData[idx];
+            if (cacheMyAssetData.contains(pair)) {
+                MyRestrictedAssetRecord *rec = &cacheMyAssetData[pair];
+                return rec;
+            }
+        }
+        return 0;
+    }
+
+//    QString describe(TransactionRecord *rec, int unit)
+//    {
+//        {
+//            LOCK2(cs_main, wallet->cs_wallet);
+//            std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(rec->hash);
+//            if(mi != wallet->mapWallet.end())
+//            {
+//                return TransactionDesc::toHTML(wallet, mi->second, rec, unit);
+//            }
+//        }
+//        return QString();
+//    }
+
+//    QString getTxHex(TransactionRecord *rec)
+//    {
+//        LOCK2(cs_main, wallet->cs_wallet);
+//        std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(rec->hash);
+//        if(mi != wallet->mapWallet.end())
+//        {
+//            std::string strHex = EncodeHexTx(static_cast<CTransaction>(mi->second));
+//            return QString::fromStdString(strHex);
+//        }
+//        return QString();
+//    }
+};
+
+MyRestrictedAssetsTableModel::MyRestrictedAssetsTableModel(const PlatformStyle *_platformStyle, CWallet* _wallet, WalletModel *parent):
+        QAbstractTableModel(parent),
+        wallet(_wallet),
+        walletModel(parent),
+        priv(new MyRestrictedAssetsTablePriv(_wallet, this)),
+        fProcessingQueuedTransactions(false),
+        platformStyle(_platformStyle)
+{
+    columns << tr("Date") << tr("Type") << tr("Address") << tr("Asset Name");
+
+    priv->refreshWallet();
+
+    connect(walletModel->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
+
+    subscribeToCoreSignals();
+}
+
+MyRestrictedAssetsTableModel::~MyRestrictedAssetsTableModel()
+{
+    unsubscribeFromCoreSignals();
+    delete priv;
+}
+
+void MyRestrictedAssetsTableModel::updateMyRestrictedAssets(const QString &address, const QString& asset_name, const int type, const qint64 date)
+{
+    priv->updateMyRestrictedAssets(address, asset_name, type, date);
+}
+
+int MyRestrictedAssetsTableModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return priv->size();
+}
+
+int MyRestrictedAssetsTableModel::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return columns.length();
+}
+
+QString MyRestrictedAssetsTableModel::formatTxDate(const MyRestrictedAssetRecord *wtx) const
+{
+    if(wtx->time)
+    {
+        return GUIUtil::dateTimeStr(wtx->time);
+    }
+    return QString();
+}
+
+/* Look up address in address book, if found return label (address)
+   otherwise just return (address)
+ */
+QString MyRestrictedAssetsTableModel::lookupAddress(const std::string &address, bool tooltip) const
+{
+    QString label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(address));
+    QString description;
+    if(!label.isEmpty())
+    {
+        description += label;
+    }
+    if(label.isEmpty() || tooltip)
+    {
+        description += QString(" (") + QString::fromStdString(address) + QString(")");
+    }
+    return description;
+}
+
+QString MyRestrictedAssetsTableModel::formatTxType(const MyRestrictedAssetRecord *wtx) const
+{
+    switch(wtx->type)
+    {
+        case MyRestrictedAssetRecord::Tagged:
+            return tr("Tagged");
+        case MyRestrictedAssetRecord::UnTagged:
+            return tr("Untagged");
+        case MyRestrictedAssetRecord::Frozen:
+            return tr("Frozen");
+        case MyRestrictedAssetRecord::UnFrozen:
+            return tr("Unfrozen");
+        case MyRestrictedAssetRecord::Other:
+            return tr("Other");
+        default:
+            return QString();
+    }
+}
+
+QVariant MyRestrictedAssetsTableModel::txAddressDecoration(const MyRestrictedAssetRecord *wtx) const
+{
+    if (wtx->involvesWatchAddress)
+        return QIcon(":/icons/eye");
+
+    return QVariant();
+
+    // TODO get icons, and update when added
+//    switch(wtx->type)
+//    {
+//        case MyRestrictedAssetRecord::Tagged:
+//            return QIcon(":/icons/tx_mined");
+//        case MyRestrictedAssetRecord::UnTagged:
+//            return QIcon(":/icons/tx_input");
+//        case MyRestrictedAssetRecord::Frozen:
+//            return QIcon(":/icons/tx_output");
+//        case MyRestrictedAssetRecord::UnFrozen:
+//            return QIcon(":/icons/tx_asset_input");
+//        case MyRestrictedAssetRecord::Other:
+//            return QIcon(":/icons/tx_inout");
+//        default:
+//            return QIcon(":/icons/tx_inout");
+//    }
+}
+
+QString MyRestrictedAssetsTableModel::formatTxToAddress(const MyRestrictedAssetRecord *wtx, bool tooltip) const
+{
+    QString watchAddress;
+    if (tooltip) {
+        // Mark transactions involving watch-only addresses by adding " (watch-only)"
+        watchAddress = wtx->involvesWatchAddress ? QString(" (") + tr("watch-only") + QString(")") : "";
+    }
+
+    return QString::fromStdString(wtx->address) + watchAddress;
+}
+
+QVariant MyRestrictedAssetsTableModel::addressColor(const MyRestrictedAssetRecord *wtx) const
+{
+    return QVariant();
+}
+
+
+QVariant MyRestrictedAssetsTableModel::txWatchonlyDecoration(const MyRestrictedAssetRecord *wtx) const
+{
+    if (wtx->involvesWatchAddress)
+        return QIcon(":/icons/eye");
+    else
+        return QVariant();
+}
+
+QString MyRestrictedAssetsTableModel::formatTooltip(const MyRestrictedAssetRecord *rec) const
+{
+    QString tooltip = formatTxType(rec);
+    return tooltip;
+}
+
+QVariant MyRestrictedAssetsTableModel::data(const QModelIndex &index, int role) const
+{
+    if(!index.isValid())
+        return QVariant();
+    MyRestrictedAssetRecord *rec = static_cast<MyRestrictedAssetRecord*>(index.internalPointer());
+
+    switch(role)
+    {
+        case RawDecorationRole:
+            switch(index.column())
+            {
+                case ToAddress:
+                    return txAddressDecoration(rec);
+                case AssetName:
+                    return QString::fromStdString(rec->assetName);
+            }
+            break;
+        case Qt::DecorationRole:
+        {
+            QIcon icon = qvariant_cast<QIcon>(index.data(RawDecorationRole));
+            return platformStyle->TextColorIcon(icon);
+        }
+        case Qt::DisplayRole:
+            switch(index.column())
+            {
+                case Date:
+                    return formatTxDate(rec);
+                case Type:
+                    return formatTxType(rec);
+                case ToAddress:
+                    return formatTxToAddress(rec, false);
+                case AssetName:
+                    return QString::fromStdString(rec->assetName);
+            }
+            break;
+        case Qt::EditRole:
+            // Edit role is used for sorting, so return the unformatted values
+            switch(index.column())
+            {
+                case Date:
+                    return rec->time;
+                case Type:
+                    return formatTxType(rec);
+                case ToAddress:
+                    return formatTxToAddress(rec, true);
+                case AssetName:
+                    return QString::fromStdString(rec->assetName);
+            }
+            break;
+        case Qt::ToolTipRole:
+            return formatTooltip(rec);
+        case Qt::TextAlignmentRole:
+            return column_alignments[index.column()];
+        case Qt::ForegroundRole:
+            if(index.column() == ToAddress)
+            {
+                return addressColor(rec);
+            }
+            break;
+        case TypeRole:
+            return rec->type;
+        case DateRole:
+            return QDateTime::fromTime_t(static_cast<uint>(rec->time));
+        case WatchonlyRole:
+            return rec->involvesWatchAddress;
+        case WatchonlyDecorationRole:
+            return txWatchonlyDecoration(rec);
+        case AddressRole:
+            return QString::fromStdString(rec->address);
+        case LabelRole:
+            return walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(rec->address));
+        case TxIDRole:
+            return rec->getTxID();
+        case TxHashRole:
+            return QString::fromStdString(rec->hash.ToString());
+        case TxHexRole:
+            return ""; //priv->getTxHex(rec);
+        case TxPlainTextRole:
+        {
+            QString details;
+            QDateTime date = QDateTime::fromTime_t(static_cast<uint>(rec->time));
+            QString txLabel = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(rec->address));
+
+            details.append(date.toString("M/d/yy HH:mm"));
+            details.append(" ");
+            details.append(". ");
+            if(!formatTxType(rec).isEmpty()) {
+                details.append(formatTxType(rec));
+                details.append(" ");
+            }
+            if(!rec->address.empty()) {
+                if(txLabel.isEmpty())
+                    details.append(tr("(no label)") + " ");
+                else {
+                    details.append("(");
+                    details.append(txLabel);
+                    details.append(") ");
+                }
+                details.append(QString::fromStdString(rec->address));
+                details.append(" ");
+            }
+            return details;
+        }
+        case AssetNameRole:
+        {
+            QString assetName;
+            assetName.append(QString::fromStdString(rec->assetName));
+            return assetName;
+        }
+    }
+    return QVariant();
+}
+
+QVariant MyRestrictedAssetsTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(orientation == Qt::Horizontal)
+    {
+        if(role == Qt::DisplayRole)
+        {
+            return columns[section];
+        }
+        else if (role == Qt::TextAlignmentRole)
+        {
+            return column_alignments[section];
+        } else if (role == Qt::ToolTipRole)
+        {
+            switch(section)
+            {
+                case Date:
+                    return tr("Date and time that the transaction was received.");
+                case Type:
+                    return tr("Type of transaction.");
+                case ToAddress:
+                    return tr("User-defined intent/purpose of the transaction.");
+                case AssetName:
+                    return tr("The asset (or RVN) removed or added to balance.");
+            }
+        }
+    }
+    return QVariant();
+}
+
+QModelIndex MyRestrictedAssetsTableModel::index(int row, int column, const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    MyRestrictedAssetRecord *data = priv->index(row);
+    if(data)
+    {
+        return createIndex(row, column, priv->index(row));
+    }
+    return QModelIndex();
+}
+
+//// queue notifications to show a non freezing progress dialog e.g. for rescan
+struct MyRestrictedTransactionNotification
+{
+public:
+    MyRestrictedTransactionNotification() {}
+    MyRestrictedTransactionNotification(std::string _address, std::string _asset_name, int _type, uint32_t _date):
+            address(_address), asset_name(_asset_name), type(_type), date(_date) {}
+
+    void invoke(QObject *ttm)
+    {
+        QString strAddress = QString::fromStdString(address);
+        QString strName= QString::fromStdString(asset_name);
+        qDebug() << "MyRestrictedAssetChanged: " + strAddress + " asset_name= " + strName;
+        QMetaObject::invokeMethod(ttm, "updateMyRestrictedAssets", Qt::QueuedConnection,
+                                  Q_ARG(QString, strAddress),
+                                  Q_ARG(QString, strName),
+                                  Q_ARG(int, type),
+                                  Q_ARG(qint64, date));
+    }
+private:
+    std::string address;
+    std::string asset_name;
+    int type;
+    uint32_t date;
+};
+
+static bool fQueueNotifications = false;
+static std::vector< MyRestrictedTransactionNotification > vQueueNotifications;
+
+static void NotifyTransactionChanged(MyRestrictedAssetsTableModel *ttm, CWallet *wallet, const std::string& address, const std::string& asset_name,
+                                     int type, uint32_t date)
+{
+    MyRestrictedTransactionNotification notification(address, asset_name, type, date);
+
+    if (fQueueNotifications)
+    {
+        vQueueNotifications.push_back(notification);
+        return;
+    }
+    notification.invoke(ttm);
+}
+
+static void ShowProgress(MyRestrictedAssetsTableModel *ttm, const std::string &title, int nProgress)
+{
+    if (nProgress == 0)
+        fQueueNotifications = true;
+
+    if (nProgress == 100)
+    {
+        fQueueNotifications = false;
+        if (vQueueNotifications.size() > 10) // prevent balloon spam, show maximum 10 balloons
+            QMetaObject::invokeMethod(ttm, "setProcessingQueuedTransactions", Qt::QueuedConnection, Q_ARG(bool, true));
+        for (unsigned int i = 0; i < vQueueNotifications.size(); ++i)
+        {
+            if (vQueueNotifications.size() - i <= 10)
+                QMetaObject::invokeMethod(ttm, "setProcessingQueuedTransactions", Qt::QueuedConnection, Q_ARG(bool, false));
+
+            vQueueNotifications[i].invoke(ttm);
+        }
+        std::vector<MyRestrictedTransactionNotification >().swap(vQueueNotifications); // clear
+    }
+}
+
+void MyRestrictedAssetsTableModel::subscribeToCoreSignals()
+{
+    // Connect signals to wallet
+    wallet->NotifyMyRestrictedAssetsChanged.connect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3, _4, _5));
+    wallet->ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2));
+}
+
+void MyRestrictedAssetsTableModel::unsubscribeFromCoreSignals()
+{
+    // Disconnect signals from wallet
+    wallet->NotifyMyRestrictedAssetsChanged.disconnect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3, _4, _5));
+    wallet->ShowProgress.disconnect(boost::bind(ShowProgress, this, _1, _2));
+}

--- a/src/qt/myrestrictedassettablemodel.h
+++ b/src/qt/myrestrictedassettablemodel.h
@@ -1,0 +1,99 @@
+#include "ravenunits.h"
+
+#include <QAbstractTableModel>
+#include <QStringList>
+
+class PlatformStyle;
+class MyRestrictedAssetRecord;
+class MyRestrictedAssetsTablePriv;
+class WalletModel;
+
+class CWallet;
+
+/** UI model for the transaction table of a wallet.
+ */
+class MyRestrictedAssetsTableModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+public:
+    explicit MyRestrictedAssetsTableModel(const PlatformStyle *platformStyle, CWallet* wallet, WalletModel *parent = 0);
+    ~MyRestrictedAssetsTableModel();
+
+    enum ColumnIndex {
+        Date = 0,
+        Type = 1,
+        ToAddress = 2,
+        AssetName = 3
+    };
+
+    /** Roles to get specific information from a transaction row.
+        These are independent of column.
+    */
+    enum RoleIndex {
+        /** Type of transaction */
+                TypeRole = Qt::UserRole,
+        /** Date and time this transaction was created */
+                DateRole,
+        /** Watch-only boolean */
+                WatchonlyRole,
+        /** Watch-only icon */
+                WatchonlyDecorationRole,
+        /** Address of transaction */
+                AddressRole,
+        /** Label of address related to transaction */
+                LabelRole,
+        /** Unique identifier */
+                TxIDRole,
+        /** Transaction hash */
+                TxHashRole,
+        /** Transaction data, hex-encoded */
+                TxHexRole,
+        /** Whole transaction as plain text */
+                TxPlainTextRole,
+        /** Unprocessed icon */
+                RawDecorationRole,
+        /** RVN or name of an asset */
+                AssetNameRole,
+    };
+
+    int rowCount(const QModelIndex &parent) const;
+    int columnCount(const QModelIndex &parent) const;
+    QVariant data(const QModelIndex &index, int role) const;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+    QModelIndex index(int row, int column, const QModelIndex & parent = QModelIndex()) const;
+    bool processingQueuedTransactions() const { return fProcessingQueuedTransactions; }
+
+private:
+    CWallet* wallet;
+    WalletModel *walletModel;
+    QStringList columns;
+    MyRestrictedAssetsTablePriv *priv;
+    bool fProcessingQueuedTransactions;
+    const PlatformStyle *platformStyle;
+
+    void subscribeToCoreSignals();
+    void unsubscribeFromCoreSignals();
+
+    QString lookupAddress(const std::string &address, bool tooltip) const;
+    QVariant addressColor(const MyRestrictedAssetRecord *wtx) const;
+    QString formatTxDate(const MyRestrictedAssetRecord *wtx) const;
+    QString formatTxType(const MyRestrictedAssetRecord *wtx) const;
+    QString formatTxToAddress(const MyRestrictedAssetRecord *wtx, bool tooltip) const;
+    QString formatTooltip(const MyRestrictedAssetRecord *rec) const;
+    QVariant txStatusDecoration(const MyRestrictedAssetRecord *wtx) const;
+    QVariant txWatchonlyDecoration(const MyRestrictedAssetRecord *wtx) const;
+    QVariant txAddressDecoration(const MyRestrictedAssetRecord *wtx) const;
+
+public Q_SLOTS:
+    void updateMyRestrictedAssets(const QString &address, const QString& asset_name, const int type, const qint64 date);
+            /* New transaction, or transaction changed status */
+
+    /** Updates the column title to "Amount (DisplayUnit)" and emits headerDataChanged() signal for table headers to react. */
+    /* Needed to update fProcessingQueuedTransactions through a QueuedConnection */
+    void setProcessingQueuedTransactions(bool value) { fProcessingQueuedTransactions = value; }
+
+    friend class MyRestrictedAssetsTablePriv;
+};
+
+

--- a/src/qt/restrictedassetsdialog.cpp
+++ b/src/qt/restrictedassetsdialog.cpp
@@ -28,6 +28,7 @@
 #include "restrictedfreezeaddress.h"
 #include "ui_restrictedfreezeaddress.h"
 #include "sendcoinsdialog.h"
+#include "myrestrictedassettablemodel.h"
 
 #include <QGraphicsDropShadowEffect>
 #include <QFontMetrics>
@@ -82,6 +83,22 @@ void RestrictedAssetsDialog::setModel(WalletModel *_model)
         assetFilterProxy->setAssetNamePrefix("$");
         assetFilterProxy->setSortCaseSensitivity(Qt::CaseInsensitive);
         assetFilterProxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
+
+        myRestrictedAssetsFilterProxy = new QSortFilterProxyModel(this);
+        myRestrictedAssetsFilterProxy->setSourceModel(_model->getMyRestrictedAssetsTableModel());
+        myRestrictedAssetsFilterProxy->setDynamicSortFilter(true);
+        myRestrictedAssetsFilterProxy->setSortCaseSensitivity(Qt::CaseInsensitive);
+        myRestrictedAssetsFilterProxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
+
+        myRestrictedAssetsFilterProxy->setSortRole(Qt::EditRole);
+
+        ui->myAddressList->setModel(myRestrictedAssetsFilterProxy);
+        ui->myAddressList->horizontalHeader()->setStretchLastSection(true);
+        ui->myAddressList->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+        ui->myAddressList->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+        ui->myAddressList->setAlternatingRowColors(true);
+        ui->myAddressList->setSortingEnabled(true);
+        ui->myAddressList->verticalHeader()->hide();
 
         ui->listAssets->setModel(assetFilterProxy);
         ui->listAssets->horizontalHeader()->setStretchLastSection(true);

--- a/src/qt/restrictedassetsdialog.h
+++ b/src/qt/restrictedassetsdialog.h
@@ -18,6 +18,9 @@ class SendAssetsEntry;
 class SendCoinsRecipient;
 class AssetFilterProxy;
 class AssignQualifier;
+class MyRestrictedAssetsTableModel;
+class MyRestrictedAssetsFilterProxy;
+class QSortFilterProxyModel;
 
 
 namespace Ui {
@@ -55,6 +58,9 @@ private:
     WalletModel *model;
     const PlatformStyle *platformStyle;
     AssetFilterProxy *assetFilterProxy;
+    QSortFilterProxyModel *myRestrictedAssetsFilterProxy;
+
+    MyRestrictedAssetsTableModel *myRestrictedAssetsModel;
 
 private Q_SLOTS:
     void updateDisplayUnit();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -15,6 +15,7 @@
 #include "sendcoinsdialog.h"
 #include "transactiontablemodel.h"
 #include "assettablemodel.h"
+#include "myrestrictedassettablemodel.h"
 
 #include "base58.h"
 #include "chain.h"
@@ -55,6 +56,7 @@ WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, O
     transactionTableModel = new TransactionTableModel(platformStyle, wallet, this);
     assetTableModel = new AssetTableModel(this);
     recentRequestsTableModel = new RecentRequestsTableModel(wallet, this);
+    myRestrictedAssetsTableModel = new MyRestrictedAssetsTableModel(platformStyle, wallet, this);
 
     // This timer will be fired repeatedly to update the balance
     pollTimer = new QTimer(this);
@@ -448,6 +450,11 @@ AssetTableModel *WalletModel::getAssetTableModel()
     return assetTableModel;
 }
 
+MyRestrictedAssetsTableModel *WalletModel::getMyRestrictedAssetsTableModel()
+{
+    return myRestrictedAssetsTableModel;
+}
+
 RecentRequestsTableModel *WalletModel::getRecentRequestsTableModel()
 {
     return recentRequestsTableModel;
@@ -545,6 +552,16 @@ static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, 
     QMetaObject::invokeMethod(walletmodel, "updateTransaction", Qt::QueuedConnection);
 }
 
+static void NotifyMyRestrictedAssetChanged(WalletModel *walletmodel, CWallet *wallet, const std::string &address, const std::string& asset_name,  int type, uint32_t date)
+{
+    Q_UNUSED(wallet);
+    Q_UNUSED(address);
+    Q_UNUSED(asset_name);
+    Q_UNUSED(type);
+    Q_UNUSED(date);
+    QMetaObject::invokeMethod(walletmodel, "updateMyRestrictedAssets", Qt::QueuedConnection);
+}
+
 static void ShowProgress(WalletModel *walletmodel, const std::string &title, int nProgress)
 {
     // emits signal "showProgress"
@@ -565,6 +582,7 @@ void WalletModel::subscribeToCoreSignals()
     wallet->NotifyStatusChanged.connect(boost::bind(&NotifyKeyStoreStatusChanged, this, _1));
     wallet->NotifyAddressBookChanged.connect(boost::bind(NotifyAddressBookChanged, this, _1, _2, _3, _4, _5, _6));
     wallet->NotifyTransactionChanged.connect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
+    wallet->NotifyMyRestrictedAssetsChanged.connect(boost::bind(NotifyMyRestrictedAssetChanged, this, _1, _2, _3, _4, _5));
     wallet->ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2));
     wallet->NotifyWatchonlyChanged.connect(boost::bind(NotifyWatchonlyChanged, this, _1));
 }
@@ -575,6 +593,7 @@ void WalletModel::unsubscribeFromCoreSignals()
     wallet->NotifyStatusChanged.disconnect(boost::bind(&NotifyKeyStoreStatusChanged, this, _1));
     wallet->NotifyAddressBookChanged.disconnect(boost::bind(NotifyAddressBookChanged, this, _1, _2, _3, _4, _5, _6));
     wallet->NotifyTransactionChanged.disconnect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
+    wallet->NotifyMyRestrictedAssetsChanged.disconnect(boost::bind(NotifyMyRestrictedAssetChanged, this, _1, _2, _3, _4, _5));
     wallet->ShowProgress.disconnect(boost::bind(ShowProgress, this, _1, _2));
     wallet->NotifyWatchonlyChanged.disconnect(boost::bind(NotifyWatchonlyChanged, this, _1));
 }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -23,6 +23,7 @@ class RecentRequestsTableModel;
 class TransactionTableModel;
 class AssetTableModel;
 class WalletModelTransaction;
+class MyRestrictedAssetsTableModel;
 
 class CCoinControl;
 class CKeyID;
@@ -196,6 +197,7 @@ public:
     TransactionTableModel *getTransactionTableModel();
     AssetTableModel *getAssetTableModel();
     RecentRequestsTableModel *getRecentRequestsTableModel();
+    MyRestrictedAssetsTableModel *getMyRestrictedAssetsTableModel();
 
     CAmount getBalance(const CCoinControl *coinControl = nullptr) const;
     CAmount getUnconfirmedBalance() const;
@@ -306,6 +308,7 @@ private:
     TransactionTableModel *transactionTableModel;
     AssetTableModel *assetTableModel;
     RecentRequestsTableModel *recentRequestsTableModel;
+    MyRestrictedAssetsTableModel *myRestrictedAssetsTableModel;
 
     // Cache some values to be able to detect changes
     CAmount cachedBalance;

--- a/src/validation.h
+++ b/src/validation.h
@@ -36,7 +36,7 @@
 #include <assets/assets.h>
 #include <assets/assetdb.h>
 #include <assets/messages.h>
-#include <assets/messagedb.h>
+#include <assets/myassetsdb.h>
 #include <assets/restricteddb.h>
 
 class CBlockIndex;
@@ -524,6 +524,9 @@ extern CMessageDB *pmessagedb;
 
 /** Global variable that points to the message channel database (protected by cs_main) */
 extern CMessageChannelDB *pmessagechanneldb;
+
+/** Global variable that points to my wallets restricted database (protected by cs_main) */
+extern CMyRestrictedDB *pmyrestricteddb;
 
 /** Global variable that points to the active restricted asset database (protected by cs_main) */
 extern CRestrictedDB *prestricteddb;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4742,6 +4742,12 @@ bool CWallet::BackupWallet(const std::string& strDest)
     return dbw->Backup(strDest);
 }
 
+void CWallet::UpdateMyRestrictedAssets(std::string& address, std::string& asset_name, int type, uint32_t date)
+{
+    LOCK(cs_wallet);
+    NotifyMyRestrictedAssetsChanged(this, address, asset_name, type, date);
+}
+
 CKeyPool::CKeyPool()
 {
     nTime = GetTime();
@@ -4802,3 +4808,5 @@ bool CMerkleTx::AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& 
     return ::AcceptToMemoryPool(mempool, state, tx, nullptr /* pfMissingInputs */,
                                 nullptr /* plTxnReplaced */, false /* bypass_limits */, nAbsurdFee);
 }
+
+

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1122,6 +1122,9 @@ public:
     //! Flush wallet (bitdb flush)
     void Flush(bool shutdown=false);
 
+    void UpdateMyRestrictedAssets(std::string& address, std::string& asset_name,
+                                  int type, uint32_t date);
+
     /** 
      * Address book entry changed.
      * @note called with lock cs_wallet held.
@@ -1137,6 +1140,13 @@ public:
      */
     boost::signals2::signal<void (CWallet *wallet, const uint256 &hashTx,
             ChangeType status)> NotifyTransactionChanged;
+
+    /**
+     * Wallets Restricted Asset Address data added or updated.
+     * @note called with lock cs_wallet held.
+     */
+    boost::signals2::signal<void (CWallet *wallet, std::string& address, std::string& asset_name,
+                                  int type, uint32_t date)> NotifyMyRestrictedAssetsChanged;
 
     /** Show progress e.g. for rescan */
     boost::signals2::signal<void (const std::string &title, int nProgress)> ShowProgress;


### PR DESCRIPTION
- Add rpc call to view wallets tagged addresses
- Add rpc call to view wallets restricted addresses
- Added backend database to support wallet tagged and restricted addresses
- Added QT Table model to display when addresses are tagged or restricted