### PR TITLE
Functional test cleanup, stabilization, optimization, beautification

### DIFF
--- a/test/functional/feature_assets_reorg.py
+++ b/test/functional/feature_assets_reorg.py
@@ -63,7 +63,7 @@ class AssetReorgTest(RavenTestFramework):
         # self.log.info(n0.listmyassets())
         # self.log.info(n1.listmyassets())
         # Connect the nodes together, and force a reorg to occur
-        connect_all_nodes_bi(self.nodes)
+        connect_all_nodes_bi(self.nodes, True)
 
         # Uncomment to debug
         # self.log.info(f"{n0.getblockcount()}: {n0.getbestblockhash()}")
@@ -94,7 +94,7 @@ class AssetReorgTest(RavenTestFramework):
         assert_equal(True, n0.listmyassets('DOUBLE_TROUBLE2*') == n1.listmyassets('DOUBLE_TROUBLE2*'))
 
         # Connect the nodes together, and force a reorg to occur
-        connect_all_nodes_bi(self.nodes)
+        connect_all_nodes_bi(self.nodes, True)
 
         # Verify that node0 reorged to the node1 chain and that node1 has the asset and not node0
         assert_equal(n0.getblockcount(), node_1_height)

--- a/test/functional/interface_raven_cli.py
+++ b/test/functional/interface_raven_cli.py
@@ -25,12 +25,12 @@ class TestRavenCli(RavenTestFramework):
         user, password = get_auth_cookie(self.nodes[0].datadir)
 
         self.log.info("Test -stdinrpcpass option")
-        assert_equal(0, self.nodes[0].cli('-rpcuser=%s' % user, '-stdinrpcpass', input=password).getblockcount())
-        assert_raises_process_error(1, "incorrect rpcuser or rpcpassword", self.nodes[0].cli('-rpcuser=%s' % user, '-stdinrpcpass', input="foo").echo)
+        assert_equal(0, self.nodes[0].cli('-rpcuser=%s' % user, '-stdinrpcpass', input_data=password).getblockcount())
+        assert_raises_process_error(1, "incorrect rpcuser or rpcpassword", self.nodes[0].cli('-rpcuser=%s' % user, '-stdinrpcpass', input_data="foo").echo)
 
         self.log.info("Test -stdin and -stdinrpcpass")
-        assert_equal(["foo", "bar"], self.nodes[0].cli('-rpcuser=%s' % user, '-stdin', '-stdinrpcpass', input=password + "\nfoo\nbar").echo())
-        assert_raises_process_error(1, "incorrect rpcuser or rpcpassword", self.nodes[0].cli('-rpcuser=%s' % user, '-stdin', '-stdinrpcpass', input="foo").echo)
+        assert_equal(["foo", "bar"], self.nodes[0].cli('-rpcuser=%s' % user, '-stdin', '-stdinrpcpass', input_data=password + "\nfoo\nbar").echo())
+        assert_raises_process_error(1, "incorrect rpcuser or rpcpassword", self.nodes[0].cli('-rpcuser=%s' % user, '-stdin', '-stdinrpcpass', input_data="foo").echo)
 
         self.log.info("Compare responses from `raven-cli -getinfo` and the RPCs data is retrieved from.")
         cli_get_info = self.nodes[0].cli('-getinfo').help()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -43,7 +43,7 @@ class NetTest(RavenTestFramework):
         # the bytes sent/received should change
         # note ping and pong are 32 bytes each
         self.nodes[0].ping()
-        time.sleep(0.1)
+        time.sleep(1)
         peer_info_after_ping = self.nodes[0].getpeerinfo()
         net_totals_after_ping = self.nodes[0].getnettotals()
         for before, after in zip(peer_info, peer_info_after_ping):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -24,7 +24,7 @@ from .authproxy import JSONRPCException
 
 RAVEND_PROC_WAIT_TIMEOUT = 60
 
-class TestNode():
+class TestNode:
     """A class for representing a ravend node under test.
 
     This class contains:
@@ -163,7 +163,7 @@ class TestNode():
         self.encryptwallet(passphrase)
         self.wait_until_stopped()
 
-class TestNodeCLI():
+class TestNodeCLI:
     """Interface to raven-cli for an individual node"""
 
     def __init__(self, binary, datadir):
@@ -172,10 +172,10 @@ class TestNodeCLI():
         self.datadir = datadir
         self.input = None
 
-    def __call__(self, *args, input=None):
+    def __call__(self, *args, input_data=None):
         # TestNodeCLI is callable with raven-cli command-line args
         self.args = [str(arg) for arg in args]
-        self.input = input
+        self.input = input_data
         return self
 
     def __getattr__(self, command):


### PR DESCRIPTION
This PR adds some new functionality to the test runner.  It also speeds the running of the tests up (previously we slowed them down to help them run more consistently). It does this by getting the CPU count from the OS and running the same number of test threads simultaneously. 
The test results are now sorted so passed tests are at the top, failed at the bottom.  Passed tests are marked in green and failed tests in red.
A new command argument was added --FailFast.  If this flag is set the test runner will abort on the first test failure instead of continuing.
A second new argument was added --filter='regex, filter list'.  This uses regular expressions to allow the test runner to only run specific tests
The test runner display results is more compact than before. The dots indicating test running status are cleared after each test completes. As each test is run the full status is on one line instead of three. This is purely a cosmetic change that I'm working to setup a test result status output to a website or somewhere semi-public where test results for every build can be viewed.
There are also a few additional test tweaks to remove a couple of additional intermittent failures. The Wallet_Basic.py test is fixed and is back in the tests that will run (it was accidentally removed a year ago).
Image below comparing the old vs new test runner status and results:
![functional test runner new V old](https://user-images.githubusercontent.com/33036650/68168162-215b1180-ff25-11e9-9138-90ec7ad2abe0.png)
