### PR TITLE
Fixing a few small test issues

### DIFF
--- a/test/functional/feature_assets_mempool.py
+++ b/test/functional/feature_assets_mempool.py
@@ -150,7 +150,7 @@ class AssetMempoolTest(RavenTestFramework):
     def run_test(self):
         self.activate_assets()
         self.issue_mempool_test()
-        self.issue_mempool_test_extended()te
+        self.issue_mempool_test_extended()
         self.issue_mempool_test_extended_sub()
 
 if __name__ == '__main__':

--- a/test/functional/feature_assets_mempool.py
+++ b/test/functional/feature_assets_mempool.py
@@ -46,7 +46,7 @@ class AssetMempoolTest(RavenTestFramework):
         # Issue asset on chain 2 but keep it in the mempool. No mining
         n1.issue(asset_name)
 
-        connect_all_nodes_bi(self.nodes)
+        connect_all_nodes_bi(self.nodes, True)
 
         # Assert that the reorg was successful
         assert_equal(n0.getblockcount(), n1.getblockcount())
@@ -150,7 +150,7 @@ class AssetMempoolTest(RavenTestFramework):
     def run_test(self):
         self.activate_assets()
         self.issue_mempool_test()
-        self.issue_mempool_test_extended()
+        self.issue_mempool_test_extended()te
         self.issue_mempool_test_extended_sub()
 
 if __name__ == '__main__':

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -79,7 +79,7 @@ BASE_SCRIPTS= [
     # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv Tests less than 45s vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     'rpc_fundrawtransaction.py',
     # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv Tests less than 30s vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-#    'wallet_basic.py',
+    'wallet_basic.py',
     'mempool_limit.py',
     'feature_assets.py',
     'feature_messaging.py',


### PR DESCRIPTION
- feature_assets_mempool.py - Intermittent failure because chain sync sometimes didn't finish in time, uses new functionality that waits for chans to sync before checking.
- feature_rawassettransactions.py - Intermittent failure, used same UTXO which would occasionally run out of funds and create transactions with negative values.  Now it checks and retrieves the first UTXO with a large enough balance.
- authproxy.py - Added an exception handler for unknown protocol, resolves a few intermittent failures.
- test_runner.py and wallet_basic.py - Last year I accidentally removed this test from the list of tests to run.  It was also broken due to fee changes and how RVN handles long chains in the mempool.  Also found an issue that is a bug on Bitcoin main in this test where the nodes are stopped and restarted several times in a row due to them being included in a for-each. Will have a PR against BTC for this shortly.