### PR TITLE
Merging new btc tests and a new RPC call

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -19,8 +19,8 @@ max_height=313000
 # bootstrap.dat input/output settings (linearize-data)
 
 # mainnet
-netmagic=f9beb4d9
-genesis=000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+netmagic=43524f57
+genesis=0b2c703dc93bb63a36c4e33b85be4855ddbca2ac951a7a0a29b8de0408200a3c
 input=/home/example/.raven/blocks
 
 # testnet

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1502,9 +1502,9 @@ BOOST_FIXTURE_TEST_SUITE(script_tests, BasicTestingSetup)
 
     BOOST_AUTO_TEST_CASE(script_FindAndDelete_test)
     {
-        BOOST_TEST_MESSAGE("Running script FindAndDelete Test");
+        BOOST_TEST_MESSAGE("Running script find_and_delete Test");
 
-        // Exercise the FindAndDelete functionality
+        // Exercise the find_and_delete functionality
         CScript s;
         CScript d;
         CScript expect;
@@ -1541,7 +1541,7 @@ BOOST_FIXTURE_TEST_SUITE(script_tests, BasicTestingSetup)
 
         s = ScriptFromHex("0302ff030302ff03");
         d = ScriptFromHex("02");
-        expect = s; // FindAndDelete matches entire opcodes
+        expect = s; // find_and_delete matches entire opcodes
         BOOST_CHECK_EQUAL(s.FindAndDelete(d), 0);
         BOOST_CHECK(s == expect);
 
@@ -1586,13 +1586,13 @@ BOOST_FIXTURE_TEST_SUITE(script_tests, BasicTestingSetup)
 
         s = CScript() << OP_0 << OP_0 << OP_1 << OP_1;
         d = CScript() << OP_0 << OP_1;
-        expect = CScript() << OP_0 << OP_1; // FindAndDelete is single-pass
+        expect = CScript() << OP_0 << OP_1; // find_and_delete is single-pass
         BOOST_CHECK_EQUAL(s.FindAndDelete(d), 1);
         BOOST_CHECK(s == expect);
 
         s = CScript() << OP_0 << OP_0 << OP_1 << OP_0 << OP_1 << OP_1;
         d = CScript() << OP_0 << OP_1;
-        expect = CScript() << OP_0 << OP_1; // FindAndDelete is single-pass
+        expect = CScript() << OP_0 << OP_1; // find_and_delete is single-pass
         BOOST_CHECK_EQUAL(s.FindAndDelete(d), 2);
         BOOST_CHECK(s == expect);
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -24,7 +24,7 @@
 
 extern UniValue read_json(const std::string &jsondata);
 
-// Old script.cpp SignatureHash function
+// Old script.cpp signature_hash function
 uint256 static SignatureHashOld(CScript scriptCode, const CTransaction &txTo, unsigned int nIn, int nHashType)
 {
     static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
@@ -168,7 +168,7 @@ BOOST_FIXTURE_TEST_SUITE(sighash_tests, BasicTestingSetup)
     #endif
     }
 
-    // Goal: check that SignatureHash generates correct hash
+    // Goal: check that signature_hash generates correct hash
     BOOST_AUTO_TEST_CASE(sighash_from_data_test)
     {
         BOOST_TEST_MESSAGE("Running SigHas From Data Test");

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -28,9 +28,9 @@ BOOST_FIXTURE_TEST_SUITE(sigopcount_tests, BasicTestingSetup)
 
     BOOST_AUTO_TEST_CASE(GetSigOpCount_test)
     {
-        BOOST_TEST_MESSAGE("Running GetSigOpCount Test");
+        BOOST_TEST_MESSAGE("Running get_sig_op_count Test");
 
-        // Test CScript::GetSigOpCount()
+        // Test CScript::get_sig_op_count()
         CScript s1;
         BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 0U);
         BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 0U);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -129,7 +129,7 @@ public:
         ppmutexOpenSSL.reset(new CCriticalSection[CRYPTO_num_locks()]);
         CRYPTO_set_locking_callback(locking_callback);
 
-        // OpenSSL can optionally load a config file which lists omake ptional loadable modules and engines.
+        // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
         // We don't use them so we don't require the config. However some of our libs may call functions
         // which attempt to load the config file, possibly resulting in an exit() or crash if it is missing
         // or corrupt. Explicitly tell OpenSSL not to try to load the file. The result for our libs will be

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -129,7 +129,7 @@ public:
         ppmutexOpenSSL.reset(new CCriticalSection[CRYPTO_num_locks()]);
         CRYPTO_set_locking_callback(locking_callback);
 
-        // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
+        // OpenSSL can optionally load a config file which lists omake ptional loadable modules and engines.
         // We don't use them so we don't require the config. However some of our libs may call functions
         // which attempt to load the config file, possibly resulting in an exit() or crash if it is missing
         // or corrupt. Explicitly tell OpenSSL not to try to load the file. The result for our libs will be

--- a/test/functional/combine_logs.py
+++ b/test/functional/combine_logs.py
@@ -3,13 +3,16 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Combine logs from multiple raven nodes as well as the test_framework log.
+
+"""
+Combine logs from multiple raven nodes as well as the test_framework log.
 
 This streams the combined log output to stdout. Use combine_logs.py > outputfile
-to write to an outputfile."""
+to write to an outputfile.
+"""
 
 import argparse
-from collections import (defaultdict, namedtuple)
+from collections import defaultdict, namedtuple
 import heapq
 import itertools
 import os
@@ -89,6 +92,8 @@ def get_log_events(source, logfile):
     except FileNotFoundError:
         print("File %s could not be opened. Continuing without it." % logfile, file=sys.stderr)
 
+
+# noinspection PyProtectedMember
 def print_logs(log_events, color=False, html=False):
     """Renders the iterator of log events into text or html."""
     if not html:

--- a/test/functional/create_cache.py
+++ b/test/functional/create_cache.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Create a blockchain cache.
+
+"""
+Create a blockchain cache.
 
 Creating a cache of the blockchain speeds up test execution when running
 multiple functional tests. This helper script is executed by test_runner when multiple

--- a/test/functional/feature_assets.py
+++ b/test/functional/feature_assets.py
@@ -3,12 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Testing asset use cases
 
-"""
+"""Testing asset use cases"""
+
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, assert_is_hash_string, assert_does_not_contain_key, assert_raises_rpc_error, JSONRPCException, Decimal)
-
+from test_framework.util import assert_equal, assert_is_hash_string, assert_does_not_contain_key, assert_raises_rpc_error, JSONRPCException, Decimal
 
 import string
 
@@ -35,7 +34,7 @@ class AssetTest(RavenTestFramework):
         self.log.info("Calling issue()...")
         address0 = n0.getnewaddress()
         ipfs_hash = "QmcvyefkqQX3PpjpY5L8B2yMd47XrVwAipr6cxUt2zvYU8"
-        n0.issue(asset_name="MY_ASSET", qty=1000, to_address=address0, change_address="", \
+        n0.issue(asset_name="MY_ASSET", qty=1000, to_address=address0, change_address="",
                  units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
 
         self.log.info("Waiting for ten confirmations after issue...")
@@ -62,8 +61,7 @@ class AssetTest(RavenTestFramework):
         assert_equal(len(myassets["MY_ASSET"]["outpoints"]), 1)
         assert_equal(len(myassets["MY_ASSET!"]["outpoints"]), 1)
         assert_is_hash_string(myassets["MY_ASSET"]["outpoints"][0]["txid"])
-        assert_equal(myassets["MY_ASSET"]["outpoints"][0]["txid"], \
-                     myassets["MY_ASSET!"]["outpoints"][0]["txid"])
+        assert_equal(myassets["MY_ASSET"]["outpoints"][0]["txid"], myassets["MY_ASSET!"]["outpoints"][0]["txid"])
         assert(int(myassets["MY_ASSET"]["outpoints"][0]["vout"]) >= 0)
         assert(int(myassets["MY_ASSET!"]["outpoints"][0]["vout"]) >= 0)
         assert_equal(myassets["MY_ASSET"]["outpoints"][0]["amount"], 1000)
@@ -103,10 +101,10 @@ class AssetTest(RavenTestFramework):
         assert_equal(sum(n0.listaddressesbyasset("MY_ASSET").values()), 1000)
         assert_equal(sum(n1.listaddressesbyasset("MY_ASSET").values()), 1000)
         for assaddr in n0.listaddressesbyasset("MY_ASSET").keys():
-            if n0.validateaddress(assaddr)["ismine"] == True:
+            if n0.validateaddress(assaddr)["ismine"]:
                 changeaddress = assaddr
                 assert_equal(n0.listassetbalancesbyaddress(changeaddress)["MY_ASSET"], 800)
-        assert(changeaddress != None)
+        assert(changeaddress is not None)
         assert_equal(n0.listassetbalancesbyaddress(address0)["MY_ASSET!"], 1)
 
         self.log.info("Burning all units to test reissue on zero units...")
@@ -117,8 +115,7 @@ class AssetTest(RavenTestFramework):
         self.log.info("Calling reissue()...")
         address1 = n0.getnewaddress()
         ipfs_hash2 = "QmcvyefkqQX3PpjpY5L8B2yMd47XrVwAipr6cxUt2zvYU8"
-        n0.reissue(asset_name="MY_ASSET", qty=2000, to_address=address0, change_address=address1, \
-                   reissuable=False, new_unit=-1, new_ipfs=ipfs_hash2)
+        n0.reissue(asset_name="MY_ASSET", qty=2000, to_address=address0, change_address=address1, reissuable=False, new_unit=-1, new_ipfs=ipfs_hash2)
 
         self.log.info("Waiting for ten confirmations after reissue...")
         self.sync_all()
@@ -147,8 +144,7 @@ class AssetTest(RavenTestFramework):
         n0.listassets(asset="RAVEN*", verbose=False, count=2, start=-2)
 
         self.log.info("Creating some sub-assets...")
-        n0.issue(asset_name="MY_ASSET/SUB1", qty=1000, to_address=address0, change_address=address0,\
-                 units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
+        n0.issue(asset_name="MY_ASSET/SUB1", qty=1000, to_address=address0, change_address=address0, units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
 
         self.sync_all()
         self.log.info("Waiting for ten confirmations after issuesubasset...")
@@ -175,22 +171,16 @@ class AssetTest(RavenTestFramework):
         n0 = self.nodes[0]
 
         # just plain bad asset name
-        assert_raises_rpc_error(-8, "Invalid asset name: bad-asset-name", \
-            n0.issue, "bad-asset-name")
+        assert_raises_rpc_error(-8, "Invalid asset name: bad-asset-name", n0.issue, "bad-asset-name")
 
         # trying to issue things that can't be issued
-        assert_raises_rpc_error(-8, "Unsupported asset type: OWNER", \
-            n0.issue, "AN_OWNER!")
-        assert_raises_rpc_error(-8, "Unsupported asset type: VOTE", \
-            n0.issue, "A_VOTE^PEDRO")
+        assert_raises_rpc_error(-8, "Unsupported asset type: OWNER", n0.issue, "AN_OWNER!")
+        assert_raises_rpc_error(-8, "Unsupported asset type: VOTE", n0.issue, "A_VOTE^PEDRO")
 
         # check bad unique params
-        assert_raises_rpc_error(-8, "Invalid parameters for issuing a unique asset.", \
-            n0.issue, "A_UNIQUE#ASSET", 2)
-        assert_raises_rpc_error(-8, "Invalid parameters for issuing a unique asset.", \
-            n0.issue, "A_UNIQUE#ASSET", 1, "", "", 1)
-        assert_raises_rpc_error(-8, "Invalid parameters for issuing a unique asset.", \
-            n0.issue, "A_UNIQUE#ASSET", 1, "", "", 0, True)
+        assert_raises_rpc_error(-8, "Invalid parameters for issuing a unique asset.", n0.issue, "A_UNIQUE#ASSET", 2)
+        assert_raises_rpc_error(-8, "Invalid parameters for issuing a unique asset.", n0.issue, "A_UNIQUE#ASSET", 1, "", "", 1)
+        assert_raises_rpc_error(-8, "Invalid parameters for issuing a unique asset.", n0.issue, "A_UNIQUE#ASSET", 1, "", "", 0, True)
 
     def chain_assets(self):
         self.log.info("Issuing chained assets in depth issue()...")
@@ -199,15 +189,13 @@ class AssetTest(RavenTestFramework):
         chain_address = n0.getnewaddress()
         ipfs_hash = "QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"
         chain_string = "CHAIN1"
-        n0.issue(asset_name=chain_string, qty=1000, to_address=chain_address, change_address="", \
-                 units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
+        n0.issue(asset_name=chain_string, qty=1000, to_address=chain_address, change_address="", units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
 
         for c in string.ascii_uppercase:
             chain_string += '/' + c
             if len(chain_string) > 30:
                 break
-            n0.issue(asset_name=chain_string, qty=1000, to_address=chain_address, change_address="", \
-                     units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
+            n0.issue(asset_name=chain_string, qty=1000, to_address=chain_address, change_address="", units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
 
         n0.generate(1)
         self.sync_all()
@@ -218,14 +206,12 @@ class AssetTest(RavenTestFramework):
         self.log.info("Issuing chained assets in width issue()...")
         chain_address = n0.getnewaddress()
         chain_string = "CHAIN2"
-        n0.issue(asset_name=chain_string, qty=1000, to_address=chain_address, change_address="", \
-                 units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
+        n0.issue(asset_name=chain_string, qty=1000, to_address=chain_address, change_address="", units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
 
         for c in string.ascii_uppercase:
             asset_name = chain_string + '/' + c
 
-            n0.issue(asset_name=asset_name, qty=1000, to_address=chain_address, change_address="", \
-                     units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
+            n0.issue(asset_name=asset_name, qty=1000, to_address=chain_address, change_address="", units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
 
         n0.generate(1)
         self.sync_all()
@@ -235,21 +221,18 @@ class AssetTest(RavenTestFramework):
 
         self.log.info("Chaining reissue transactions...")
         address0 = n0.getnewaddress()
-        n0.issue(asset_name="CHAIN_REISSUE", qty=1000, to_address=address0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="CHAIN_REISSUE", qty=1000, to_address=address0, change_address="", units=4, reissuable=True, has_ipfs=False)
 
         n0.generate(1)
         self.sync_all()
 
-        n0.reissue(asset_name="CHAIN_REISSUE", qty=1000, to_address=address0, change_address="", \
-                   reissuable=True)
+        n0.reissue(asset_name="CHAIN_REISSUE", qty=1000, to_address=address0, change_address="", reissuable=True)
         assert_raises_rpc_error(-4, "Error: The transaction was rejected! Reason given: bad-tx-reissue-chaining-not-allowed", n0.reissue, "CHAIN_REISSUE", 1000, address0, "", True)
 
         n0.generate(1)
         self.sync_all()
 
-        n0.reissue(asset_name="CHAIN_REISSUE", qty=1000, to_address=address0, change_address="", \
-                   reissuable=True)
+        n0.reissue(asset_name="CHAIN_REISSUE", qty=1000, to_address=address0, change_address="", reissuable=True)
 
         n0.generate(1)
         self.sync_all()
@@ -276,8 +259,7 @@ class AssetTest(RavenTestFramework):
         # bad hash (isn't a valid multihash sha2-256)
         self.log.info("Testing issue asset with invalid IPFS...")
         try:
-            n0.issue(asset_name=asset_name1, qty=1000, to_address=address1, change_address=address2, \
-                     units=0, reissuable=True, has_ipfs=True, ipfs_hash=bad_hash)
+            n0.issue(asset_name=asset_name1, qty=1000, to_address=address1, change_address=address2, units=0, reissuable=True, has_ipfs=True, ipfs_hash=bad_hash)
         except JSONRPCException as e:
             if "Invalid IPFS/Txid hash" not in e.error['message']:
                 raise AssertionError("Expected substring not found:" + e.error['message'])
@@ -289,8 +271,7 @@ class AssetTest(RavenTestFramework):
         ########################################
         # no hash
         self.log.info("Testing issue asset with no IPFS...")
-        n0.issue(asset_name=asset_name2, qty=1000, to_address=address1, change_address=address2, \
-                 units=0, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name=asset_name2, qty=1000, to_address=address1, change_address=address2, units=0, reissuable=True, has_ipfs=False)
         n0.generate(1)
         ad = n0.getassetdata(asset_name2)
         assert_equal(0, ad['has_ipfs'])
@@ -300,8 +281,7 @@ class AssetTest(RavenTestFramework):
         # reissue w/ bad hash
         self.log.info("Testing re-issue asset with invalid IPFS...")
         try:
-            n0.reissue(asset_name=asset_name2, qty=2000, to_address=address1, change_address=address2, \
-                       reissuable=True, new_unit=-1, new_ipfs=bad_hash)
+            n0.reissue(asset_name=asset_name2, qty=2000, to_address=address1, change_address=address2, reissuable=True, new_unit=-1, new_ipfs=bad_hash)
         except JSONRPCException as e:
             if "Invalid IPFS/Txid hash" not in e.error['message']:
                 raise AssertionError("Expected substring not found:" + e.error['message'])
@@ -313,8 +293,7 @@ class AssetTest(RavenTestFramework):
         ########################################
         # reissue w/ hash
         self.log.info("Testing re-issue asset with valid IPFS...")
-        n0.reissue(asset_name=asset_name2, qty=2000, to_address=address1, change_address=address2, \
-                   reissuable=True, new_unit=-1, new_ipfs=ipfs_hash)
+        n0.reissue(asset_name=asset_name2, qty=2000, to_address=address1, change_address=address2, reissuable=True, new_unit=-1, new_ipfs=ipfs_hash)
         n0.generate(1)
         ad = n0.getassetdata(asset_name2)
         assert_equal(1, ad['has_ipfs'])
@@ -342,6 +321,7 @@ class AssetTest(RavenTestFramework):
         a = n0.generate(1)[0]
 
         n0.reissue(asset_name, 500, n0.getnewaddress())
+        # noinspection PyStatementEffect
         n0.generate(1)[0]
 
         self.log.info(f"Invalidating {a}...")
@@ -365,40 +345,12 @@ class AssetTest(RavenTestFramework):
             n0.reissue(asset_name, 10.0**(-i), address, "", True, i+1)
             n0.generate(1)
             assert_equal(i+1, n0.listassets("*", True)[asset_name]["units"])
-            assert_raises_rpc_error(-25, "Error: Unable to reissue asset: unit must be larger than current unit selection", \
-                                    n0.reissue, asset_name, 10.0**(-i), address, "", True, i)
+            assert_raises_rpc_error(-25, "Error: Unable to reissue asset: unit must be larger than current unit selection", n0.reissue, asset_name, 10.0**(-i), address, "", True, i)
 
         n0.reissue(asset_name, 0.00000001, address)
         n0.generate(1)
         assert_equal(Decimal('11.11111111'), n0.listassets("*", True)[asset_name]["amount"])
 
-
-    def issue_transfer_change(self):
-        self.log.info("Testing specified RVN and asset change on issue and transfer...")
-        n0 = self.nodes[0]
-
-        asset_name = "TRC"
-        issue_qty = 50
-        issue_address = n0.getnewaddress()
-        issue_rvn_change = n0.getnewaddress()
-
-        assert_equal(0, n0.getreceivedbyaddress(issue_rvn_change))
-        n0.issue(asset_name, issue_qty, issue_address, issue_rvn_change)
-        n0.generate(1)
-        assert(n0.getreceivedbyaddress(issue_rvn_change) > 0)
-
-        transfer_address = n0.getnewaddress()
-        transfer_asset_change = n0.getnewaddress()
-        transfer_rvn_change = n0.getnewaddress()
-        transfer_qty = 5
-        change_qty = issue_qty - transfer_qty
-
-        assert_equal(0, n0.getreceivedbyaddress(transfer_rvn_change))
-        n0.transfer(asset_name, 5, transfer_address, "", 0, transfer_rvn_change, transfer_asset_change)
-        n0.generate(1)
-        assert(n0.getreceivedbyaddress(transfer_rvn_change) > 0)
-        assert_equal(transfer_qty, n0.listassetbalancesbyaddress(transfer_address)[asset_name])
-        assert_equal(change_qty, n0.listassetbalancesbyaddress(transfer_asset_change)[asset_name])
 
     def run_test(self):
         self.activate_assets()
@@ -408,7 +360,6 @@ class AssetTest(RavenTestFramework):
         self.ipfs_state()
         self.db_corruption_regression()
         self.reissue_prec_change()
-        self.issue_transfer_change()
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_assets_mempool.py
+++ b/test/functional/feature_assets_mempool.py
@@ -3,14 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Testing asset mempool use cases
 
-"""
+"""Testing asset mempool use cases"""
+
 from test_framework.test_framework import RavenTestFramework
 from test_framework.util import assert_equal, disconnect_all_nodes, connect_all_nodes_bi
-
-
-import string
 
 class AssetMempoolTest(RavenTestFramework):
     def set_test_params(self):
@@ -68,8 +65,7 @@ class AssetMempoolTest(RavenTestFramework):
 
         # Reissue that asset
         address1 = n0.getnewaddress()
-        n0.reissue(asset_name=asset_name, qty=2000, to_address=address1, change_address='', \
-                   reissuable=True, new_unit=-1)
+        n0.reissue(asset_name=asset_name, qty=2000, to_address=address1, change_address='', reissuable=True, new_unit=-1)
         n0.generate(15)
 
         # Get a transfer address
@@ -91,7 +87,7 @@ class AssetMempoolTest(RavenTestFramework):
         # Connect the nodes, a reorg should occur
         connect_all_nodes_bi(self.nodes, True)
 
-        # Asset the reorg occured
+        # Asset the reorg occurred
         assert_equal(n0.getblockcount(), n1.getblockcount())
         assert_equal(n0.getbestblockhash(), n1.getbestblockhash())
 

--- a/test/functional/feature_assets_reorg.py
+++ b/test/functional/feature_assets_reorg.py
@@ -3,14 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Testing asset reorg use cases
 
-"""
+"""Testing asset reorg use cases"""
+
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, disconnect_all_nodes, connect_all_nodes_bi)
-
-
-import string
+from test_framework.util import assert_equal, disconnect_all_nodes, connect_all_nodes_bi
 
 class AssetReorgTest(RavenTestFramework):
     def set_test_params(self):
@@ -115,7 +112,6 @@ class AssetReorgTest(RavenTestFramework):
         # Mine 44 blocks on chain 2
         n1.generate(20)
         node_1_hash_20 = n1.getbestblockhash()
-        node_1_height_20 = n1.getblockcount()
 
         n1.generate(24)
         node_1_hash_44 = n1.getbestblockhash()

--- a/test/functional/feature_bip_softforks.py
+++ b/test/functional/feature_bip_softforks.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test BIP 9 soft forks.
+
+"""
+Test BIP 9 soft forks.
 
 Connect to a single node.
 regtest lock-in with 108/144 block signalling
@@ -16,11 +18,11 @@ mine a further 143 blocks (LOCKED_IN)
 test that enforcement has not triggered (which triggers ACTIVE)
 test that enforcement has triggered
 """
+
 from io import BytesIO
 import shutil
 import time
 import itertools
-
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.util import hex_str_to_bytes, bytes_to_hex_str, assert_equal
 from test_framework.mininode import CTransaction, NetworkThread
@@ -40,7 +42,8 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         NetworkThread().start() # Start up network handling in another thread
         self.test.run()
 
-    def create_transaction(self, node, coinbase, to_address, amount):
+    @staticmethod
+    def create_transaction(node, coinbase, to_address, amount):
         from_txid = node.getblock(coinbase)['tx'][0]
         inputs = [{ "txid" : from_txid, "vout" : 0}]
         outputs = { to_address : amount }
@@ -51,14 +54,17 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         tx.nVersion = 2
         return tx
 
-    def sign_transaction(self, node, tx):
+    @staticmethod
+    def sign_transaction(node, tx):
         signresult = node.signrawtransaction(bytes_to_hex_str(tx.serialize()))
         tx = CTransaction()
         f = BytesIO(hex_str_to_bytes(signresult['hex']))
         tx.deserialize(f)
         return tx
 
-    def generate_blocks(self, number, version, test_blocks = []):
+    def generate_blocks(self, number, version, test_blocks=None):
+        if test_blocks is None:
+            test_blocks = []
         for _ in range(number):
             block = create_block(self.tip, create_coinbase(self.height), self.last_block_time + 1)
             block.nVersion = version
@@ -74,9 +80,9 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         info = self.nodes[0].getblockchaininfo()
         return info['bip9_softforks'][key]
 
-    def test_BIP(self, bipName, activated_version, invalidate, invalidatePostSignature, bitno):
-        assert_equal(self.get_bip9_status(bipName)['status'], 'defined')
-        assert_equal(self.get_bip9_status(bipName)['since'], 0)
+    def test_bip(self, bip_name, activated_version, invalidate, invalidate_post_signature, bit_no):
+        assert_equal(self.get_bip9_status(bip_name)['status'], 'defined')
+        assert_equal(self.get_bip9_status(bip_name)['since'], 0)
 
         # generate some coins for later
         self.coinbase_blocks = self.nodes[0].generate(2)
@@ -85,11 +91,11 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         self.nodeaddress = self.nodes[0].getnewaddress()
         self.last_block_time = int(time.time())
 
-        assert_equal(self.get_bip9_status(bipName)['status'], 'defined')
-        assert_equal(self.get_bip9_status(bipName)['since'], 0)
+        assert_equal(self.get_bip9_status(bip_name)['status'], 'defined')
+        assert_equal(self.get_bip9_status(bip_name)['since'], 0)
         tmpl = self.nodes[0].getblocktemplate({})
-        assert(bipName not in tmpl['rules'])
-        assert(bipName not in tmpl['vbavailable'])
+        assert(bip_name not in tmpl['rules'])
+        assert(bip_name not in tmpl['vbavailable'])
         assert_equal(tmpl['vbrequired'], 0)
         assert_equal(tmpl['version'], 0x20000000)
 
@@ -98,44 +104,44 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         test_blocks = self.generate_blocks(141, 4)
         yield TestInstance(test_blocks, sync_every_block=False)
 
-        assert_equal(self.get_bip9_status(bipName)['status'], 'started')
-        assert_equal(self.get_bip9_status(bipName)['since'], 144)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['elapsed'], 0)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['count'], 0)
+        assert_equal(self.get_bip9_status(bip_name)['status'], 'started')
+        assert_equal(self.get_bip9_status(bip_name)['since'], 144)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['elapsed'], 0)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['count'], 0)
         tmpl = self.nodes[0].getblocktemplate({})
-        assert(bipName not in tmpl['rules'])
-        assert_equal(tmpl['vbavailable'][bipName], bitno)
+        assert(bip_name not in tmpl['rules'])
+        assert_equal(tmpl['vbavailable'][bip_name], bit_no)
         assert_equal(tmpl['vbrequired'], 0)
         assert(tmpl['version'] & activated_version)
 
         # Test 1-A
         # check stats after max number of "signalling not" blocks such that LOCKED_IN still possible this period
-        test_blocks = self.generate_blocks(36, 4, test_blocks) # 0x00000004 (signalling not)
+        self.generate_blocks(36, 4, test_blocks) # 0x00000004 (signalling not)
         test_blocks = self.generate_blocks(10, activated_version) # 0x20000001 (signalling ready)
         yield TestInstance(test_blocks, sync_every_block=False)
 
-        assert_equal(self.get_bip9_status(bipName)['statistics']['elapsed'], 46)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['count'], 10)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['possible'], True)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['elapsed'], 46)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['count'], 10)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['possible'], True)
 
         # Test 1-B
         # check stats after one additional "signalling not" block --  LOCKED_IN no longer possible this period
         test_blocks = self.generate_blocks(1, 4, test_blocks) # 0x00000004 (signalling not)
         yield TestInstance(test_blocks, sync_every_block=False)
 
-        assert_equal(self.get_bip9_status(bipName)['statistics']['elapsed'], 47)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['count'], 10)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['possible'], False)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['elapsed'], 47)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['count'], 10)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['possible'], False)
 
         # Test 1-C
         # finish period with "ready" blocks, but soft fork will still fail to advance to LOCKED_IN
         test_blocks = self.generate_blocks(97, activated_version) # 0x20000001 (signalling ready)
         yield TestInstance(test_blocks, sync_every_block=False)
 
-        assert_equal(self.get_bip9_status(bipName)['statistics']['elapsed'], 0)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['count'], 0)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['possible'], True)
-        assert_equal(self.get_bip9_status(bipName)['status'], 'started')
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['elapsed'], 0)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['count'], 0)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['possible'], True)
+        assert_equal(self.get_bip9_status(bip_name)['status'], 'started')
 
         # Test 2
         # Fail to achieve LOCKED_IN 100 out of 144 signal bit 1
@@ -146,13 +152,13 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         test_blocks = self.generate_blocks(24, 4, test_blocks) # 0x20010000 (signalling not)
         yield TestInstance(test_blocks, sync_every_block=False)
 
-        assert_equal(self.get_bip9_status(bipName)['status'], 'started')
-        assert_equal(self.get_bip9_status(bipName)['since'], 144)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['elapsed'], 0)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['count'], 0)
+        assert_equal(self.get_bip9_status(bip_name)['status'], 'started')
+        assert_equal(self.get_bip9_status(bip_name)['since'], 144)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['elapsed'], 0)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['count'], 0)
         tmpl = self.nodes[0].getblocktemplate({})
-        assert(bipName not in tmpl['rules'])
-        assert_equal(tmpl['vbavailable'][bipName], bitno)
+        assert(bip_name not in tmpl['rules'])
+        assert_equal(tmpl['vbavailable'][bip_name], bit_no)
         assert_equal(tmpl['vbrequired'], 0)
         assert(tmpl['version'] & activated_version)
 
@@ -166,29 +172,29 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         yield TestInstance(test_blocks, sync_every_block=False)
 
         # check counting stats and "possible" flag before last block of this period achieves LOCKED_IN...
-        assert_equal(self.get_bip9_status(bipName)['statistics']['elapsed'], 143)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['count'], 107)
-        assert_equal(self.get_bip9_status(bipName)['statistics']['possible'], True)
-        assert_equal(self.get_bip9_status(bipName)['status'], 'started')
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['elapsed'], 143)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['count'], 107)
+        assert_equal(self.get_bip9_status(bip_name)['statistics']['possible'], True)
+        assert_equal(self.get_bip9_status(bip_name)['status'], 'started')
 
         # ...continue with Test 3
         test_blocks = self.generate_blocks(1, activated_version) # 0x20000001 (signalling ready)
         yield TestInstance(test_blocks, sync_every_block=False)
 
-        assert_equal(self.get_bip9_status(bipName)['status'], 'locked_in')
-        assert_equal(self.get_bip9_status(bipName)['since'], 576)
+        assert_equal(self.get_bip9_status(bip_name)['status'], 'locked_in')
+        assert_equal(self.get_bip9_status(bip_name)['since'], 576)
         tmpl = self.nodes[0].getblocktemplate({})
-        assert(bipName not in tmpl['rules'])
+        assert(bip_name not in tmpl['rules'])
 
         # Test 4
         # 143 more version 536870913 blocks (waiting period-1)
         test_blocks = self.generate_blocks(143, 4)
         yield TestInstance(test_blocks, sync_every_block=False)
 
-        assert_equal(self.get_bip9_status(bipName)['status'], 'locked_in')
-        assert_equal(self.get_bip9_status(bipName)['since'], 576)
+        assert_equal(self.get_bip9_status(bip_name)['status'], 'locked_in')
+        assert_equal(self.get_bip9_status(bip_name)['since'], 576)
         tmpl = self.nodes[0].getblocktemplate({})
-        assert(bipName not in tmpl['rules'])
+        assert(bip_name not in tmpl['rules'])
 
         # Test 5
         # Check that the new rule is enforced
@@ -197,7 +203,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         invalidate(spendtx)
         spendtx = self.sign_transaction(self.nodes[0], spendtx)
         spendtx.rehash()
-        invalidatePostSignature(spendtx)
+        invalidate_post_signature(spendtx)
         spendtx.rehash()
         block = create_block(self.tip, create_coinbase(self.height), self.last_block_time + 1)
         block.nVersion = activated_version
@@ -211,13 +217,13 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         self.height += 1
         yield TestInstance([[block, True]])
 
-        assert_equal(self.get_bip9_status(bipName)['status'], 'active')
-        assert_equal(self.get_bip9_status(bipName)['since'], 720)
+        assert_equal(self.get_bip9_status(bip_name)['status'], 'active')
+        assert_equal(self.get_bip9_status(bip_name)['since'], 720)
         tmpl = self.nodes[0].getblocktemplate({})
-        assert(bipName in tmpl['rules'])
-        assert(bipName not in tmpl['vbavailable'])
+        assert(bip_name in tmpl['rules'])
+        assert(bip_name not in tmpl['vbavailable'])
         assert_equal(tmpl['vbrequired'], 0)
-        assert(not (tmpl['version'] & (1 << bitno)))
+        assert(not (tmpl['version'] & (1 << bit_no)))
 
         # Test 6
         # Check that the new sequence lock rules are enforced
@@ -226,7 +232,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         invalidate(spendtx)
         spendtx = self.sign_transaction(self.nodes[0], spendtx)
         spendtx.rehash()
-        invalidatePostSignature(spendtx)
+        invalidate_post_signature(spendtx)
         spendtx.rehash()
 
         block = create_block(self.tip, create_coinbase(self.height), self.last_block_time + 1)
@@ -251,23 +257,25 @@ class BIP9SoftForksTest(ComparisonTestFramework):
 
     def get_tests(self):
         for test in itertools.chain(
-                self.test_BIP('csv', 0x20000001, self.sequence_lock_invalidate, self.donothing, 0),
-                self.test_BIP('csv', 0x20000001, self.mtp_invalidate, self.donothing, 0),
-                self.test_BIP('csv', 0x20000001, self.donothing, self.csv_invalidate, 0)
+                self.test_bip('csv', 0x20000001, self.sequence_lock_invalidate, self.donothing, 0),
+                self.test_bip('csv', 0x20000001, self.mtp_invalidate, self.donothing, 0),
+                self.test_bip('csv', 0x20000001, self.donothing, self.csv_invalidate, 0)
         ):
             yield test
 
     def donothing(self, tx):
         return
 
-    def csv_invalidate(self, tx):
+    @staticmethod
+    def csv_invalidate(tx):
         """Modify the signature in vin 0 of the tx to fail CSV
         Prepends -1 CSV DROP in the scriptSig itself.
         """
         tx.vin[0].scriptSig = CScript([OP_1NEGATE, OP_CHECKSEQUENCEVERIFY, OP_DROP] +
                                       list(CScript(tx.vin[0].scriptSig)))
 
-    def sequence_lock_invalidate(self, tx):
+    @staticmethod
+    def sequence_lock_invalidate(tx):
         """Modify the nSequence to make it fails once sequence lock rule is
         activated (high timespan).
         """

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -3,25 +3,19 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test BIP66 (DER SIG).
+
+"""
+Test BIP66 (DER SIG).
 
 Test that the DERSIG soft-fork activates at (regtest) height 1251.
 """
 
-from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (p2p_port, assert_equal)
-from test_framework.mininode import (CTransaction, 
-                                    hex_str_to_bytes, 
-                                    NodeConnCB, 
-                                    NodeConn, 
-                                    NetworkThread, 
-                                    msg_block, 
-                                    wait_until, 
-                                    mininode_lock, 
-                                    msg_tx)
-from test_framework.blocktools import (create_coinbase, create_block)
-from test_framework.script import CScript
 from io import BytesIO
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import p2p_port, assert_equal, hex_str_to_bytes
+from test_framework.mininode import CTransaction, NodeConnCB, NodeConn, NetworkThread, MsgBlock, wait_until, mininode_lock, MsgTx
+from test_framework.blocktools import create_coinbase, create_block
+from test_framework.script import CScript
 
 DERSIG_HEIGHT = 1251
 
@@ -32,15 +26,15 @@ REJECT_NONSTANDARD = 64
 
 # A canonical signature consists of:
 # <30> <total len> <02> <len R> <R> <02> <len S> <S> <hashtype>
-def unDERify(tx):
+def un_der_ify(tx):
     """
     Make the signature in vin 0 of a tx non-DER-compliant,
     by adding padding after the S-value.
     """
-    scriptSig = CScript(tx.vin[0].scriptSig)
+    script_sig = CScript(tx.vin[0].scriptSig)
     newscript = []
-    for i in scriptSig:
-        if (len(newscript) == 0):
+    for i in script_sig:
+        if len(newscript) == 0:
             newscript.append(i[0:-1] + b'\0' + i[-1:])
         else:
             newscript.append(i)
@@ -64,8 +58,7 @@ class BIP66Test(RavenTestFramework):
 
     def run_test(self):
         node0 = NodeConnCB()
-        connections = []
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], node0))
+        connections = [NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], node0)]
         node0.add_connection(connections[0])
         NetworkThread().start() # Start up network handling in another thread
 
@@ -78,9 +71,8 @@ class BIP66Test(RavenTestFramework):
 
         self.log.info("Test that a transaction with non-DER signature can still appear in a block")
 
-        spendtx = create_transaction(self.nodes[0], self.coinbase_blocks[0],
-                self.nodeaddress, 1.0)
-        unDERify(spendtx)
+        spendtx = create_transaction(self.nodes[0], self.coinbase_blocks[0], self.nodeaddress, 1.0)
+        un_der_ify(spendtx)
         spendtx.rehash()
 
         tip = self.nodes[0].getbestblockhash()
@@ -92,7 +84,7 @@ class BIP66Test(RavenTestFramework):
         block.rehash()
         block.solve()
 
-        node0.send_and_ping(msg_block(block))
+        node0.send_and_ping(MsgBlock(block))
         assert_equal(self.nodes[0].getbestblockhash(), block.hash)
 
         self.log.info("Test that blocks must now be at least version 3")
@@ -102,10 +94,10 @@ class BIP66Test(RavenTestFramework):
         block.nVersion = 2
         block.rehash()
         block.solve()
-        node0.send_and_ping(msg_block(block))
+        node0.send_and_ping(MsgBlock(block))
         assert_equal(int(self.nodes[0].getbestblockhash(), 16), tip)
 
-        wait_until(lambda: "reject" in node0.last_message.keys(), lock=mininode_lock)
+        wait_until(lambda: "reject" in node0.last_message.keys(), lock=mininode_lock, err_msg="last_message")
         with mininode_lock:
             assert_equal(node0.last_message["reject"].code, REJECT_OBSOLETE)
             assert_equal(node0.last_message["reject"].reason, b'bad-version(0x00000002)')
@@ -115,15 +107,14 @@ class BIP66Test(RavenTestFramework):
         self.log.info("Test that transactions with non-DER signatures cannot appear in a block")
         block.nVersion = 3
 
-        spendtx = create_transaction(self.nodes[0], self.coinbase_blocks[1],
-                self.nodeaddress, 1.0)
-        unDERify(spendtx)
+        spendtx = create_transaction(self.nodes[0], self.coinbase_blocks[1], self.nodeaddress, 1.0)
+        un_der_ify(spendtx)
         spendtx.rehash()
 
         # First we show that this tx is valid except for DERSIG by getting it
         # accepted to the mempool (which we can achieve with
         # -promiscuousmempoolflags).
-        node0.send_and_ping(msg_tx(spendtx))
+        node0.send_and_ping(MsgTx(spendtx))
         assert spendtx.hash in self.nodes[0].getrawmempool()
 
         # Now we verify that a block with this transaction is invalid.
@@ -132,10 +123,10 @@ class BIP66Test(RavenTestFramework):
         block.rehash()
         block.solve()
 
-        node0.send_and_ping(msg_block(block))
+        node0.send_and_ping(MsgBlock(block))
         assert_equal(int(self.nodes[0].getbestblockhash(), 16), tip)
 
-        wait_until(lambda: "reject" in node0.last_message.keys(), lock=mininode_lock)
+        wait_until(lambda: "reject" in node0.last_message.keys(), lock=mininode_lock, err_msg="last_message")
         with mininode_lock:
             # We can receive different reject messages depending on whether
             # ravend is running with multiple script check threads. If script
@@ -157,7 +148,7 @@ class BIP66Test(RavenTestFramework):
         block.rehash()
         block.solve()
 
-        node0.send_and_ping(msg_block(block))
+        node0.send_and_ping(MsgBlock(block))
         assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
 
 if __name__ == '__main__':

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -3,12 +3,13 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test fee estimation code."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (satoshi_round, Decimal, connect_nodes, random, sync_mempools, sync_blocks)
-from test_framework.script import (CScript, OP_1, OP_DROP, OP_2, OP_HASH160, OP_EQUAL, hash160, OP_TRUE)
-from test_framework.mininode import (CTransaction, CTxIn, CTxOut, COutPoint, ToHex, COIN)
+from test_framework.util import satoshi_round, Decimal, connect_nodes, random, sync_mempools, sync_blocks
+from test_framework.script import CScript, OP_1, OP_DROP, OP_2, OP_HASH160, OP_EQUAL, hash160, OP_TRUE
+from test_framework.mininode import CTransaction, CTxIn, CTxOut, COutPoint, to_hex, COIN
 
 # Construct 2 trivial P2SH's and the ScriptSigs that spend them
 # So we can create many transactions without needing to spend
@@ -21,9 +22,10 @@ P2SH_2 = CScript([OP_HASH160, hash160(redeem_script_2), OP_EQUAL])
 # Associated ScriptSig's to spend satisfy P2SH_1 and P2SH_2
 SCRIPT_SIG = [CScript([OP_TRUE, redeem_script_1]), CScript([OP_TRUE, redeem_script_2])]
 
+# noinspection PyGlobalUndefined
 global log
 
-def small_txpuzzle_randfee(from_node, conflist, unconflist, amount, min_fee, fee_increment):
+def small_tx_puzzle_rand_fee(from_node, conflist, unconflist, amount, min_fee, fee_increment):
     """
     Create and send a transaction with a random fee.
     The transaction pays to a trivial P2SH script, and assumes that its inputs
@@ -58,11 +60,11 @@ def small_txpuzzle_randfee(from_node, conflist, unconflist, amount, min_fee, fee
     # the ScriptSig that will satisfy the ScriptPubKey.
     for inp in tx.vin:
         inp.scriptSig = SCRIPT_SIG[inp.prevout.n]
-    txid = from_node.sendrawtransaction(ToHex(tx), True)
+    txid = from_node.sendrawtransaction(to_hex(tx), True)
     unconflist.append({ "txid" : txid, "vout" : 0 , "amount" : total_in - amount - fee})
     unconflist.append({ "txid" : txid, "vout" : 1 , "amount" : amount})
 
-    return (ToHex(tx), fee)
+    return to_hex(tx), fee
 
 def split_inputs(from_node, txins, txouts, initial_split = False):
     """
@@ -83,11 +85,11 @@ def split_inputs(from_node, txins, txouts, initial_split = False):
 
     # If this is the initial split we actually need to sign the transaction
     # Otherwise we just need to insert the proper ScriptSig
-    if (initial_split) :
-        completetx = from_node.signrawtransaction(ToHex(tx))["hex"]
+    if initial_split:
+        completetx = from_node.signrawtransaction(to_hex(tx))["hex"]
     else :
         tx.vin[0].scriptSig = SCRIPT_SIG[prevtxout["vout"]]
-        completetx = ToHex(tx)
+        completetx = to_hex(tx)
     txid = from_node.sendrawtransaction(completetx, True)
     txouts.append({ "txid" : txid, "vout" : 0 , "amount" : half_change})
     txouts.append({ "txid" : txid, "vout" : 1 , "amount" : rem_change})
@@ -137,7 +139,7 @@ def check_estimates(node, fees_seen, max_invalid, print_estimates = True):
     # Check on the expected number of different confirmation counts
     # that we might not have valid estimates for
     if invalid_estimates > max_invalid:
-        raise AssertionError("More than (%d) invalid estimates"%(max_invalid))
+        raise AssertionError("More than (%d) invalid estimates" % max_invalid)
     return all_estimates
 
 
@@ -166,14 +168,14 @@ class EstimateFeeTest(RavenTestFramework):
         min_fee = Decimal("0.0100000")
         # We will now mine numblocks blocks generating on average 100 transactions between each block
         # We shuffle our confirmed txout set before each set of transactions
-        # small_txpuzzle_randfee will use the transactions that have inputs already in the chain when possible
+        # small_tx_puzzle_rand_fee will use the transactions that have inputs already in the chain when possible
         # resorting to tx's that depend on the mempool when those run out
         for _ in range(numblocks):
             random.shuffle(self.confutxo)
             for _ in range(random.randrange(100-50,100+50)):
                 from_index = random.randint(1,2)
-                (txhex, fee) = small_txpuzzle_randfee(self.nodes[from_index], self.confutxo,
-                                                      self.memutxo, Decimal("0.005"), min_fee, min_fee)
+                (txhex, fee) = small_tx_puzzle_rand_fee(self.nodes[from_index], self.confutxo,
+                                                        self.memutxo, Decimal("0.005"), min_fee, min_fee)
                 tx_kbytes = (len(txhex) // 2) / 1000.0
                 self.fees_per_kb.append(float(fee)/tx_kbytes)
             sync_mempools(self.nodes[0:3], wait=.1)
@@ -204,22 +206,22 @@ class EstimateFeeTest(RavenTestFramework):
         split_inputs(self.nodes[0], self.nodes[0].listunspent(0), self.txouts, True)
 
         # Mine
-        while (len(self.nodes[0].getrawmempool()) > 0):
+        while len(self.nodes[0].getrawmempool()) > 0:
             self.nodes[0].generate(1)
 
         # Repeatedly split those 2 outputs, doubling twice for each rep
         # Use txouts to monitor the available utxo, since these won't be tracked in wallet
         reps = 0
-        while (reps < 5):
+        while reps < 5:
             #Double txouts to txouts2
-            while (len(self.txouts)>0):
+            while len(self.txouts)>0:
                 split_inputs(self.nodes[0], self.txouts, self.txouts2)
-            while (len(self.nodes[0].getrawmempool()) > 0):
+            while len(self.nodes[0].getrawmempool()) > 0:
                 self.nodes[0].generate(1)
             #Double txouts2 to txouts
-            while (len(self.txouts2)>0):
+            while len(self.txouts2)>0:
                 split_inputs(self.nodes[0], self.txouts2, self.txouts)
-            while (len(self.nodes[0].getrawmempool()) > 0):
+            while len(self.nodes[0].getrawmempool()) > 0:
                 self.nodes[0].generate(1)
             reps += 1
         self.log.info("Finished splitting")

--- a/test/functional/feature_listmyassets.py
+++ b/test/functional/feature_listmyassets.py
@@ -3,12 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test listmyassets RPC command."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, assert_contains_pair)
-from test_framework.mininode import CInv
-from io import BytesIO
+from test_framework.util import assert_equal, assert_contains_pair
 
 class ListMyAssetsTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2019 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Test loadblock option
+
+Test the option to start a node with the option loadblock which loads
+a serialized blockchain from a file (usually called bootstrap.dat).
+To generate that file this test uses the helper scripts available
+in contrib/linearize.
+"""
+
+import configparser
+import os
+import subprocess
+import sys
+import tempfile
+import urllib
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import assert_equal, wait_until
+
+class LoadblockTest(RavenTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def run_test(self):
+        self.nodes[1].setnetworkactive(state=False)
+        self.nodes[0].generate(100)
+
+        # Parsing the url of our node to get settings for config file
+        data_dir = self.nodes[0].datadir
+        node_url = urllib.parse.urlparse(self.nodes[0].url)
+        cfg_file = os.path.join(data_dir, "linearize.cfg")
+        bootstrap_file = os.path.join(self.options.tmpdir, "bootstrap.dat")
+        genesis_block = self.nodes[0].getblockhash(0)
+        blocks_dir = os.path.join(data_dir, "regtest", "blocks")
+        hash_list = tempfile.NamedTemporaryFile(dir=data_dir,
+                                                mode='w',
+                                                delete=False,
+                                                encoding="utf-8")
+
+        self.log.info("Create linearization config file")
+        with open(cfg_file, "a", encoding="utf-8") as cfg:
+            cfg.write("datadir={}\n".format(data_dir))
+            cfg.write("rpcuser={}\n".format(node_url.username))
+            cfg.write("rpcpassword={}\n".format(node_url.password))
+            cfg.write("port={}\n".format(node_url.port))
+            cfg.write("host={}\n".format(node_url.hostname))
+            cfg.write("output_file={}\n".format(bootstrap_file))
+            cfg.write("max_height=100\n")
+            cfg.write("netmagic=43524f57\n")
+            cfg.write("input={}\n".format(blocks_dir))
+            cfg.write("genesis={}\n".format(genesis_block))
+            cfg.write("hashlist={}\n".format(hash_list.name))
+
+        # Get the configuration file to find src and linearize
+        config = configparser.ConfigParser()
+        if not self.options.configfile:
+            self.options.configfile = os.path.abspath(os.path.join(os.path.dirname(__file__), "../config.ini"))
+        config.read_file(open(self.options.configfile))
+        base_dir = config["environment"]["SRCDIR"]
+        linearize_dir = os.path.join(base_dir, "contrib", "linearize")
+
+        self.log.info("Run linearization of block hashes")
+        linearize_hashes_file = os.path.join(linearize_dir, "linearize-hashes.py")
+        subprocess.run([sys.executable, linearize_hashes_file, cfg_file],
+                       stdout=hash_list,
+                       check=True)
+
+        self.log.info("Run linearization of block data")
+        linearize_data_file = os.path.join(linearize_dir, "linearize-data.py")
+        subprocess.run([sys.executable, linearize_data_file, cfg_file],
+                       check=True)
+
+        self.log.info("Restart second, unsynced node with bootstrap file")
+        self.stop_node(1)
+        self.start_node(1, ["-loadblock=" + bootstrap_file])
+        wait_until(lambda: self.nodes[1].getblockcount() == 100, err_msg="Wait for block count == 100")
+
+        assert_equal(self.nodes[1].getblockchaininfo()['blocks'], 100)
+        assert_equal(self.nodes[0].getbestblockhash(), self.nodes[1].getbestblockhash())
+
+
+if __name__ == '__main__':
+    LoadblockTest().main()

--- a/test/functional/feature_maxreorgdepth.py
+++ b/test/functional/feature_maxreorgdepth.py
@@ -3,17 +3,15 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Max Reorg Test
+
 """
+Max Reorg Test
+"""
+
 import sys
 import time
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_all_nodes_bi, 
-                                set_node_times, 
-                                assert_equal, 
-                                connect_nodes_bi, 
-                                assert_contains_pair, 
-                                assert_does_not_contain_key) 
+from test_framework.util import connect_all_nodes_bi, set_node_times, assert_equal, connect_nodes_bi, assert_contains_pair, assert_does_not_contain_key
 from test_framework.mininode import wait_until
 
 
@@ -30,12 +28,9 @@ class MaxReorgTest(RavenTestFramework):
         # self.extra_args = [[f"-maxreorg={self.max_reorg_depth}", f"-minreorgpeers={self.min_reorg_peers}", f"-minreorgage={self.min_reorg_age}"] for i in range(self.num_nodes)]
 
     def add_options(self, parser):
-        parser.add_option("--height", dest="height", default=65,
-                          help="The height of good branch when adversary surprises.")
-        parser.add_option("--tip_age", dest="tip_age", default=60*5,
-                          help="Age of tip of non-adversaries at time of reorg.")
-        parser.add_option("--should_reorg", dest="should_reorg", default=0,
-                          help="Whether a reorg is expected (0 or 1).")
+        parser.add_option("--height", dest="height", default=65, help="The height of good branch when adversary surprises.")
+        parser.add_option("--tip_age", dest="tip_age", default=60*5, help="Age of tip of non-adversaries at time of reorg.")
+        parser.add_option("--should_reorg", dest="should_reorg", default=0, help="Whether a reorg is expected (0 or 1).")
 
 
     def setup_network(self):
@@ -117,8 +112,9 @@ class MaxReorgTest(RavenTestFramework):
         else:
             self.log.info(f"Didn't expect a reorg -- blockcount should remain {expected_height} and both subject and adversary should own {asset_name} (waiting 5 seconds)...")
 
+        # noinspection PyBroadException
         try:
-            wait_until(lambda: [n.getblockcount() for n in self.nodes] == [expected_height] * peers, timeout=5)
+            wait_until(lambda: [n.getblockcount() for n in self.nodes] == [expected_height] * peers, timeout=5, err_msg="getblockcount")
         except:
             pass
         self.log.info("BlockCount: " +str([n.getblockcount() for n in self.nodes]))

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test behavior of -maxuploadtarget.
+
+"""
+Test behavior of -maxuploadtarget.
 
 * Verify that getdata requests for old blocks (>1week) are dropped
 if uploadtarget has been reached.
@@ -11,13 +13,12 @@ if uploadtarget has been reached.
 if uploadtarget has been reached.
 * Verify that the upload counters are reset after 24 hours.
 """
+
 from collections import defaultdict
 import time
-
-from pprint import re
-from test_framework.mininode import (NodeConn, NodeConnCB, NetworkThread, msg_getdata, CInv)
+from test_framework.mininode import NodeConn, NodeConnCB, NetworkThread, MsgGetdata, CInv
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (p2p_port, mine_large_block, assert_equal)
+from test_framework.util import p2p_port, mine_large_block, assert_equal
 
 
 class TestNode(NodeConnCB):
@@ -29,8 +30,8 @@ class TestNode(NodeConnCB):
         pass
 
     def on_block(self, conn, message):
-        message.block.calc_sha256()
-        self.block_receive_map[message.block.sha256] += 1
+        message.block.calc_x16r()
+        self.block_receive_map[message.block.x16r] += 1
 
 
 class MaxUploadTest(RavenTestFramework):
@@ -91,7 +92,7 @@ class MaxUploadTest(RavenTestFramework):
         # test_nodes[0] will test what happens if we just keep requesting the
         # the same big old block too many times (expect: disconnect)
 
-        getdata_request = msg_getdata()
+        getdata_request = MsgGetdata()
         getdata_request.inv.append(CInv(2, big_old_block))
 
         block_rate_minutes = 1

--- a/test/functional/feature_messaging.py
+++ b/test/functional/feature_messaging.py
@@ -3,15 +3,13 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Testing messaging
+
+"""
+Testing messaging
 """
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, 
-                                assert_raises_rpc_error, 
-                                assert_contains, 
-                                assert_does_not_contain, 
-                                assert_contains_pair)
+from test_framework.util import assert_equal, assert_raises_rpc_error, assert_contains, assert_does_not_contain, assert_contains_pair
 
 class MessagingTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test logic for setting nMinimumChainWork on command line.
+
+"""
+Test logic for setting nMinimumChainWork on command line.
 
 Nodes don't consider themselves out of "initial block download" until
 their active chain has more work than nMinimumChainWork.
@@ -17,9 +19,8 @@ only succeeds past a given node once its nMinimumChainWork has been exceeded.
 """
 
 import time
-
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (sync_blocks, connect_nodes, assert_equal)
+from test_framework.util import connect_nodes, assert_equal
 
 # 2 hashes required per regtest block (with no difficulty adjustment)
 REGTEST_WORK_PER_BLOCK = 2

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -3,11 +3,14 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test the -alertnotify, -blocknotify and -walletnotify options."""
-import os
 
+"""
+Test the -alertnotify, -blocknotify and -walletnotify options.
+"""
+
+import os
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, wait_until, connect_nodes_bi)
+from test_framework.util import assert_equal, wait_until, connect_nodes_bi
 
 class NotificationsTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test ravend with different proxy configuration.
+
+"""
+Test ravend with different proxy configuration.
 
 Test plan:
 - Start ravend's with different proxy configurations
@@ -30,10 +32,9 @@ addnode connect to generic DNS name
 
 import socket
 import os
-
-from test_framework.socks5 import (Socks5Configuration, Socks5Command, Socks5Server, AddressType)
+from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (PORT_MIN, PORT_RANGE, assert_equal)
+from test_framework.util import PORT_MIN, PORT_RANGE, assert_equal
 from test_framework.netutil import test_ipv6_local
 
 RANGE_BEGIN = PORT_MIN + 2 * PORT_RANGE  # Start after p2p and rpc ports
@@ -76,13 +77,13 @@ class ProxyTest(RavenTestFramework):
         # Note: proxies are not used to connect to local nodes
         # this is because the proxy to use is based on CService.GetNetwork(), which return NET_UNROUTABLE for localhost
         args = [
-            ['-listen', '-proxy=%s:%i' % (self.conf1.addr),'-proxyrandomize=1'], 
-            ['-listen', '-proxy=%s:%i' % (self.conf1.addr),'-onion=%s:%i' % (self.conf2.addr),'-proxyrandomize=0'], 
-            ['-listen', '-proxy=%s:%i' % (self.conf2.addr),'-proxyrandomize=1'], 
+            ['-listen', '-proxy=%s:%i' % self.conf1.addr, '-proxyrandomize=1'],
+            ['-listen', '-proxy=%s:%i' % self.conf1.addr, '-onion=%s:%i' % self.conf2.addr, '-proxyrandomize=0'],
+            ['-listen', '-proxy=%s:%i' % self.conf2.addr, '-proxyrandomize=1'],
             []
             ]
         if self.have_ipv6:
-            args[3] = ['-listen', '-proxy=[%s]:%i' % (self.conf3.addr),'-proxyrandomize=0', '-noonion']
+            args[3] = ['-listen', '-proxy=[%s]:%i' % self.conf3.addr, '-proxyrandomize=0', '-noonion']
         self.add_nodes(self.num_nodes, extra_args=args)
         self.start_nodes()
 
@@ -169,28 +170,28 @@ class ProxyTest(RavenTestFramework):
         # test RPC getnetworkinfo
         n0 = networks_dict(self.nodes[0].getnetworkinfo())
         for net in ['ipv4','ipv6','onion']:
-            assert_equal(n0[net]['proxy'], '%s:%i' % (self.conf1.addr))
+            assert_equal(n0[net]['proxy'], '%s:%i' % self.conf1.addr)
             assert_equal(n0[net]['proxy_randomize_credentials'], True)
         assert_equal(n0['onion']['reachable'], True)
 
         n1 = networks_dict(self.nodes[1].getnetworkinfo())
         for net in ['ipv4','ipv6']:
-            assert_equal(n1[net]['proxy'], '%s:%i' % (self.conf1.addr))
+            assert_equal(n1[net]['proxy'], '%s:%i' % self.conf1.addr)
             assert_equal(n1[net]['proxy_randomize_credentials'], False)
-        assert_equal(n1['onion']['proxy'], '%s:%i' % (self.conf2.addr))
+        assert_equal(n1['onion']['proxy'], '%s:%i' % self.conf2.addr)
         assert_equal(n1['onion']['proxy_randomize_credentials'], False)
         assert_equal(n1['onion']['reachable'], True)
         
         n2 = networks_dict(self.nodes[2].getnetworkinfo())
         for net in ['ipv4','ipv6','onion']:
-            assert_equal(n2[net]['proxy'], '%s:%i' % (self.conf2.addr))
+            assert_equal(n2[net]['proxy'], '%s:%i' % self.conf2.addr)
             assert_equal(n2[net]['proxy_randomize_credentials'], True)
         assert_equal(n2['onion']['reachable'], True)
 
         if self.have_ipv6:
             n3 = networks_dict(self.nodes[3].getnetworkinfo())
             for net in ['ipv4','ipv6']:
-                assert_equal(n3[net]['proxy'], '[%s]:%i' % (self.conf3.addr))
+                assert_equal(n3[net]['proxy'], '[%s]:%i' % self.conf3.addr)
                 assert_equal(n3[net]['proxy_randomize_credentials'], False)
             assert_equal(n3['onion']['reachable'], False)
 

--- a/test/functional/feature_rawassettransactions.py
+++ b/test/functional/feature_rawassettransactions.py
@@ -3,33 +3,24 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test the rawtransaction RPCs for asset transactions.
+
 """
+Test the rawtransaction RPCs for asset transactions.
+"""
+
+import math
 from io import BytesIO
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal,
-                                 assert_raises_rpc_error,
-                                 assert_is_hash_string,
-                                 assert_does_not_contain_key,
-                                 assert_contains_key,
-                                 assert_contains_pair)
-from test_framework.mininode import (CTransaction,
-                                     hex_str_to_bytes,
-                                     bytes_to_hex_str,
-                                     CScriptReissue,
-                                     CScriptOwner,
-                                     CScriptTransfer,
-                                     CTxOut,
-                                     CScriptIssue)
-import math
-
+from test_framework.util import assert_equal, assert_raises_rpc_error, assert_is_hash_string, assert_does_not_contain_key, assert_contains_key, assert_contains_pair
+from test_framework.mininode import CTransaction, hex_str_to_bytes, bytes_to_hex_str, CScriptReissue, CScriptOwner, CScriptTransfer, CTxOut, CScriptIssue
 
 def truncate(number, digits=8):
     stepper = pow(10.0, digits)
     return math.trunc(stepper * number) / stepper
 
 
-def get_first_unspent(self: object, node: object, needed: object = 500.1) -> object:
+# noinspection PyTypeChecker,PyUnboundLocalVariable,PyUnresolvedReferences
+def get_first_unspent(self: object, node: object, needed: float = 500.1) -> object:
     # Find the first unspent with enough required for transaction
     for n in range(0, len(node.listunspent())):
         unspent = node.listunspent()[n]
@@ -64,6 +55,7 @@ def get_tx_issue_hex(self, node, asset_name, asset_quantity, asset_units=0):
     return tx_issue_hex
 
 
+# noinspection PyTypeChecker
 class RawAssetTransactionsTest(RavenTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
@@ -1332,7 +1324,7 @@ class RawAssetTransactionsTest(RavenTestFramework):
         assert_equal(1, n0.listmyassets()[owner])
 
     def transfer_asset_tampering_test(self):
-        self.log.info("Testing trasnfer of asset transaction tampering...")
+        self.log.info("Testing transfer of asset transaction tampering...")
         n0, n1 = self.nodes[0], self.nodes[1]
 
         ########################################

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -3,19 +3,20 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the RBF code."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (satoshi_round, assert_raises_rpc_error, assert_equal, Decimal)
+from test_framework.util import satoshi_round, assert_raises_rpc_error, assert_equal, Decimal
 from test_framework.script import CScript
-from test_framework.mininode import (bytes_to_hex_str, COIN, CTransaction, CTxIn, COutPoint, CTxOut)
+from test_framework.mininode import bytes_to_hex_str, COIN, CTransaction, CTxIn, COutPoint, CTxOut
 
 MAX_REPLACEMENT_LIMIT = 100
 
-def txToHex(tx):
+def tx_to_hex(tx):
     return bytes_to_hex_str(tx.serialize())
 
-def make_utxo(node, amount, confirmed=True, scriptPubKey=CScript([1])):
+def make_utxo(node, amount, confirmed=True, script_pub_key=CScript([1])):
     """Create a txout with a given amount and scriptPubKey
 
     Mines coins as needed.
@@ -40,10 +41,10 @@ def make_utxo(node, amount, confirmed=True, scriptPubKey=CScript([1])):
 
     tx2 = CTransaction()
     tx2.vin = [CTxIn(COutPoint(txid, i))]
-    tx2.vout = [CTxOut(amount, scriptPubKey)]
+    tx2.vout = [CTxOut(amount, script_pub_key)]
     tx2.rehash()
 
-    signed_tx = node.signrawtransaction(txToHex(tx2))
+    signed_tx = node.signrawtransaction(tx_to_hex(tx2))
 
     txid = node.sendrawtransaction(signed_tx['hex'], True)
 
@@ -91,7 +92,7 @@ class ReplaceByFeeTest(RavenTestFramework):
         self.test_doublespend_tree()
 
         self.log.info("Running test replacement feeperkb...")
-        self.test_replacement_feeperkb()
+        self.test_replacement_fee_per_kb()
 
         self.log.info("Running test spends of conflicting outputs...")
         self.test_spends_of_conflicting_outputs()
@@ -123,18 +124,18 @@ class ReplaceByFeeTest(RavenTestFramework):
         self.sync_all()
 
         tx1a = CTransaction()
-        tx1a.vin = [CTxIn(tx0_outpoint, nSequence=0)]
+        tx1a.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
         tx1a.vout = [CTxOut(1*COIN, CScript([b'a']))]
-        tx1a_hex = txToHex(tx1a)
+        tx1a_hex = tx_to_hex(tx1a)
         tx1a_txid = self.nodes[0].sendrawtransaction(tx1a_hex, True)
 
         self.sync_all()
 
         # Should fail because we haven't changed the fee
         tx1b = CTransaction()
-        tx1b.vin = [CTxIn(tx0_outpoint, nSequence=0)]
+        tx1b.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
         tx1b.vout = [CTxOut(1*COIN, CScript([b'b']))]
-        tx1b_hex = txToHex(tx1b)
+        tx1b_hex = tx_to_hex(tx1b)
 
         # This will raise an exception due to insufficient fee
         assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, True)
@@ -143,9 +144,9 @@ class ReplaceByFeeTest(RavenTestFramework):
 
         # Extra 0.1 RVN fee
         tx1b = CTransaction()
-        tx1b.vin = [CTxIn(tx0_outpoint, nSequence=0)]
+        tx1b.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
         tx1b.vout = [CTxOut(int(0.9*COIN), CScript([b'b']))]
-        tx1b_hex = txToHex(tx1b)
+        tx1b_hex = tx_to_hex(tx1b)
         # Replacement still disabled even with "enough fee"
         assert_raises_rpc_error(-26, "txn-mempool-conflict", self.nodes[1].sendrawtransaction, tx1b_hex, True)
         # Works when enabled
@@ -166,18 +167,18 @@ class ReplaceByFeeTest(RavenTestFramework):
     def test_doublespend_chain(self):
         """Doublespend of a long chain"""
 
-        initial_nValue = 5000*COIN
-        tx0_outpoint = make_utxo(self.nodes[0], initial_nValue)
+        initial_n_value = 5000*COIN
+        tx0_outpoint = make_utxo(self.nodes[0], initial_n_value)
 
         prevout = tx0_outpoint
-        remaining_value = initial_nValue
+        remaining_value = initial_n_value
         chain_txids = []
         while remaining_value > 1000*COIN:
             remaining_value -= 100*COIN
             tx = CTransaction()
-            tx.vin = [CTxIn(prevout, nSequence=0)]
+            tx.vin = [CTxIn(prevout, n_sequence=0)]
             tx.vout = [CTxOut(remaining_value, CScript([1]))]
-            tx_hex = txToHex(tx)
+            tx_hex = tx_to_hex(tx)
             txid = self.nodes[0].sendrawtransaction(tx_hex, True)
             chain_txids.append(txid)
             prevout = COutPoint(int(txid, 16), 0)
@@ -185,18 +186,18 @@ class ReplaceByFeeTest(RavenTestFramework):
         # Whether the double-spend is allowed is evaluated by including all
         # child fees - 40 RVN - so this attempt is rejected.
         dbl_tx = CTransaction()
-        dbl_tx.vin = [CTxIn(tx0_outpoint, nSequence=0)]
-        dbl_tx.vout = [CTxOut(initial_nValue - 30*COIN, CScript([1]))]
-        dbl_tx_hex = txToHex(dbl_tx)
+        dbl_tx.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
+        dbl_tx.vout = [CTxOut(initial_n_value - 30*COIN, CScript([1]))]
+        dbl_tx_hex = tx_to_hex(dbl_tx)
 
         # This will raise an exception due to insufficient fee
         assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
 
         # Accepted with sufficient fee
         dbl_tx = CTransaction()
-        dbl_tx.vin = [CTxIn(tx0_outpoint, nSequence=0)]
+        dbl_tx.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
         dbl_tx.vout = [CTxOut(1*COIN, CScript([1]))]
-        dbl_tx_hex = txToHex(dbl_tx)
+        dbl_tx_hex = tx_to_hex(dbl_tx)
         self.nodes[0].sendrawtransaction(dbl_tx_hex, True)
 
         mempool = self.nodes[0].getrawmempool()
@@ -206,58 +207,58 @@ class ReplaceByFeeTest(RavenTestFramework):
     def test_doublespend_tree(self):
         """Doublespend of a big tree of transactions"""
 
-        initial_nValue = 50*COIN
-        tx0_outpoint = make_utxo(self.nodes[0], initial_nValue)
+        initial_n_value = 50*COIN
+        tx0_outpoint = make_utxo(self.nodes[0], initial_n_value)
 
-        def branch(prevout, initial_value, max_txs, tree_width=5, fee=0.0001*COIN, _total_txs=None):
+        def branch(prevout, initial_value, max_txs, tree_width=5, fee_val=0.0001 * COIN, _total_txs=None):
             if _total_txs is None:
                 _total_txs = [0]
             if _total_txs[0] >= max_txs:
                 return
 
-            txout_value = (initial_value - fee) // tree_width
-            if txout_value < fee:
+            txout_value = (initial_value - fee_val) // tree_width
+            if txout_value < fee_val:
                 return
 
             vout = [CTxOut(txout_value, CScript([i+1]))
                     for i in range(tree_width)]
-            tx = CTransaction()
-            tx.vin = [CTxIn(prevout, nSequence=0)]
-            tx.vout = vout
-            tx_hex = txToHex(tx)
+            tx_data = CTransaction()
+            tx_data.vin = [CTxIn(prevout, n_sequence=0)]
+            tx_data.vout = vout
+            tx_hex = tx_to_hex(tx_data)
 
-            assert(len(tx.serialize()) < 100000)
+            assert(len(tx_data.serialize()) < 100000)
             txid = self.nodes[0].sendrawtransaction(tx_hex, True)
-            yield tx
+            yield tx_data
             _total_txs[0] += 1
 
             txid = int(txid, 16)
 
-            for i, _ in enumerate(tx.vout):
+            for i, _ in enumerate(tx_data.vout):
                 for x in branch(COutPoint(txid, i), txout_value,
-                                  max_txs,
-                                  tree_width=tree_width, fee=fee,
-                                  _total_txs=_total_txs):
+                                max_txs,
+                                tree_width=tree_width, fee_val=fee_val,
+                                _total_txs=_total_txs):
                     yield x
 
         fee = int(0.0001*COIN)
         n = MAX_REPLACEMENT_LIMIT
-        tree_txs = list(branch(tx0_outpoint, initial_nValue, n, fee=fee))
+        tree_txs = list(branch(tx0_outpoint, initial_n_value, n, fee_val=fee))
         assert_equal(len(tree_txs), n)
 
         # Attempt double-spend, will fail because too little fee paid
         dbl_tx = CTransaction()
-        dbl_tx.vin = [CTxIn(tx0_outpoint, nSequence=0)]
-        dbl_tx.vout = [CTxOut(initial_nValue - fee*n, CScript([1]))]
-        dbl_tx_hex = txToHex(dbl_tx)
+        dbl_tx.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
+        dbl_tx.vout = [CTxOut(initial_n_value - fee*n, CScript([1]))]
+        dbl_tx_hex = tx_to_hex(dbl_tx)
         # This will raise an exception due to insufficient fee
         assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
 
         # 1 RVN fee is enough
         dbl_tx = CTransaction()
-        dbl_tx.vin = [CTxIn(tx0_outpoint, nSequence=0)]
-        dbl_tx.vout = [CTxOut(initial_nValue - fee*n - 1*COIN, CScript([1]))]
-        dbl_tx_hex = txToHex(dbl_tx)
+        dbl_tx.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
+        dbl_tx.vout = [CTxOut(initial_n_value - fee*n - 1*COIN, CScript([1]))]
+        dbl_tx_hex = tx_to_hex(dbl_tx)
         self.nodes[0].sendrawtransaction(dbl_tx_hex, True)
 
         mempool = self.nodes[0].getrawmempool()
@@ -270,14 +271,14 @@ class ReplaceByFeeTest(RavenTestFramework):
         # double-spent at once" anti-DoS limit.
         for n in (MAX_REPLACEMENT_LIMIT+1, MAX_REPLACEMENT_LIMIT*2):
             fee = int(0.0001*COIN)
-            tx0_outpoint = make_utxo(self.nodes[0], initial_nValue)
-            tree_txs = list(branch(tx0_outpoint, initial_nValue, n, fee=fee))
+            tx0_outpoint = make_utxo(self.nodes[0], initial_n_value)
+            tree_txs = list(branch(tx0_outpoint, initial_n_value, n, fee_val=fee))
             assert_equal(len(tree_txs), n)
 
             dbl_tx = CTransaction()
-            dbl_tx.vin = [CTxIn(tx0_outpoint, nSequence=0)]
-            dbl_tx.vout = [CTxOut(initial_nValue - 2*fee*n, CScript([1]))]
-            dbl_tx_hex = txToHex(dbl_tx)
+            dbl_tx.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
+            dbl_tx.vout = [CTxOut(initial_n_value - 2*fee*n, CScript([1]))]
+            dbl_tx_hex = tx_to_hex(dbl_tx)
             # This will raise an exception
             assert_raises_rpc_error(-26, "too many potential replacements", self.nodes[0].sendrawtransaction, dbl_tx_hex, True)
 
@@ -285,22 +286,22 @@ class ReplaceByFeeTest(RavenTestFramework):
                 tx.rehash()
                 self.nodes[0].getrawtransaction(tx.hash)
 
-    def test_replacement_feeperkb(self):
+    def test_replacement_fee_per_kb(self):
         """Replacement requires fee-per-KB to be higher"""
         tx0_outpoint = make_utxo(self.nodes[0], int(1.1*COIN))
 
         tx1a = CTransaction()
-        tx1a.vin = [CTxIn(tx0_outpoint, nSequence=0)]
+        tx1a.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
         tx1a.vout = [CTxOut(1*COIN, CScript([b'a']))]
-        tx1a_hex = txToHex(tx1a)
+        tx1a_hex = tx_to_hex(tx1a)
         self.nodes[0].sendrawtransaction(tx1a_hex, True)
 
         # Higher fee, but the fee per KB is much lower, so the replacement is
         # rejected.
         tx1b = CTransaction()
-        tx1b.vin = [CTxIn(tx0_outpoint, nSequence=0)]
+        tx1b.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
         tx1b.vout = [CTxOut(int(0.001*COIN), CScript([b'a'*999000]))]
-        tx1b_hex = txToHex(tx1b)
+        tx1b_hex = tx_to_hex(tx1b)
 
         # This will raise an exception due to insufficient fee
         assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, True)
@@ -311,36 +312,36 @@ class ReplaceByFeeTest(RavenTestFramework):
         utxo2 = make_utxo(self.nodes[0], 3*COIN)
 
         tx1a = CTransaction()
-        tx1a.vin = [CTxIn(utxo1, nSequence=0)]
+        tx1a.vin = [CTxIn(utxo1, n_sequence=0)]
         tx1a.vout = [CTxOut(int(1.1*COIN), CScript([b'a']))]
-        tx1a_hex = txToHex(tx1a)
+        tx1a_hex = tx_to_hex(tx1a)
         tx1a_txid = self.nodes[0].sendrawtransaction(tx1a_hex, True)
 
         tx1a_txid = int(tx1a_txid, 16)
 
         # Direct spend an output of the transaction we're replacing.
         tx2 = CTransaction()
-        tx2.vin = [CTxIn(utxo1, nSequence=0), CTxIn(utxo2, nSequence=0)]
-        tx2.vin.append(CTxIn(COutPoint(tx1a_txid, 0), nSequence=0))
+        tx2.vin = [CTxIn(utxo1, n_sequence=0), CTxIn(utxo2, n_sequence=0)]
+        tx2.vin.append(CTxIn(COutPoint(tx1a_txid, 0), n_sequence=0))
         tx2.vout = tx1a.vout
-        tx2_hex = txToHex(tx2)
+        tx2_hex = tx_to_hex(tx2)
 
         # This will raise an exception
         assert_raises_rpc_error(-26, "bad-txns-spends-conflicting-tx", self.nodes[0].sendrawtransaction, tx2_hex, True)
 
         # Spend tx1a's output to test the indirect case.
         tx1b = CTransaction()
-        tx1b.vin = [CTxIn(COutPoint(tx1a_txid, 0), nSequence=0)]
+        tx1b.vin = [CTxIn(COutPoint(tx1a_txid, 0), n_sequence=0)]
         tx1b.vout = [CTxOut(1*COIN, CScript([b'a']))]
-        tx1b_hex = txToHex(tx1b)
+        tx1b_hex = tx_to_hex(tx1b)
         tx1b_txid = self.nodes[0].sendrawtransaction(tx1b_hex, True)
         tx1b_txid = int(tx1b_txid, 16)
 
         tx2 = CTransaction()
-        tx2.vin = [CTxIn(utxo1, nSequence=0), CTxIn(utxo2, nSequence=0),
+        tx2.vin = [CTxIn(utxo1, n_sequence=0), CTxIn(utxo2, n_sequence=0),
                    CTxIn(COutPoint(tx1b_txid, 0))]
         tx2.vout = tx1a.vout
-        tx2_hex = txToHex(tx2)
+        tx2_hex = tx_to_hex(tx2)
 
         # This will raise an exception
         assert_raises_rpc_error(-26, "bad-txns-spends-conflicting-tx", self.nodes[0].sendrawtransaction, tx2_hex, True)
@@ -353,13 +354,13 @@ class ReplaceByFeeTest(RavenTestFramework):
         tx1 = CTransaction()
         tx1.vin = [CTxIn(confirmed_utxo)]
         tx1.vout = [CTxOut(1*COIN, CScript([b'a']))]
-        tx1_hex = txToHex(tx1)
+        tx1_hex = tx_to_hex(tx1)
         self.nodes[0].sendrawtransaction(tx1_hex, True)
 
         tx2 = CTransaction()
         tx2.vin = [CTxIn(confirmed_utxo), CTxIn(unconfirmed_utxo)]
         tx2.vout = tx1.vout
-        tx2_hex = txToHex(tx2)
+        tx2_hex = tx_to_hex(tx2)
 
         # This will raise an exception
         assert_raises_rpc_error(-26, "replacement-adds-unconfirmed", self.nodes[0].sendrawtransaction, tx2_hex, True)
@@ -370,19 +371,19 @@ class ReplaceByFeeTest(RavenTestFramework):
         # transactions
 
         # Start by creating a single transaction with many outputs
-        initial_nValue = 10*COIN
-        utxo = make_utxo(self.nodes[0], initial_nValue)
+        initial_n_value = 10 * COIN
+        utxo = make_utxo(self.nodes[0], initial_n_value)
         fee = int(0.0001*COIN)
-        split_value = int((initial_nValue-fee)/(MAX_REPLACEMENT_LIMIT+1))
+        split_value = int((initial_n_value - fee) / (MAX_REPLACEMENT_LIMIT + 1))
 
         outputs = []
         for i in range(MAX_REPLACEMENT_LIMIT+1):
             outputs.append(CTxOut(split_value, CScript([1])))
 
         splitting_tx = CTransaction()
-        splitting_tx.vin = [CTxIn(utxo, nSequence=0)]
+        splitting_tx.vin = [CTxIn(utxo, n_sequence=0)]
         splitting_tx.vout = outputs
-        splitting_tx_hex = txToHex(splitting_tx)
+        splitting_tx_hex = tx_to_hex(splitting_tx)
 
         txid = self.nodes[0].sendrawtransaction(splitting_tx_hex, True)
         txid = int(txid, 16)
@@ -390,9 +391,9 @@ class ReplaceByFeeTest(RavenTestFramework):
         # Now spend each of those outputs individually
         for i in range(MAX_REPLACEMENT_LIMIT+1):
             tx_i = CTransaction()
-            tx_i.vin = [CTxIn(COutPoint(txid, i), nSequence=0)]
+            tx_i.vin = [CTxIn(COutPoint(txid, i), n_sequence=0)]
             tx_i.vout = [CTxOut(split_value-fee, CScript([b'a']))]
-            tx_i_hex = txToHex(tx_i)
+            tx_i_hex = tx_to_hex(tx_i)
             self.nodes[0].sendrawtransaction(tx_i_hex, True)
 
         # Now create doublespend of the whole lot; should fail.
@@ -401,11 +402,11 @@ class ReplaceByFeeTest(RavenTestFramework):
         double_spend_value = (split_value-100*fee)*(MAX_REPLACEMENT_LIMIT+1)
         inputs = []
         for i in range(MAX_REPLACEMENT_LIMIT+1):
-            inputs.append(CTxIn(COutPoint(txid, i), nSequence=0))
+            inputs.append(CTxIn(COutPoint(txid, i), n_sequence=0))
         double_tx = CTransaction()
         double_tx.vin = inputs
         double_tx.vout = [CTxOut(double_spend_value, CScript([b'a']))]
-        double_tx_hex = txToHex(double_tx)
+        double_tx_hex = tx_to_hex(double_tx)
 
         # This will raise an exception
         assert_raises_rpc_error(-26, "too many potential replacements", self.nodes[0].sendrawtransaction, double_tx_hex, True)
@@ -414,7 +415,7 @@ class ReplaceByFeeTest(RavenTestFramework):
         double_tx = CTransaction()
         double_tx.vin = inputs[0:-1]
         double_tx.vout = [CTxOut(double_spend_value, CScript([b'a']))]
-        double_tx_hex = txToHex(double_tx)
+        double_tx_hex = tx_to_hex(double_tx)
         self.nodes[0].sendrawtransaction(double_tx_hex, True)
 
     def test_opt_in(self):
@@ -423,16 +424,16 @@ class ReplaceByFeeTest(RavenTestFramework):
 
         # Create a non-opting in transaction
         tx1a = CTransaction()
-        tx1a.vin = [CTxIn(tx0_outpoint, nSequence=0xffffffff)]
+        tx1a.vin = [CTxIn(tx0_outpoint, n_sequence=0xffffffff)]
         tx1a.vout = [CTxOut(1*COIN, CScript([b'a']))]
-        tx1a_hex = txToHex(tx1a)
+        tx1a_hex = tx_to_hex(tx1a)
         tx1a_txid = self.nodes[0].sendrawtransaction(tx1a_hex, True)
 
         # Shouldn't be able to double-spend
         tx1b = CTransaction()
-        tx1b.vin = [CTxIn(tx0_outpoint, nSequence=0)]
+        tx1b.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
         tx1b.vout = [CTxOut(int(0.9*COIN), CScript([b'b']))]
-        tx1b_hex = txToHex(tx1b)
+        tx1b_hex = tx_to_hex(tx1b)
 
         # This will raise an exception
         assert_raises_rpc_error(-26, "txn-mempool-conflict", self.nodes[0].sendrawtransaction, tx1b_hex, True)
@@ -441,16 +442,16 @@ class ReplaceByFeeTest(RavenTestFramework):
 
         # Create a different non-opting in transaction
         tx2a = CTransaction()
-        tx2a.vin = [CTxIn(tx1_outpoint, nSequence=0xfffffffe)]
+        tx2a.vin = [CTxIn(tx1_outpoint, n_sequence=0xfffffffe)]
         tx2a.vout = [CTxOut(1*COIN, CScript([b'a']))]
-        tx2a_hex = txToHex(tx2a)
+        tx2a_hex = tx_to_hex(tx2a)
         tx2a_txid = self.nodes[0].sendrawtransaction(tx2a_hex, True)
 
         # Still shouldn't be able to double-spend
         tx2b = CTransaction()
-        tx2b.vin = [CTxIn(tx1_outpoint, nSequence=0)]
+        tx2b.vin = [CTxIn(tx1_outpoint, n_sequence=0)]
         tx2b.vout = [CTxOut(int(0.9*COIN), CScript([b'b']))]
-        tx2b_hex = txToHex(tx2b)
+        tx2b_hex = tx_to_hex(tx2b)
 
         # This will raise an exception
         assert_raises_rpc_error(-26, "txn-mempool-conflict", self.nodes[0].sendrawtransaction, tx2b_hex, True)
@@ -463,22 +464,22 @@ class ReplaceByFeeTest(RavenTestFramework):
         tx2a_txid = int(tx2a_txid, 16)
 
         tx3a = CTransaction()
-        tx3a.vin = [CTxIn(COutPoint(tx1a_txid, 0), nSequence=0xffffffff),
-                    CTxIn(COutPoint(tx2a_txid, 0), nSequence=0xfffffffd)]
+        tx3a.vin = [CTxIn(COutPoint(tx1a_txid, 0), n_sequence=0xffffffff),
+                    CTxIn(COutPoint(tx2a_txid, 0), n_sequence=0xfffffffd)]
         tx3a.vout = [CTxOut(int(0.9*COIN), CScript([b'c'])), CTxOut(int(0.9*COIN), CScript([b'd']))]
-        tx3a_hex = txToHex(tx3a)
+        tx3a_hex = tx_to_hex(tx3a)
 
         self.nodes[0].sendrawtransaction(tx3a_hex, True)
 
         tx3b = CTransaction()
-        tx3b.vin = [CTxIn(COutPoint(tx1a_txid, 0), nSequence=0)]
+        tx3b.vin = [CTxIn(COutPoint(tx1a_txid, 0), n_sequence=0)]
         tx3b.vout = [CTxOut(int(0.5*COIN), CScript([b'e']))]
-        tx3b_hex = txToHex(tx3b)
+        tx3b_hex = tx_to_hex(tx3b)
 
         tx3c = CTransaction()
-        tx3c.vin = [CTxIn(COutPoint(tx2a_txid, 0), nSequence=0)]
+        tx3c.vin = [CTxIn(COutPoint(tx2a_txid, 0), n_sequence=0)]
         tx3c.vout = [CTxOut(int(0.5*COIN), CScript([b'f']))]
-        tx3c_hex = txToHex(tx3c)
+        tx3c_hex = tx_to_hex(tx3c)
 
         self.nodes[0].sendrawtransaction(tx3b_hex, True)
         # If tx3b was accepted, tx3c won't look like a replacement,
@@ -493,16 +494,16 @@ class ReplaceByFeeTest(RavenTestFramework):
         tx0_outpoint = make_utxo(self.nodes[0], int(1.1*COIN))
 
         tx1a = CTransaction()
-        tx1a.vin = [CTxIn(tx0_outpoint, nSequence=0)]
+        tx1a.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
         tx1a.vout = [CTxOut(1*COIN, CScript([b'a']))]
-        tx1a_hex = txToHex(tx1a)
+        tx1a_hex = tx_to_hex(tx1a)
         tx1a_txid = self.nodes[0].sendrawtransaction(tx1a_hex, True)
 
         # Higher fee, but the actual fee per KB is much lower.
         tx1b = CTransaction()
-        tx1b.vin = [CTxIn(tx0_outpoint, nSequence=0)]
+        tx1b.vin = [CTxIn(tx0_outpoint, n_sequence=0)]
         tx1b.vout = [CTxOut(int(0.001*COIN), CScript([b'a'*740000]))]
-        tx1b_hex = txToHex(tx1b)
+        tx1b_hex = tx_to_hex(tx1b)
 
         # Verify tx1b cannot replace tx1a.
         assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, True)
@@ -519,17 +520,17 @@ class ReplaceByFeeTest(RavenTestFramework):
         tx1_outpoint = make_utxo(self.nodes[0], int(1.1*COIN))
 
         tx2a = CTransaction()
-        tx2a.vin = [CTxIn(tx1_outpoint, nSequence=0)]
+        tx2a.vin = [CTxIn(tx1_outpoint, n_sequence=0)]
         tx2a.vout = [CTxOut(1*COIN, CScript([b'a']))]
-        tx2a_hex = txToHex(tx2a)
+        tx2a_hex = tx_to_hex(tx2a)
         self.nodes[0].sendrawtransaction(tx2a_hex, True)
 
         # Lower fee, but we'll prioritise it
         tx2b = CTransaction()
-        tx2b.vin = [CTxIn(tx1_outpoint, nSequence=0)]
+        tx2b.vin = [CTxIn(tx1_outpoint, n_sequence=0)]
         tx2b.vout = [CTxOut(int(1.01*COIN), CScript([b'a']))]
         tx2b.rehash()
-        tx2b_hex = txToHex(tx2b)
+        tx2b_hex = tx_to_hex(tx2b)
 
         # Verify tx2b cannot replace tx2a.
         assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx2b_hex, True)
@@ -554,11 +555,11 @@ class ReplaceByFeeTest(RavenTestFramework):
         assert_equal(json1["vin"][0]["sequence"], 4294967295)
 
         rawtx2 = self.nodes[0].createrawtransaction([], outs)
-        frawtx2a = self.nodes[0].fundrawtransaction(rawtx2, {"replaceable": True})
-        frawtx2b = self.nodes[0].fundrawtransaction(rawtx2, {"replaceable": False})
+        f_raw_tx2a = self.nodes[0].fundrawtransaction(rawtx2, {"replaceable": True})
+        f_raw_tx2b = self.nodes[0].fundrawtransaction(rawtx2, {"replaceable": False})
 
-        json0  = self.nodes[0].decoderawtransaction(frawtx2a['hex'])
-        json1  = self.nodes[0].decoderawtransaction(frawtx2b['hex'])
+        json0  = self.nodes[0].decoderawtransaction(f_raw_tx2a['hex'])
+        json1  = self.nodes[0].decoderawtransaction(f_raw_tx2b['hex'])
         assert_equal(json0["vin"][0]["sequence"], 4294967293)
         assert_equal(json1["vin"][0]["sequence"], 4294967294)
 

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -3,16 +3,18 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test running ravend with -reindex and -reindex-chainstate options.
+
+"""
+Test running ravend with -reindex and -reindex-chainstate options.
 
 - Start a single node and generate 3 blocks.
-- Stop the node and restart it with -reindex. Verify that the node has reindexed up to block 3.
-- Stop the node and restart it with -reindex-chainstate. Verify that the node has reindexed up to block 3.
+- Stop the node and restart it with -reindex. Verify that the node has re-indexed up to block 3.
+- Stop the node and restart it with -reindex-chainstate. Verify that the node has re-indexed up to block 3.
 """
 
+import time
 from test_framework.test_framework import RavenTestFramework
 from test_framework.util import assert_equal
-import time
 
 class ReindexTest(RavenTestFramework):
 

--- a/test/functional/feature_restricted_assets.py
+++ b/test/functional/feature_restricted_assets.py
@@ -3,11 +3,13 @@
 # Copyright (c) 2017-2018 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test restricted asset related RPC commands."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_rpc_error, assert_does_not_contain_key, assert_does_not_contain, assert_contains_key, assert_happening, assert_contains
 
+# noinspection PyAttributeOutsideInit
 class RestrictedAssetsTest(RavenTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
@@ -42,26 +44,20 @@ class RestrictedAssetsTest(RavenTestFramework):
         assert_raises_rpc_error(None, "Arguments:", n0.issuerestrictedasset, asset_name, qty, verifier)
 
         # valid params
-        assert_raises_rpc_error(None, "Invalid asset name",
-                                n0.issuerestrictedasset, "$!N\/AL!D", qty, verifier, to_address)
-        assert_raises_rpc_error(None, "Verifier string can not be empty",
-                                n0.issuerestrictedasset, asset_name, qty, "", to_address)
-        assert_raises_rpc_error(None, "bad-txns-null-verifier-failed-syntax-check",
-                                n0.issuerestrictedasset, asset_name, qty, "false && true", to_address)
-        assert_raises_rpc_error(None, "bad-txns-null-verifier-contains-non-issued-qualifier",
-                                n0.issuerestrictedasset, asset_name, qty, "#NONEXIZTENT", to_address)
-        assert_raises_rpc_error(None, "Invalid Raven address",
-                                n0.issuerestrictedasset, asset_name, qty, verifier, "garbageaddress")
+        assert_raises_rpc_error(None, "Invalid asset name", n0.issuerestrictedasset, "$!N\/AL!D", qty, verifier, to_address)
+        assert_raises_rpc_error(None, "Verifier string can not be empty", n0.issuerestrictedasset, asset_name, qty, "", to_address)
+        assert_raises_rpc_error(None, "bad-txns-null-verifier-failed-syntax-check", n0.issuerestrictedasset, asset_name, qty, "false && true", to_address)
+        assert_raises_rpc_error(None, "bad-txns-null-verifier-contains-non-issued-qualifier", n0.issuerestrictedasset, asset_name, qty, "#NONEXIZTENT", to_address)
+        assert_raises_rpc_error(None, "Invalid Raven address", n0.issuerestrictedasset, asset_name, qty, verifier, "garbageaddress")
 
         # base asset required
-        assert_raises_rpc_error(-32600, f"Wallet doesn't have asset: {base_asset_name}!",
-                                n0.issuerestrictedasset, asset_name, qty, verifier, to_address)
+        assert_raises_rpc_error(-32600, f"Wallet doesn't have asset: {base_asset_name}!", n0.issuerestrictedasset, asset_name, qty, verifier, to_address)
         n0.issue(base_asset_name)
 
         # issue
         txid = n0.issuerestrictedasset(asset_name, qty, verifier, to_address)
 
-        #verify
+        # verify
         assert_equal(64, len(txid[0]))
         assert_equal(qty, n0.listmyassets(asset_name, True)[asset_name]['balance'])
         n0.generate(1)
@@ -89,18 +85,14 @@ class RestrictedAssetsTest(RavenTestFramework):
         n0.issue(base_asset_name)
 
         # valid params
-        assert_raises_rpc_error(None, "Invalid Raven address",
-                                n0.issuerestrictedasset, asset_name, qty, verifier, to_address, "garbagechangeaddress")
-        assert_raises_rpc_error(None, "Units must be between 0 and 8",
-                                n0.issuerestrictedasset, asset_name, qty, verifier, to_address, change_address, 9)
-        assert_raises_rpc_error(None, "Units must be between 0 and 8",
-                                n0.issuerestrictedasset, asset_name, qty, verifier, to_address, change_address, -1)
+        assert_raises_rpc_error(None, "Invalid Raven address", n0.issuerestrictedasset, asset_name, qty, verifier, to_address, "garbagechangeaddress")
+        assert_raises_rpc_error(None, "Units must be between 0 and 8", n0.issuerestrictedasset, asset_name, qty, verifier, to_address, change_address, 9)
+        assert_raises_rpc_error(None, "Units must be between 0 and 8", n0.issuerestrictedasset, asset_name, qty, verifier, to_address, change_address, -1)
 
-        #issue
-        txid = n0.issuerestrictedasset(asset_name, qty, verifier, to_address, change_address, units, reissuable,
-                                       has_ipfs, ipfs_hash)
+        # issue
+        txid = n0.issuerestrictedasset(asset_name, qty, verifier, to_address, change_address, units, reissuable, has_ipfs, ipfs_hash)
 
-        #verify
+        # verify
         assert_equal(64, len(txid[0]))
         assert_equal(qty, n0.listmyassets(asset_name, True)[asset_name]['balance'])
         n0.generate(1)
@@ -150,25 +142,15 @@ class RestrictedAssetsTest(RavenTestFramework):
         n0.generate(1)
 
         # valid params
-        assert_raises_rpc_error(None, "Invalid asset name",
-                                n0.reissuerestrictedasset, "$!N\/AL!D", qty, to_address)
-        assert_raises_rpc_error(None, "Wallet doesn't have asset",
-                                n0.reissuerestrictedasset, foreign_asset_name, qty, to_address)
-        assert_raises_rpc_error(None, "Invalid Raven address",
-                                n0.reissuerestrictedasset, asset_name, qty, "garbageaddress")
-        assert_raises_rpc_error(None, "Invalid Raven address",
-                                n0.reissuerestrictedasset, asset_name, qty, to_address,
-                                change_verifier, verifier, "garbagechangeaddress")
-        assert_raises_rpc_error(None, "Units must be between -1 and 8",
-                                n0.reissuerestrictedasset, asset_name, qty, to_address,
-                                change_verifier, verifier, change_address, 9)
-        assert_raises_rpc_error(None, "Units must be between -1 and 8",
-                                n0.reissuerestrictedasset, asset_name, qty, to_address,
-                                change_verifier, verifier, change_address, -2)
+        assert_raises_rpc_error(None, "Invalid asset name", n0.reissuerestrictedasset, "$!N\/AL!D", qty, to_address)
+        assert_raises_rpc_error(None, "Wallet doesn't have asset", n0.reissuerestrictedasset, foreign_asset_name, qty, to_address)
+        assert_raises_rpc_error(None, "Invalid Raven address", n0.reissuerestrictedasset, asset_name, qty, "garbageaddress")
+        assert_raises_rpc_error(None, "Invalid Raven address", n0.reissuerestrictedasset, asset_name, qty, to_address, change_verifier, verifier, "garbagechangeaddress")
+        assert_raises_rpc_error(None, "Units must be between -1 and 8", n0.reissuerestrictedasset, asset_name, qty, to_address, change_verifier, verifier, change_address, 9)
+        assert_raises_rpc_error(None, "Units must be between -1 and 8", n0.reissuerestrictedasset, asset_name, qty, to_address, change_verifier, verifier, change_address, -2)
 
         # reissue
-        txid = n0.reissuerestrictedasset(asset_name, qty, to_address,
-                                         change_verifier, verifier, change_address, units, reissuable, ipfs_hash)
+        txid = n0.reissuerestrictedasset(asset_name, qty, to_address, change_verifier, verifier, change_address, units, reissuable, ipfs_hash)
 
         # verify
         assert_equal(64, len(txid[0]))
@@ -204,7 +186,7 @@ class RestrictedAssetsTest(RavenTestFramework):
         assert_equal(False, asset_data['reissuable'])
         assert_equal(False, asset_data['has_ipfs'])
 
-    def issuequalifierasset_full(self):
+    def issue_qualifier_asset_full(self):
         self.log.info("Testing issuequalifierasset() with all params...")
         n0 = self.nodes[0]
 
@@ -216,13 +198,9 @@ class RestrictedAssetsTest(RavenTestFramework):
         ipfs_hash = "QmacSRmrkVmvJfbCpmU6pK72furJ8E8fbKHindrLxmYMQo"
 
         assert_raises_rpc_error(None, "Amount must be between 1 and 10", n0.issuequalifierasset, asset_name, 0)
-        assert_raises_rpc_error(None, "Invalid Raven address", n0.issuequalifierasset, asset_name, qty,
-                                "garbageaddress")
-        assert_raises_rpc_error(None, "Invalid Raven address", n0.issuequalifierasset, asset_name, qty, to_address,
-                                "gargabechangeaddress")
-        assert_raises_rpc_error(None, "ipfs_hash must be 46 characters", n0.issuequalifierasset, asset_name, qty,
-                                to_address, change_address, True)
-
+        assert_raises_rpc_error(None, "Invalid Raven address", n0.issuequalifierasset, asset_name, qty, "garbageaddress")
+        assert_raises_rpc_error(None, "Invalid Raven address", n0.issuequalifierasset, asset_name, qty, to_address, "gargabechangeaddress")
+        assert_raises_rpc_error(None, "ipfs_hash must be 46 characters", n0.issuequalifierasset, asset_name, qty, to_address, change_address, True)
 
         # issue
         txid = n0.issuequalifierasset(asset_name, qty, to_address, change_address, has_ipfs, ipfs_hash)
@@ -252,16 +230,13 @@ class RestrictedAssetsTest(RavenTestFramework):
         n0.generate(1)
         self.sync_all()
 
-        assert_equal(1, n0.listmyassets(asset_name,  True)[asset_name]['balance'])
+        assert_equal(1, n0.listmyassets(asset_name, True)[asset_name]['balance'])
         assert_does_not_contain_key(asset_name, n1.listmyassets())
 
-        assert_raises_rpc_error(None, "Only use this rpc call to send Qualifier assets", n0.transferqualifier,
-                                nonqualifier_asset_name, 1, n1_address)
+        assert_raises_rpc_error(None, "Only use this rpc call to send Qualifier assets", n0.transferqualifier, nonqualifier_asset_name, 1, n1_address)
         assert_raises_rpc_error(None, "Invalid Raven address", n0.transferqualifier, asset_name, 1, "garbageaddress")
-        assert_raises_rpc_error(None, "Invalid Raven address", n0.transferqualifier, asset_name, 1, n1_address,
-                                "garbagechangeaddress")
-        assert_raises_rpc_error(None, "Invalid IPFS hash", n0.transferqualifier, asset_name, 1, n1_address,
-                                n0_change_address, "garbagemessage")
+        assert_raises_rpc_error(None, "Invalid Raven address", n0.transferqualifier, asset_name, 1, n1_address, "garbagechangeaddress")
+        assert_raises_rpc_error(None, "Invalid IPFS hash", n0.transferqualifier, asset_name, 1, n1_address, n0_change_address, "garbagemessage")
 
         # transfer
         txid = n0.transferqualifier(asset_name, 1, n1_address, n0_change_address, message)
@@ -290,12 +265,12 @@ class RestrictedAssetsTest(RavenTestFramework):
         verifier = tag
         issue_address = n0.getnewaddress()
         n0.issue(base_asset_name)
-        assert_raises_rpc_error(-8, "bad-txns-null-verifier-address-failed-verification", n0.issuerestrictedasset,
-            asset_name, qty, verifier, issue_address)
+        assert_raises_rpc_error(-8, "bad-txns-null-verifier-address-failed-verification", n0.issuerestrictedasset, asset_name, qty, verifier, issue_address)
 
         # Isolate this test from other tagging on n0...
         def viewmytaggedaddresses():
             return list(filter(lambda x: tag == x['Tag Name'], n0.viewmytaggedaddresses()))
+
         assert_equal(0, len(viewmytaggedaddresses()))
 
         n0.addtagtoaddress(tag, issue_address, change_address)
@@ -317,8 +292,7 @@ class RestrictedAssetsTest(RavenTestFramework):
         assert_contains_key('Assigned', t1)
         assert_happening(t1['Assigned'])
 
-        assert_raises_rpc_error(-8, "bad-txns-null-verifier-address-failed-verification", n0.transfer,
-                                asset_name, 100, address)
+        assert_raises_rpc_error(-8, "bad-txns-null-verifier-address-failed-verification", n0.transfer, asset_name, 100, address)
 
         # special case: make sure transfer fails if change address(es) are verified even though to address isn't
         rvn_change_address = n0.getnewaddress()
@@ -326,23 +300,20 @@ class RestrictedAssetsTest(RavenTestFramework):
         n0.addtagtoaddress(tag, rvn_change_address)
         n0.addtagtoaddress(tag, asset_change_address)
         n0.generate(1)
-        assert_raises_rpc_error(-8, "bad-txns-null-verifier-address-failed-verification", n0.transfer,
-                                asset_name, 100, address, "", 0, rvn_change_address, asset_change_address)
+        assert_raises_rpc_error(-8, "bad-txns-null-verifier-address-failed-verification", n0.transfer, asset_name, 100, address, "", 0, rvn_change_address, asset_change_address)
         n0.removetagfromaddress(tag, rvn_change_address)
         n0.removetagfromaddress(tag, asset_change_address)
         n0.generate(1)
         ##
 
         assert_raises_rpc_error(None, "Invalid Raven address", n0.addtagtoaddress, tag, "garbageaddress")
-        assert_raises_rpc_error(None, "Invalid Raven change address", n0.addtagtoaddress, tag, address,
-                                "garbagechangeaddress")
+        assert_raises_rpc_error(None, "Invalid Raven change address", n0.addtagtoaddress, tag, address, "garbagechangeaddress")
 
         n0.addtagtoaddress(tag, address, change_address)
         n0.addtagtoaddress(tag, address, change_address)  # redundant tagging ok if consistent
         n0.generate(1)
 
-        assert_raises_rpc_error(-32600, "add-qualifier-when-already-assigned", n0.addtagtoaddress,
-                                tag, address, change_address)
+        assert_raises_rpc_error(-32600, "add-qualifier-when-already-assigned", n0.addtagtoaddress, tag, address, change_address)
 
         # post-tagging verification
         assert_contains(address, n0.listaddressesfortag(tag))
@@ -351,12 +322,12 @@ class RestrictedAssetsTest(RavenTestFramework):
 
         # viewmytaggedaddresses
         tagged = viewmytaggedaddresses()
-        assert_equal(4, len(tagged))  # includes removed...
+        assert_equal(4, len(tagged))
         assert_contains(issue_address, list(map(lambda x: x['Address'], tagged)))
         assert_contains(address, list(map(lambda x: x['Address'], tagged)))
         for t in tagged:
             assert_equal(tag, t['Tag Name'])
-            if ('Assigned' in t):
+            if 'Assigned' in t:
                 assert_happening(t['Assigned'])
             else:
                 assert_happening(t['Removed'])
@@ -364,15 +335,12 @@ class RestrictedAssetsTest(RavenTestFramework):
         # special case: make sure transfer fails if the asset change address isn't verified (even if the rvn change address is)
         rvn_change_address = n0.getnewaddress()
         asset_change_address = n0.getnewaddress()
-        assert_raises_rpc_error(-20, "bad-txns-null-verifier-address-failed-verification", n0.transfer,
-                                asset_name, 100, address, "", 0, rvn_change_address, asset_change_address)
+        assert_raises_rpc_error(-20, "bad-txns-null-verifier-address-failed-verification", n0.transfer, asset_name, 100, address, "", 0, rvn_change_address, asset_change_address)
         n0.addtagtoaddress(tag, rvn_change_address)
         n0.generate(1)
-        assert_raises_rpc_error(-20, "bad-txns-null-verifier-address-failed-verification", n0.transfer,
-                                asset_name, 100, address, "", 0, rvn_change_address, asset_change_address)
+        assert_raises_rpc_error(-20, "bad-txns-null-verifier-address-failed-verification", n0.transfer, asset_name, 100, address, "", 0, rvn_change_address, asset_change_address)
         n0.removetagfromaddress(tag, rvn_change_address)
         n0.generate(1)
-        ##
 
         # do the transfer already!
         txid = n0.transfer(asset_name, 100, address)
@@ -387,18 +355,16 @@ class RestrictedAssetsTest(RavenTestFramework):
         txid = n0.transfer(asset_name, 1, issue_address, "", 0, "", asset_change_address)
         n0.generate(1)
         assert_equal(64, len(txid[0]))
-        assert(n0.listassetbalancesbyaddress(asset_change_address)[asset_name] > 0)
+        assert (n0.listassetbalancesbyaddress(asset_change_address)[asset_name] > 0)
 
         assert_raises_rpc_error(None, "Invalid Raven address", n0.removetagfromaddress, tag, "garbageaddress")
-        assert_raises_rpc_error(None, "Invalid Raven change address", n0.removetagfromaddress, tag, address,
-                                "garbagechangeaddress")
+        assert_raises_rpc_error(None, "Invalid Raven change address", n0.removetagfromaddress, tag, address, "garbagechangeaddress")
 
         n0.removetagfromaddress(tag, address, change_address)
-        n0.removetagfromaddress(tag, address, change_address) # redundant untagging ok if consistent
+        n0.removetagfromaddress(tag, address, change_address)  # redundant untagging ok if consistent
         n0.generate(1)
 
-        assert_raises_rpc_error(-32600, "removing-qualifier-when-not-assigned", n0.removetagfromaddress,
-                                tag, address, change_address)
+        assert_raises_rpc_error(-32600, "removing-qualifier-when-not-assigned", n0.removetagfromaddress, tag, address, change_address)
 
         # TODO: test without specifying change address when there are no valid change addresses (all untagged)
 
@@ -409,7 +375,7 @@ class RestrictedAssetsTest(RavenTestFramework):
 
         # viewmytaggedaddresses
         tagged = viewmytaggedaddresses()
-        assert_equal(6, len(tagged)) # includes removed
+        assert_equal(6, len(tagged))  # includes removed
         assert_contains(issue_address, list(map(lambda x: x['Address'], tagged)))
         assert_contains(address, list(map(lambda x: x['Address'], tagged)))
         for t in tagged:
@@ -419,8 +385,7 @@ class RestrictedAssetsTest(RavenTestFramework):
             if address == t['Address']:
                 assert_happening(t['Removed'])
 
-        assert_raises_rpc_error(-8, "bad-txns-null-verifier-address-failed-verification", n0.transfer,
-                                asset_name, 100, address)
+        assert_raises_rpc_error(-8, "bad-txns-null-verifier-address-failed-verification", n0.transfer, asset_name, 100, address)
 
     def freezing(self):
         self.log.info("Testing freezing...")
@@ -464,18 +429,16 @@ class RestrictedAssetsTest(RavenTestFramework):
         self.sync_all()
         assert_equal(9000, n0.listassetbalancesbyaddress(change_address)[asset_name])
         assert_equal(1000, n1.listmyassets()[asset_name])
-        address = change_address # assets have moved
+        address = change_address  # assets have moved
 
         assert_raises_rpc_error(None, "Invalid Raven address", n0.freezeaddress, asset_name, "garbageaddress")
-        assert_raises_rpc_error(None, "Invalid Raven change address", n0.freezeaddress, asset_name, address,
-                                "garbagechangeaddress")
+        assert_raises_rpc_error(None, "Invalid Raven change address", n0.freezeaddress, asset_name, address, "garbagechangeaddress")
 
         n0.freezeaddress(asset_name, address, rvn_change_address)
-        n0.freezeaddress(asset_name, address, rvn_change_address) # redundant freezing ok if consistent
+        n0.freezeaddress(asset_name, address, rvn_change_address)  # redundant freezing ok if consistent
         n0.generate(1)
 
-        assert_raises_rpc_error(-32600, "freeze-address-when-already-frozen", n0.freezeaddress,
-                                asset_name, address, rvn_change_address)
+        assert_raises_rpc_error(-32600, "freeze-address-when-already-frozen", n0.freezeaddress, asset_name, address, rvn_change_address)
 
         # post-freezing verification
         assert_contains(asset_name, n0.listaddressrestrictions(address))
@@ -489,19 +452,16 @@ class RestrictedAssetsTest(RavenTestFramework):
         assert_equal(asset_name, r['Asset Name'])
         assert_happening(r['Restricted'])
 
-        assert_raises_rpc_error(-8, "No asset outpoints are selected from the given address", n0.transferfromaddress,
-                                asset_name, address, 1000, n1.getnewaddress())
+        assert_raises_rpc_error(-8, "No asset outpoints are selected from the given address", n0.transferfromaddress, asset_name, address, 1000, n1.getnewaddress())
 
         assert_raises_rpc_error(None, "Invalid Raven address", n0.unfreezeaddress, asset_name, "garbageaddress")
-        assert_raises_rpc_error(None, "Invalid Raven change address", n0.unfreezeaddress, asset_name, address,
-                                "garbagechangeaddress")
+        assert_raises_rpc_error(None, "Invalid Raven change address", n0.unfreezeaddress, asset_name, address, "garbagechangeaddress")
 
         n0.unfreezeaddress(asset_name, address, rvn_change_address)
-        n0.unfreezeaddress(asset_name, address, rvn_change_address) # redundant unfreezing ok if consistent
+        n0.unfreezeaddress(asset_name, address, rvn_change_address)  # redundant unfreezing ok if consistent
         n0.generate(1)
 
-        assert_raises_rpc_error(-32600, "unfreeze-address-when-not-frozen", n0.unfreezeaddress,
-                                asset_name, address, rvn_change_address)
+        assert_raises_rpc_error(-32600, "unfreeze-address-when-not-frozen", n0.unfreezeaddress, asset_name, address, rvn_change_address)
 
         # post-unfreezing verification
         assert_does_not_contain(asset_name, n0.listaddressrestrictions(address))
@@ -522,7 +482,6 @@ class RestrictedAssetsTest(RavenTestFramework):
         self.sync_all()
         assert_equal(8000, n0.listassetbalancesbyaddress(change_address)[asset_name])
         assert_equal(2000, n1.listmyassets()[asset_name])
-        address = change_address # assets have moved
 
     def global_freezing(self):
         self.log.info("Testing global freezing...")
@@ -551,33 +510,28 @@ class RestrictedAssetsTest(RavenTestFramework):
         self.sync_all()
         assert_equal(9000, n0.listassetbalancesbyaddress(change_address)[asset_name])
         assert_equal(1000, n1.listmyassets()[asset_name])
-        address = change_address # assets have moved
+        address = change_address  # assets have moved
 
-        assert_raises_rpc_error(None, "Invalid Raven change address", n0.freezerestrictedasset, asset_name,
-                                "garbagechangeaddress")
+        assert_raises_rpc_error(None, "Invalid Raven change address", n0.freezerestrictedasset, asset_name, "garbagechangeaddress")
 
         n0.freezerestrictedasset(asset_name, rvn_change_address)
-        n0.freezerestrictedasset(asset_name, rvn_change_address) # redundant freezing ok if consistent
+        n0.freezerestrictedasset(asset_name, rvn_change_address)  # redundant freezing ok if consistent
         n0.generate(1)
 
-        assert_raises_rpc_error(None, "global-freeze-when-already-frozen", n0.freezerestrictedasset,
-                                asset_name, rvn_change_address)
+        assert_raises_rpc_error(None, "global-freeze-when-already-frozen", n0.freezerestrictedasset, asset_name, rvn_change_address)
 
         # post-freeze validation
         assert_contains(asset_name, n0.listglobalrestrictions())
         assert n0.checkglobalrestriction(asset_name)
-        assert_raises_rpc_error(-8, "restricted asset has been globally frozen", n0.transferfromaddress,
-                                asset_name, address, 1000, n1.getnewaddress())
+        assert_raises_rpc_error(-8, "restricted asset has been globally frozen", n0.transferfromaddress, asset_name, address, 1000, n1.getnewaddress())
 
-        assert_raises_rpc_error(None, "Invalid Raven change address", n0.unfreezerestrictedasset, asset_name,
-                                "garbagechangeaddress")
+        assert_raises_rpc_error(None, "Invalid Raven change address", n0.unfreezerestrictedasset, asset_name, "garbagechangeaddress")
 
         n0.unfreezerestrictedasset(asset_name, rvn_change_address)
-        n0.unfreezerestrictedasset(asset_name, rvn_change_address) # redundant unfreezing ok if consistent
+        n0.unfreezerestrictedasset(asset_name, rvn_change_address)  # redundant unfreezing ok if consistent
         n0.generate(1)
 
-        assert_raises_rpc_error(None, "global-unfreeze-when-not-frozen", n0.unfreezerestrictedasset,
-                                asset_name, rvn_change_address)
+        assert_raises_rpc_error(None, "global-unfreeze-when-not-frozen", n0.unfreezerestrictedasset, asset_name, rvn_change_address)
 
         # post-unfreeze validation
         assert_does_not_contain(asset_name, n0.listglobalrestrictions())
@@ -589,8 +543,6 @@ class RestrictedAssetsTest(RavenTestFramework):
         self.sync_all()
         assert_equal(8000, n0.listassetbalancesbyaddress(change_address)[asset_name])
         assert_equal(2000, n1.listmyassets()[asset_name])
-        address = change_address # assets have moved
-
 
     def isvalidverifierstring(self):
         self.log.info("Testing isvalidverifierstring()...")
@@ -614,8 +566,7 @@ class RestrictedAssetsTest(RavenTestFramework):
             "    "
         ]
         for s in invalid_empty:
-            assert_raises_rpc_error(-8, "Verifier string can not be empty",
-                                    n0.isvalidverifierstring, s)
+            assert_raises_rpc_error(-8, "Verifier string can not be empty", n0.isvalidverifierstring, s)
 
         invalid_syntax = [
             "asdf",
@@ -624,12 +575,9 @@ class RestrictedAssetsTest(RavenTestFramework):
         for s in invalid_syntax:
             assert_raises_rpc_error(-8, "failed-syntax", n0.isvalidverifierstring, s)
 
-        invalid_non_issued = [
-            "#NOPE"
-        ]
+        invalid_non_issued = ["#NOPE"]
         for s in invalid_non_issued:
-            assert_raises_rpc_error(-8, "contains-non-issued-qualifier",
-                                    n0.isvalidverifierstring, s)
+            assert_raises_rpc_error(-8, "contains-non-issued-qualifier", n0.isvalidverifierstring, s)
 
     def run_test(self):
         self.activate_restricted_assets()
@@ -638,12 +586,13 @@ class RestrictedAssetsTest(RavenTestFramework):
         self.issuerestrictedasset_full()
         self.reissuerestrictedasset_full()
         self.issuequalifierasset()
-        self.issuequalifierasset_full()
+        self.issue_qualifier_asset_full()
         self.transferqualifier()
         self.tagging()
         self.freezing()
         self.global_freezing()
         self.isvalidverifierstring()
+
 
 if __name__ == '__main__':
     RestrictedAssetsTest().main()

--- a/test/functional/feature_rewards.py
+++ b/test/functional/feature_rewards.py
@@ -3,20 +3,19 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Testing rewards use cases
 
-"""
+"""Testing rewards use cases"""
+
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_rpc_error, assert_contains, Decimal
 
-
-import string
-
+# noinspection PyAttributeOutsideInit
 class RewardsTest(RavenTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 4
-        self.extra_args = [["-assetindex", "-debug=rewards"], ["-assetindex", "-minrewardheight=15"], ["-assetindex"], ["-assetindex"]]
+        self.extra_args = [["-assetindex", "-debug=rewards"], ["-assetindex", "-minrewardheight=15"], ["-assetindex"],
+                           ["-assetindex"]]
 
     def activate_assets(self):
         self.log.info("Generating RVN for node[0] and activating assets...")
@@ -28,130 +27,129 @@ class RewardsTest(RavenTestFramework):
         self.sync_all()
         assert_equal("active", n0.getblockchaininfo()["bip9_softforks"]["assets"]["status"])
 
-    ## Basic functionality test - RVN reward
-    ## - create the main owner address
-    ## - mine blocks to have enouugh RVN for the reward payments, plus purchasing the asset
-    ## - issue the STOCK1 asset to the owner
-    ## - create 5 shareholder addresses
-    ## - distribute different amounts of the STOCK1 asset to each of the shareholder addresses
-    ## - mine some blocks
-    ## - retrieve the current chain height
-    ## - distribute an RVN reward amongst the shareholders
-    ## - verify that each one receives the expected amount of reward RVN
+    # Basic functionality test - RVN reward
+    # - create the main owner address
+    # - mine blocks to have enough RVN for the reward payments, plus purchasing the asset
+    # - issue the STOCK1 asset to the owner
+    # - create 5 shareholder addresses
+    # - distribute different amounts of the STOCK1 asset to each of the shareholder addresses
+    # - mine some blocks
+    # - retrieve the current chain height
+    # - distribute an RVN reward amongst the shareholders
+    # - verify that each one receives the expected amount of reward RVN
     def basic_test_rvn(self):
         self.log.info("Running basic RVN reward test!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
-        # self.log.info(f"Owner address: {ownerAddr0}")
+        owner_addr0 = n0.getnewaddress()
+        # self.log.info(f"Owner address: {owner_addr0}")
 
         self.log.info("Creating distributor address")
-        distAddr0 = n0.getnewaddress()
-        # self.log.info(f"Distributor address: {distAddr0}")
+        dist_addr0 = n0.getnewaddress()
+        # self.log.info(f"Distributor address: {dist_addr0}")
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing STOCK1 asset")
-        n0.issue(asset_name="STOCK1", qty=10000, to_address=ownerAddr0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="STOCK1", qty=10000, to_address=owner_addr0, change_address="", units=4, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Checking listassetbalancesbyaddress()...")
-        assert_equal(n0.listassetbalancesbyaddress(ownerAddr0)["STOCK1"], 10000)
+        assert_equal(n0.listassetbalancesbyaddress(owner_addr0)["STOCK1"], 10000)
 
         self.log.info("Transferring all assets to a single address for tracking")
-        n0.transfer(asset_name="STOCK1", qty=10000, to_address=distAddr0)
+        n0.transfer(asset_name="STOCK1", qty=10000, to_address=dist_addr0)
         n0.generate(10)
         self.sync_all()
-        assert_equal(n0.listassetbalancesbyaddress(distAddr0)["STOCK1"], 10000)
+        assert_equal(n0.listassetbalancesbyaddress(dist_addr0)["STOCK1"], 10000)
 
         self.log.info("Creating shareholder addresses")
-        shareholderAddr0 = n0.getnewaddress()
-        shareholderAddr1 = n1.getnewaddress()
-        shareholderAddr2 = n2.getnewaddress()
-        shareholderAddr3 = n1.getnewaddress()
-        shareholderAddr4 = n0.getnewaddress()
+        shareholder_addr0 = n0.getnewaddress()
+        shareholder_addr1 = n1.getnewaddress()
+        shareholder_addr2 = n2.getnewaddress()
+        shareholder_addr3 = n1.getnewaddress()
+        shareholder_addr4 = n0.getnewaddress()
 
         self.log.info("Distributing shares")
-        n0.transfer(asset_name="STOCK1", qty=200, to_address=shareholderAddr0, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        n0.transfer(asset_name="STOCK1", qty=300, to_address=shareholderAddr1, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        n0.transfer(asset_name="STOCK1", qty=400, to_address=shareholderAddr2, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        n0.transfer(asset_name="STOCK1", qty=500, to_address=shareholderAddr3, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        n0.transfer(asset_name="STOCK1", qty=600, to_address=shareholderAddr4, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
+        n0.transfer(asset_name="STOCK1", qty=200, to_address=shareholder_addr0, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        n0.transfer(asset_name="STOCK1", qty=300, to_address=shareholder_addr1, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        n0.transfer(asset_name="STOCK1", qty=400, to_address=shareholder_addr2, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        n0.transfer(asset_name="STOCK1", qty=500, to_address=shareholder_addr3, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        n0.transfer(asset_name="STOCK1", qty=600, to_address=shareholder_addr4, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Verifying share distribution")
-        ##ownerDetails = n0.listmyassets("STOCK1", True)
-        ##self.log.info(f"Owner: {ownerDetails}")
-        ##distDetails = n0.listassetbalancesbyaddress(distAddr0)
-        ##self.log.info(f"Change: {distDetails}")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)["STOCK1"], 200)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["STOCK1"], 300)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["STOCK1"], 400)
-        assert_equal(n2.listassetbalancesbyaddress(shareholderAddr3)["STOCK1"], 500)
-        assert_equal(n2.listassetbalancesbyaddress(shareholderAddr4)["STOCK1"], 600)
-        assert_equal(n0.listassetbalancesbyaddress(distAddr0)["STOCK1"], 8000)
+        # ownerDetails = n0.listmyassets("STOCK1", True)
+        # self.log.info(f"Owner: {ownerDetails}")
+        # distDetails = n0.listassetbalancesbyaddress(dist_addr0)
+        # self.log.info(f"Change: {distDetails}")
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)["STOCK1"], 200)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["STOCK1"], 300)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["STOCK1"], 400)
+        assert_equal(n2.listassetbalancesbyaddress(shareholder_addr3)["STOCK1"], 500)
+        assert_equal(n2.listassetbalancesbyaddress(shareholder_addr4)["STOCK1"], 600)
+        assert_equal(n0.listassetbalancesbyaddress(dist_addr0)["STOCK1"], 8000)
 
         self.log.info("Mining blocks")
         n0.generate(200)
         self.sync_all()
 
         self.log.info("Providing additional funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 2000)
+        self.nodes[0].sendtoaddress(owner_addr0, 2000)
         n0.generate(100)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 100
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 100
 
         self.log.info("Requesting snapshot of STOCK1 ownership in 100 blocks")
-        n0.requestsnapshot(asset_name="STOCK1", block_height=tgtBlockHeight)
+        n0.requestsnapshot(asset_name="STOCK1", block_height=tgt_block_height)
 
         n0.generate(61)
 
         self.log.info("Retrieving snapshot request")
-        snapShotReq = n0.getsnapshotrequest(asset_name="STOCK1", block_height=tgtBlockHeight)
-        assert_equal(snapShotReq["asset_name"], "STOCK1")
-        assert_equal(snapShotReq["block_height"], tgtBlockHeight)
+        snap_shot_req = n0.getsnapshotrequest(asset_name="STOCK1", block_height=tgt_block_height)
+        assert_equal(snap_shot_req["asset_name"], "STOCK1")
+        assert_equal(snap_shot_req["block_height"], tgt_block_height)
 
         self.log.info("Skipping forward to allow snapshot to process")
         n0.generate(100)
         self.sync_all()
 
         self.log.info("Retrieving snapshot for ownership validation")
-        snapShot = n0.getsnapshot(asset_name="STOCK1", block_height=tgtBlockHeight)
-        assert_equal(snapShot["name"], "STOCK1")
-        assert_equal(snapShot["height"], tgtBlockHeight)
+        snap_shot = n0.getsnapshot(asset_name="STOCK1", block_height=tgt_block_height)
+        assert_equal(snap_shot["name"], "STOCK1")
+        assert_equal(snap_shot["height"], tgt_block_height)
         owner0 = False
         owner1 = False
         owner2 = False
         owner3 = False
         owner4 = False
         owner5 = False
-        for ownerAddr in snapShot["owners"]:
-            ##self.log.info(f"Found owner {ownerAddr}")
-            if ownerAddr["address"] == shareholderAddr0:
+        for ownerAddr in snap_shot["owners"]:
+            # self.log.info(f"Found owner {ownerAddr}")
+            if ownerAddr["address"] == shareholder_addr0:
                 assert_equal(ownerAddr["amount_owned"], 200)
                 owner0 = True
-            elif ownerAddr["address"] == shareholderAddr1:
+            elif ownerAddr["address"] == shareholder_addr1:
                 assert_equal(ownerAddr["amount_owned"], 300)
                 owner1 = True
-            elif ownerAddr["address"] == shareholderAddr2:
+            elif ownerAddr["address"] == shareholder_addr2:
                 assert_equal(ownerAddr["amount_owned"], 400)
                 owner2 = True
-            elif ownerAddr["address"] == shareholderAddr3:
+            elif ownerAddr["address"] == shareholder_addr3:
                 assert_equal(ownerAddr["amount_owned"], 500)
                 owner3 = True
-            elif ownerAddr["address"] == shareholderAddr4:
+            elif ownerAddr["address"] == shareholder_addr4:
                 assert_equal(ownerAddr["amount_owned"], 600)
                 owner4 = True
-            elif ownerAddr["address"] == distAddr0:
+            elif ownerAddr["address"] == dist_addr0:
                 assert_equal(ownerAddr["amount_owned"], 8000)
                 owner5 = True
         assert_equal(owner0, True)
@@ -161,147 +159,146 @@ class RewardsTest(RavenTestFramework):
         assert_equal(owner4, True)
         assert_equal(owner5, True)
 
-        ##  listassetbalancesbyaddress only lists the most recently delivered amount
-        ##      for the address, which I believe is a bug, since there can only be one
-        ##      key in the result object with the asset name.
-        ##self.log.info("Moving shares after snapshot")
-        ##n0.transfer(asset_name="STOCK1", qty=100, to_address=shareholderAddr0, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        ##n0.transfer(asset_name="STOCK1", qty=100, to_address=shareholderAddr1, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        ##n0.transfer(asset_name="STOCK1", qty=100, to_address=shareholderAddr2, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        ##n0.transfer(asset_name="STOCK1", qty=100, to_address=shareholderAddr3, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        ##n0.transfer(asset_name="STOCK1", qty=100, to_address=shareholderAddr4, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        ##n0.generate(100)
-        ##self.sync_all()
+        #   listassetbalancesbyaddress only lists the most recently delivered amount
+        #       for the address, which I believe is a bug, since there can only be one
+        #       key in the result object with the asset name.
+        # self.log.info("Moving shares after snapshot")
+        # n0.transfer(asset_name="STOCK1", qty=100, to_address=shareholder_addr0, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        # n0.transfer(asset_name="STOCK1", qty=100, to_address=shareholder_addr1, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        # n0.transfer(asset_name="STOCK1", qty=100, to_address=shareholder_addr2, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        # n0.transfer(asset_name="STOCK1", qty=100, to_address=shareholder_addr3, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        # n0.transfer(asset_name="STOCK1", qty=100, to_address=shareholder_addr4, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        # n0.generate(100)
+        # self.sync_all()
 
-        ##self.log.info("Verifying share distribution after snapshot")
-        ##assert_equal(n2.listassetbalancesbyaddress(shareholderAddr0)["STOCK1"], 300)
-        ##assert_equal(n2.listassetbalancesbyaddress(shareholderAddr1)["STOCK1"], 400)
-        ##assert_equal(n1.listassetbalancesbyaddress(shareholderAddr2)["STOCK1"], 500)
-        ##assert_equal(n0.listassetbalancesbyaddress(shareholderAddr3)["STOCK1"], 600)
-        ##assert_equal(n0.listassetbalancesbyaddress(shareholderAddr4)["STOCK1"], 700)
+        # self.log.info("Verifying share distribution after snapshot")
+        # assert_equal(n2.listassetbalancesbyaddress(shareholder_addr0)["STOCK1"], 300)
+        # assert_equal(n2.listassetbalancesbyaddress(shareholder_addr1)["STOCK1"], 400)
+        # assert_equal(n1.listassetbalancesbyaddress(shareholder_addr2)["STOCK1"], 500)
+        # assert_equal(n0.listassetbalancesbyaddress(shareholder_addr3)["STOCK1"], 600)
+        # assert_equal(n0.listassetbalancesbyaddress(shareholder_addr4)["STOCK1"], 700)
 
         self.log.info("Initiating reward payout")
-        n0.distributereward(asset_name="STOCK1", snapshot_height=tgtBlockHeight, distribution_asset_name="RVN", gross_distribution_amount=2000, exception_addresses=distAddr0)
+        n0.distributereward(asset_name="STOCK1", snapshot_height=tgt_block_height, distribution_asset_name="RVN",
+                            gross_distribution_amount=2000, exception_addresses=dist_addr0)
         n0.generate(10)
         self.sync_all()
 
-        ##  Inexplicably, order matters here. We need to verify the amount
-        ##      using the node that created the address (?!)
+        #  Inexplicably, order matters here. We need to verify the amount
+        #      using the node that created the address (?!)
         self.log.info("Verifying RVN holdings after payout")
-        assert_equal(n0.getreceivedbyaddress(shareholderAddr0, 0), 200)
-        assert_equal(n1.getreceivedbyaddress(shareholderAddr1, 0), 300)
-        assert_equal(n2.getreceivedbyaddress(shareholderAddr2, 0), 400)
-        assert_equal(n1.getreceivedbyaddress(shareholderAddr3, 0), 500)
-        assert_equal(n0.getreceivedbyaddress(shareholderAddr4, 0), 600)
+        assert_equal(n0.getreceivedbyaddress(shareholder_addr0, 0), 200)
+        assert_equal(n1.getreceivedbyaddress(shareholder_addr1, 0), 300)
+        assert_equal(n2.getreceivedbyaddress(shareholder_addr2, 0), 400)
+        assert_equal(n1.getreceivedbyaddress(shareholder_addr3, 0), 500)
+        assert_equal(n0.getreceivedbyaddress(shareholder_addr4, 0), 600)
 
-    ## Basic functionality test - ASSET reward
-    ## - create the main owner address
-    ## - mine blocks to have enouugh RVN for the reward fees, plus purchasing the asset
-    ## - issue the STOCK2 asset to the owner
-    ## - create 5 shareholder addresses
-    ## - issue the PAYOUT1 asset to the owner
-    ## - distribute different amounts of the PAYOUT1 asset to each of the shareholder addresses
-    ## - mine some blocks
-    ## - retrieve the current chain height
-    ## - distribute reward of PAYOUT1 asset units amongst the shareholders
-    ## - verify that each one receives the expected amount of PAYOUT1
+    # Basic functionality test - ASSET reward
+    # - create the main owner address
+    # - mine blocks to have enough RVN for the reward fees, plus purchasing the asset
+    # - issue the STOCK2 asset to the owner
+    # - create 5 shareholder addresses
+    # - issue the PAYOUT1 asset to the owner
+    # - distribute different amounts of the PAYOUT1 asset to each of the shareholder addresses
+    # - mine some blocks
+    # - retrieve the current chain height
+    # - distribute reward of PAYOUT1 asset units amongst the shareholders
+    # - verify that each one receives the expected amount of PAYOUT1
     def basic_test_asset(self):
         self.log.info("Running basic ASSET reward test!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
-        # self.log.info(f"Owner address: {ownerAddr0}")
+        owner_addr0 = n0.getnewaddress()
+        # self.log.info(f"Owner address: {owner_addr0}")
 
         self.log.info("Creating distributor address")
-        distAddr0 = n0.getnewaddress()
-        # self.log.info(f"Distributor address: {distAddr0}")
+        dist_addr0 = n0.getnewaddress()
+        # self.log.info(f"Distributor address: {dist_addr0}")
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing STOCK2 asset")
-        n0.issue(asset_name="STOCK2", qty=10000, to_address=ownerAddr0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="STOCK2", qty=10000, to_address=owner_addr0, change_address="", units=4, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Creating shareholder addresses")
-        shareholderAddr0 = n0.getnewaddress()
-        shareholderAddr1 = n1.getnewaddress()
-        shareholderAddr2 = n2.getnewaddress()
-        shareholderAddr3 = n1.getnewaddress()
-        shareholderAddr4 = n0.getnewaddress()
+        shareholder_addr0 = n0.getnewaddress()
+        shareholder_addr1 = n1.getnewaddress()
+        shareholder_addr2 = n2.getnewaddress()
+        shareholder_addr3 = n1.getnewaddress()
+        shareholder_addr4 = n0.getnewaddress()
 
         self.log.info("Distributing shares")
-        n0.transfer(asset_name="STOCK2", qty=200, to_address=shareholderAddr0, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        n0.transfer(asset_name="STOCK2", qty=300, to_address=shareholderAddr1, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        n0.transfer(asset_name="STOCK2", qty=400, to_address=shareholderAddr2, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        n0.transfer(asset_name="STOCK2", qty=500, to_address=shareholderAddr3, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        n0.transfer(asset_name="STOCK2", qty=600, to_address=shareholderAddr4, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
+        n0.transfer(asset_name="STOCK2", qty=200, to_address=shareholder_addr0, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        n0.transfer(asset_name="STOCK2", qty=300, to_address=shareholder_addr1, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        n0.transfer(asset_name="STOCK2", qty=400, to_address=shareholder_addr2, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        n0.transfer(asset_name="STOCK2", qty=500, to_address=shareholder_addr3, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        n0.transfer(asset_name="STOCK2", qty=600, to_address=shareholder_addr4, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Verifying share distribution")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)["STOCK2"], 200)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["STOCK2"], 300)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["STOCK2"], 400)
-        assert_equal(n2.listassetbalancesbyaddress(shareholderAddr3)["STOCK2"], 500)
-        assert_equal(n2.listassetbalancesbyaddress(shareholderAddr4)["STOCK2"], 600)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)["STOCK2"], 200)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["STOCK2"], 300)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["STOCK2"], 400)
+        assert_equal(n2.listassetbalancesbyaddress(shareholder_addr3)["STOCK2"], 500)
+        assert_equal(n2.listassetbalancesbyaddress(shareholder_addr4)["STOCK2"], 600)
 
         self.log.info("Mining blocks")
         n0.generate(200)
         self.sync_all()
 
         self.log.info("Issuing PAYOUT1 asset")
-        n0.issue(asset_name="PAYOUT1", qty=10000, to_address=ownerAddr0, change_address="", \
-                 units=8, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="PAYOUT1", qty=10000, to_address=owner_addr0, change_address="", units=8, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 100
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 100
 
         self.log.info("Requesting snapshot of STOCK2 ownership in 100 blocks")
-        n0.requestsnapshot(asset_name="STOCK2", block_height=tgtBlockHeight)
+        n0.requestsnapshot(asset_name="STOCK2", block_height=tgt_block_height)
 
         # Mine 60 blocks to make sure the -minrewardsheight is met
         n0.generate(61)
 
         self.log.info("Retrieving snapshot request")
-        snapShotReq = n0.getsnapshotrequest(asset_name="STOCK2", block_height=tgtBlockHeight)
-        assert_equal(snapShotReq["asset_name"], "STOCK2")
-        assert_equal(snapShotReq["block_height"], tgtBlockHeight)
+        snap_shot_req = n0.getsnapshotrequest(asset_name="STOCK2", block_height=tgt_block_height)
+        assert_equal(snap_shot_req["asset_name"], "STOCK2")
+        assert_equal(snap_shot_req["block_height"], tgt_block_height)
 
         self.log.info("Skipping forward to allow snapshot to process")
         n0.generate(100)
         self.sync_all()
 
         self.log.info("Retrieving snapshot for ownership validation")
-        snapShot = n0.getsnapshot(asset_name="STOCK2", block_height=tgtBlockHeight)
-        assert_equal(snapShot["name"], "STOCK2")
-        assert_equal(snapShot["height"], tgtBlockHeight)
+        snap_shot = n0.getsnapshot(asset_name="STOCK2", block_height=tgt_block_height)
+        assert_equal(snap_shot["name"], "STOCK2")
+        assert_equal(snap_shot["height"], tgt_block_height)
         owner0 = False
         owner1 = False
         owner2 = False
         owner3 = False
         owner4 = False
-        for ownerAddr in snapShot["owners"]:
-            if ownerAddr["address"] == shareholderAddr0:
+        for ownerAddr in snap_shot["owners"]:
+            if ownerAddr["address"] == shareholder_addr0:
                 assert_equal(ownerAddr["amount_owned"], 200)
                 owner0 = True
-            elif ownerAddr["address"] == shareholderAddr1:
+            elif ownerAddr["address"] == shareholder_addr1:
                 assert_equal(ownerAddr["amount_owned"], 300)
                 owner1 = True
-            elif ownerAddr["address"] == shareholderAddr2:
+            elif ownerAddr["address"] == shareholder_addr2:
                 assert_equal(ownerAddr["amount_owned"], 400)
                 owner2 = True
-            elif ownerAddr["address"] == shareholderAddr3:
+            elif ownerAddr["address"] == shareholder_addr3:
                 assert_equal(ownerAddr["amount_owned"], 500)
                 owner3 = True
-            elif ownerAddr["address"] == shareholderAddr4:
+            elif ownerAddr["address"] == shareholder_addr4:
                 assert_equal(ownerAddr["amount_owned"], 600)
                 owner4 = True
         assert_equal(owner0, True)
@@ -310,60 +307,59 @@ class RewardsTest(RavenTestFramework):
         assert_equal(owner3, True)
         assert_equal(owner4, True)
 
-        ##  listassetbalancesbyaddress only lists the most recently delivered amount
-        ##      for the address, which I believe is a bug, since there can only be one
-        ##      key in the result object with the asset name.
-        ##self.log.info("Moving shares after snapshot")
-        ##n0.transfer(asset_name="STOCK2", qty=100, to_address=shareholderAddr0, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        ##n0.transfer(asset_name="STOCK2", qty=100, to_address=shareholderAddr1, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        ##n0.transfer(asset_name="STOCK2", qty=100, to_address=shareholderAddr2, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        ##n0.transfer(asset_name="STOCK2", qty=100, to_address=shareholderAddr3, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        ##n0.transfer(asset_name="STOCK2", qty=100, to_address=shareholderAddr4, message="", expire_time=0, change_address="", asset_change_address=distAddr0)
-        ##n0.generate(100)
-        ##self.sync_all()
-
-        ##self.log.info("Verifying share distribution after snapshot")
-        ##assert_equal(n2.listassetbalancesbyaddress(shareholderAddr0)["STOCK2"], 300)
-        ##assert_equal(n2.listassetbalancesbyaddress(shareholderAddr1)["STOCK2"], 400)
-        ##assert_equal(n1.listassetbalancesbyaddress(shareholderAddr2)["STOCK2"], 500)
-        ##assert_equal(n0.listassetbalancesbyaddress(shareholderAddr3)["STOCK2"], 600)
-        ##assert_equal(n0.listassetbalancesbyaddress(shareholderAddr4)["STOCK2"], 700)
+        #   listassetbalancesbyaddress only lists the most recently delivered amount
+        #       for the address, which I believe is a bug, since there can only be one
+        #       key in the result object with the asset name.
+        # self.log.info("Moving shares after snapshot")
+        # n0.transfer(asset_name="STOCK2", qty=100, to_address=shareholder_addr0, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        # n0.transfer(asset_name="STOCK2", qty=100, to_address=shareholder_addr1, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        # n0.transfer(asset_name="STOCK2", qty=100, to_address=shareholder_addr2, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        # n0.transfer(asset_name="STOCK2", qty=100, to_address=shareholder_addr3, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        # n0.transfer(asset_name="STOCK2", qty=100, to_address=shareholder_addr4, message="", expire_time=0, change_address="", asset_change_address=dist_addr0)
+        # n0.generate(100)
+        # self.sync_all() 
+        # self.log.info("Verifying share distribution after snapshot")
+        # assert_equal(n2.listassetbalancesbyaddress(shareholder_addr0)["STOCK2"], 300)
+        # assert_equal(n2.listassetbalancesbyaddress(shareholder_addr1)["STOCK2"], 400)
+        # assert_equal(n1.listassetbalancesbyaddress(shareholder_addr2)["STOCK2"], 500)
+        # assert_equal(n0.listassetbalancesbyaddress(shareholder_addr3)["STOCK2"], 600)
+        # assert_equal(n0.listassetbalancesbyaddress(shareholder_addr4)["STOCK2"], 700)
 
         self.log.info("Initiating reward payout")
-        n0.distributereward(asset_name="STOCK2", snapshot_height=tgtBlockHeight, distribution_asset_name="PAYOUT1", gross_distribution_amount=2000, exception_addresses=distAddr0)
+        n0.distributereward(asset_name="STOCK2", snapshot_height=tgt_block_height, distribution_asset_name="PAYOUT1",
+                            gross_distribution_amount=2000, exception_addresses=dist_addr0)
         n0.generate(10)
         self.sync_all()
 
-        ##  Inexplicably, order matters here. We need to verify the amount
-        ##      using the node that created the address (?!)
+        #  Inexplicably, order matters here. We need to verify the amount
+        #      using the node that created the address (?!)
         self.log.info("Verifying PAYOUT1 holdings after payout")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)["PAYOUT1"], 200)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["PAYOUT1"], 300)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["PAYOUT1"], 400)
-        assert_equal(n2.listassetbalancesbyaddress(shareholderAddr3)["PAYOUT1"], 500)
-        assert_equal(n2.listassetbalancesbyaddress(shareholderAddr4)["PAYOUT1"], 600)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)["PAYOUT1"], 200)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["PAYOUT1"], 300)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["PAYOUT1"], 400)
+        assert_equal(n2.listassetbalancesbyaddress(shareholder_addr3)["PAYOUT1"], 500)
+        assert_equal(n2.listassetbalancesbyaddress(shareholder_addr4)["PAYOUT1"], 600)
 
-    ## Attempts a payout without an asset snapshot
+    # Attempts a payout without an asset snapshot
     def payout_without_snapshot(self):
         self.log.info("Running payout without snapshot test!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
+        owner_addr0 = n0.getnewaddress()
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing STOCK3 asset")
-        n0.issue(asset_name="STOCK3", qty=10000, to_address=ownerAddr0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="STOCK3", qty=10000, to_address=owner_addr0, change_address="", units=4, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 100
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 100
 
         self.log.info("Skipping forward so that we're beyond the expected snapshot height")
         n0.generate(161)
@@ -371,23 +367,23 @@ class RewardsTest(RavenTestFramework):
 
         self.log.info("Initiating failing reward payout")
         assert_raises_rpc_error(-32600, "Snapshot request not found",
-            n0.distributereward, "STOCK3", tgtBlockHeight, "RVN", 2000, ownerAddr0)
+                                n0.distributereward, "STOCK3", tgt_block_height, "RVN", 2000, owner_addr0)
 
-    ## Attempts a payout for an invalid ownership asset
+    # Attempts a payout for an invalid ownership asset
     def payout_with_invalid_ownership_asset(self):
         self.log.info("Running payout with invalid ownership asset test!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
+        owner_addr0 = n0.getnewaddress()
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 100
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 100
 
         self.log.info("Skipping forward so that we're beyond the expected snapshot height")
         n0.generate(161)
@@ -395,29 +391,28 @@ class RewardsTest(RavenTestFramework):
 
         self.log.info("Initiating failing reward payout")
         assert_raises_rpc_error(-32600, "The asset hasn't been created: STOCK4",
-            n0.distributereward, "STOCK4", tgtBlockHeight, "RVN", 2000, ownerAddr0)
+                                n0.distributereward, "STOCK4", tgt_block_height, "RVN", 2000, owner_addr0)
 
-    ## Attempts a payout for an invalid payout asset
+    # Attempts a payout for an invalid payout asset
     def payout_with_invalid_payout_asset(self):
         self.log.info("Running payout with invalid payout asset test!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
+        owner_addr0 = n0.getnewaddress()
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing STOCK5 asset")
-        n0.issue(asset_name="STOCK5", qty=10000, to_address=ownerAddr0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="STOCK5", qty=10000, to_address=owner_addr0, change_address="", units=4, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 100
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 100
 
         self.log.info("Skipping forward so that we're beyond the expected snapshot height")
         n0.generate(161)
@@ -425,86 +420,86 @@ class RewardsTest(RavenTestFramework):
 
         self.log.info("Initiating failing reward payout")
         assert_raises_rpc_error(-32600, "Wallet doesn't have the ownership token(!) for the distribution asset",
-            n0.distributereward, "STOCK5", tgtBlockHeight, "PAYOUT2", 2000, ownerAddr0)
+                                n0.distributereward, "STOCK5", tgt_block_height, "PAYOUT2", 2000, owner_addr0)
 
-    ## Attempts a payout for an invalid payout asset
+    # Attempts a payout for an invalid payout asset
     def payout_before_minimum_height_is_reached(self):
         self.log.info("Running payout before minimum rewards height is reached!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
+        owner_addr0 = n0.getnewaddress()
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing STOCK6 asset")
-        n0.issue(asset_name="STOCK6", qty=10000, to_address=ownerAddr0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="STOCK6", qty=10000, to_address=owner_addr0, change_address="", units=4, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 1
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 1
 
         self.log.info("Requesting snapshot of STOCK6 ownership in 1 blocks")
-        n0.requestsnapshot(asset_name="STOCK6", block_height=tgtBlockHeight)
+        n0.requestsnapshot(asset_name="STOCK6", block_height=tgt_block_height)
 
         self.log.info("Skipping forward so that we're 15 blocks ahead of the snapshot height")
         n0.generate(16)
         self.sync_all()
 
-        self.log.info("Initiating failing reward payout because we are only 15 block ahead of the snapshot instead of 60")
-        assert_raises_rpc_error(-32600, "For security of the rewards payout, it is recommended to wait until chain is 60 blocks ahead of the snapshot height. You can modify this by using the -minrewardsheight.",
-                                n0.distributereward, "STOCK6", tgtBlockHeight, "RVN", 2000, ownerAddr0)
+        self.log.info(
+            "Initiating failing reward payout because we are only 15 block ahead of the snapshot instead of 60")
+        assert_raises_rpc_error(-32600,
+                                "For security of the rewards payout, it is recommended to wait until chain is 60 blocks ahead of the snapshot height. You can modify this by using the -minrewardsheight.",
+                                n0.distributereward, "STOCK6", tgt_block_height, "RVN", 2000, owner_addr0)
 
-    ## Attempts a payout using a custome rewards height of 15, and they have low rvn balance
+    # Attempts a payout using a custom rewards height of 15, and they have low rvn balance
     def payout_custom_height_set_with_low_funds(self):
         self.log.info("Running payout before minimum rewards height is reached with custom min height value set!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n1.getnewaddress()
+        owner_addr0 = n1.getnewaddress()
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(5)
         self.sync_all()
         n1.generate(10)
         self.sync_all()
 
         self.log.info("Issuing STOCK7 asset")
-        n1.issue(asset_name="STOCK7", qty=10000, to_address=ownerAddr0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=False)
+        n1.issue(asset_name="STOCK7", qty=10000, to_address=owner_addr0, change_address="", units=4, reissuable=True, has_ipfs=False)
         n1.generate(10)
         self.sync_all()
 
-        shareholderAddr0 = n2.getnewaddress()
+        shareholder_addr0 = n2.getnewaddress()
 
-        n1.transfer(asset_name="STOCK7", qty=200, to_address=shareholderAddr0, message="", expire_time=0, change_address="", asset_change_address=ownerAddr0)
+        n1.transfer(asset_name="STOCK7", qty=200, to_address=shareholder_addr0, message="", expire_time=0, change_address="", asset_change_address=owner_addr0)
 
         n1.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n1.getblockchaininfo()["blocks"] + 1
+        tgt_block_height = n1.getblockchaininfo()["blocks"] + 1
 
         self.log.info("Requesting snapshot of STOCK7 ownership in 1 blocks")
-        n1.requestsnapshot(asset_name="STOCK7", block_height=tgtBlockHeight)
+        n1.requestsnapshot(asset_name="STOCK7", block_height=tgt_block_height)
 
         self.log.info("Skipping forward so that we're 30 blocks ahead of the snapshot height")
         n1.generate(31)
         self.sync_all()
 
         self.log.info("Initiating reward payout should succeed because -minrewardheight=15 on node1")
-        n1.distributereward("STOCK7", tgtBlockHeight, "RVN", 2000, ownerAddr0)
+        n1.distributereward("STOCK7", tgt_block_height, "RVN", 2000, owner_addr0)
 
         n1.generate(2)
         self.sync_all()
 
-        assert_equal(n1.getdistributestatus("STOCK7", tgtBlockHeight, "RVN", 2000, ownerAddr0)['Status'], 3)
+        assert_equal(n1.getdistributestatus("STOCK7", tgt_block_height, "RVN", 2000, owner_addr0)['Status'], 3)
 
         n0.sendtoaddress(n1.getnewaddress(), 3000)
         n0.generate(5)
@@ -513,72 +508,70 @@ class RewardsTest(RavenTestFramework):
         n1.generate(10)
         self.sync_all()
 
-        assert_equal(n2.getreceivedbyaddress(shareholderAddr0, 1), 2000)
+        assert_equal(n2.getreceivedbyaddress(shareholder_addr0, 1), 2000)
 
-    ## Attempts a payout using a custome rewards height of 15, and they have low rvn balance
-    def payout_with_insufficent_asset_amount(self):
+    # Attempts a payout using a custom rewards height of 15, and they have low rvn balance
+    def payout_with_insufficient_asset_amount(self):
         self.log.info("Running payout before minimum rewards height is reached with custom min height value set!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n1.getnewaddress()
+        owner_addr0 = n1.getnewaddress()
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 2000)
+        self.nodes[0].sendtoaddress(owner_addr0, 2000)
         n0.generate(5)
         self.sync_all()
         n1.generate(10)
         self.sync_all()
 
-        n1.issue(asset_name="STOCK_7.1", qty=10000, to_address=ownerAddr0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=False)
+        n1.issue(asset_name="STOCK_7.1", qty=10000, to_address=owner_addr0, change_address="", units=4, reissuable=True, has_ipfs=False)
 
         self.log.info("Issuing LOW_ASSET_AMOUNT asset")
-        n1.issue(asset_name="LOW_ASSET_AMOUNT", qty=10000, to_address=ownerAddr0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=False)
+        n1.issue(asset_name="LOW_ASSET_AMOUNT", qty=10000, to_address=owner_addr0, change_address="", units=4, reissuable=True, has_ipfs=False)
         n1.generate(10)
         self.sync_all()
 
-        ## Send the majority of the assets to node0
-        assetHolderAddress = n0.getnewaddress()
-        n1.transfer(asset_name="LOW_ASSET_AMOUNT", qty=9000, to_address=assetHolderAddress, message="", expire_time=0, change_address="", asset_change_address=ownerAddr0)
-        shareholderAddr0 = n2.getnewaddress()
-        n1.transfer(asset_name="STOCK_7.1", qty=200, to_address=shareholderAddr0, message="", expire_time=0, change_address="", asset_change_address=ownerAddr0)
+        # Send the majority of the assets to node0
+        asset_holder_address = n0.getnewaddress()
+        n1.transfer(asset_name="LOW_ASSET_AMOUNT", qty=9000, to_address=asset_holder_address, message="", expire_time=0, change_address="", asset_change_address=owner_addr0)
+        shareholder_addr0 = n2.getnewaddress()
+        n1.transfer(asset_name="STOCK_7.1", qty=200, to_address=shareholder_addr0, message="", expire_time=0, change_address="", asset_change_address=owner_addr0)
         n1.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n1.getblockchaininfo()["blocks"] + 1
+        tgt_block_height = n1.getblockchaininfo()["blocks"] + 1
 
         self.log.info("Requesting snapshot of STOCK_7.1 ownership in 1 blocks")
-        n1.requestsnapshot(asset_name="STOCK_7.1", block_height=tgtBlockHeight)
+        n1.requestsnapshot(asset_name="STOCK_7.1", block_height=tgt_block_height)
 
         self.log.info("Skipping forward so that we're 30 blocks ahead of the snapshot height")
         n1.generate(61)
         self.sync_all()
 
         self.log.info("Initiating reward payout")
-        n1.distributereward("STOCK_7.1", tgtBlockHeight, "LOW_ASSET_AMOUNT", 2000, ownerAddr0)
+        n1.distributereward("STOCK_7.1", tgt_block_height, "LOW_ASSET_AMOUNT", 2000, owner_addr0)
 
         n1.generate(2)
         self.sync_all()
 
-        assert_equal(n1.getdistributestatus("STOCK_7.1", tgtBlockHeight, "LOW_ASSET_AMOUNT", 2000, ownerAddr0)['Status'], 5)
+        assert_equal(
+            n1.getdistributestatus("STOCK_7.1", tgt_block_height, "LOW_ASSET_AMOUNT", 2000, owner_addr0)['Status'], 5)
 
-        ## node0 transfer back the assets to node1, now the distribution transaction should get created successfully. when the next block is mined
-        n0.transfer(asset_name="LOW_ASSET_AMOUNT", qty=9000, to_address=ownerAddr0, message="", expire_time=0, change_address="")
+        # node0 transfer back the assets to node1, now the distribution transaction should get created successfully. when the next block is mined
+        n0.transfer(asset_name="LOW_ASSET_AMOUNT", qty=9000, to_address=owner_addr0, message="", expire_time=0, change_address="")
         n0.generate(5)
         self.sync_all()
 
         n1.generate(10)
         self.sync_all()
 
-        assert_equal(n2.listassetbalancesbyaddress(shareholderAddr0)["LOW_ASSET_AMOUNT"], 2000)
+        assert_equal(n2.listassetbalancesbyaddress(shareholder_addr0)["LOW_ASSET_AMOUNT"], 2000)
 
-    def listsnapshotrequests(self):
+    def list_snapshot_requests(self):
         self.log.info("Testing listsnapshotrequests()...")
         n0, n1 = self.nodes[0], self.nodes[1]
-
 
         self.log.info("Providing funding")
         self.nodes[0].sendtoaddress(n1.getnewaddress(), 1000)
@@ -595,8 +588,7 @@ class RewardsTest(RavenTestFramework):
         block_height2 = n1.getblockcount() + 200
 
         # make sure a snapshot can't be created for a non-existent
-        assert_raises_rpc_error(-8, "asset does not exist",
-                                n1.requestsnapshot, asset_name1, block_height1)
+        assert_raises_rpc_error(-8, "asset does not exist", n1.requestsnapshot, asset_name1, block_height1)
         n1.issue(asset_name1)
         n1.issue(asset_name2)
         n1.generate(1)
@@ -626,84 +618,85 @@ class RewardsTest(RavenTestFramework):
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
-        # self.log.info(f"Owner address: {ownerAddr0}")
+        owner_addr0 = n0.getnewaddress()
+        # self.log.info(f"Owner address: {owner_addr0}")
 
         self.log.info("Creating distributor address")
-        distAddr0 = n0.getnewaddress()
-        # self.log.info(f"Distributor address: {distAddr0}")
+        dist_addr0 = n0.getnewaddress()
+        # self.log.info(f"Distributor address: {dist_addr0}")
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing STOCK8 asset")
-        n0.issue(asset_name="STOCK8", qty=10000, to_address=distAddr0, change_address="", \
-                 units=0, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="STOCK8", qty=10000, to_address=dist_addr0, change_address="", units=0, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Creating shareholder addresses")
-        shareholderAddr0 = n0.getnewaddress()
-        shareholderAddr1 = n1.getnewaddress()
-        shareholderAddr2 = n2.getnewaddress()
+        shareholder_addr0 = n0.getnewaddress()
+        shareholder_addr1 = n1.getnewaddress()
+        shareholder_addr2 = n2.getnewaddress()
 
         self.log.info("Distributing shares")
-        n0.transferfromaddress(asset_name="STOCK8", from_address=distAddr0, qty=300, to_address=shareholderAddr0, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK8", from_address=distAddr0, qty=300, to_address=shareholderAddr1, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK8", from_address=distAddr0, qty=300, to_address=shareholderAddr2, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
+        n0.transferfromaddress(asset_name="STOCK8", from_address=dist_addr0, qty=300, to_address=shareholder_addr0,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK8", from_address=dist_addr0, qty=300, to_address=shareholder_addr1,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK8", from_address=dist_addr0, qty=300, to_address=shareholder_addr2,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
         n0.generate(150)
         self.sync_all()
 
         self.log.info("Verifying share distribution")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)['STOCK8'], 300)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["STOCK8"], 300)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["STOCK8"], 300)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)['STOCK8'], 300)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["STOCK8"], 300)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["STOCK8"], 300)
 
         self.log.info("Mining blocks")
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing PAYOUT8 asset")
-        n0.issue(asset_name="PAYOUT8", qty=10, to_address=ownerAddr0, change_address="", \
-                 units=0, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="PAYOUT8", qty=10, to_address=owner_addr0, change_address="", units=0, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 5
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 5
 
         self.log.info("Requesting snapshot of STOCK8 ownership in 5 blocks")
-        n0.requestsnapshot(asset_name="STOCK8", block_height=tgtBlockHeight)
+        n0.requestsnapshot(asset_name="STOCK8", block_height=tgt_block_height)
 
         # Mine 10 blocks to make sure snapshot is created
         n0.generate(10)
 
         self.log.info("Retrieving snapshot request")
-        snapShotReq = n0.getsnapshotrequest(asset_name="STOCK8", block_height=tgtBlockHeight)
-        assert_equal(snapShotReq["asset_name"], "STOCK8")
-        assert_equal(snapShotReq["block_height"], tgtBlockHeight)
+        snap_shot_req = n0.getsnapshotrequest(asset_name="STOCK8", block_height=tgt_block_height)
+        assert_equal(snap_shot_req["asset_name"], "STOCK8")
+        assert_equal(snap_shot_req["block_height"], tgt_block_height)
 
         self.log.info("Skipping forward to allow snapshot to process")
         n0.generate(61)
         self.sync_all()
 
         self.log.info("Retrieving snapshot for ownership validation")
-        snapShot = n0.getsnapshot(asset_name="STOCK8", block_height=tgtBlockHeight)
-        assert_equal(snapShot["name"], "STOCK8")
-        assert_equal(snapShot["height"], tgtBlockHeight)
+        snap_shot = n0.getsnapshot(asset_name="STOCK8", block_height=tgt_block_height)
+        assert_equal(snap_shot["name"], "STOCK8")
+        assert_equal(snap_shot["height"], tgt_block_height)
         owner0 = False
         owner1 = False
         owner2 = False
-        for ownerAddr in snapShot["owners"]:
-            if ownerAddr["address"] == shareholderAddr0:
+        for ownerAddr in snap_shot["owners"]:
+            if ownerAddr["address"] == shareholder_addr0:
                 assert_equal(ownerAddr["amount_owned"], 300)
                 owner0 = True
-            elif ownerAddr["address"] == shareholderAddr1:
+            elif ownerAddr["address"] == shareholder_addr1:
                 assert_equal(ownerAddr["amount_owned"], 300)
                 owner1 = True
-            elif ownerAddr["address"] == shareholderAddr2:
+            elif ownerAddr["address"] == shareholder_addr2:
                 assert_equal(ownerAddr["amount_owned"], 300)
                 owner2 = True
         assert_equal(owner0, True)
@@ -711,100 +704,102 @@ class RewardsTest(RavenTestFramework):
         assert_equal(owner2, True)
 
         self.log.info("Initiating reward payout")
-        n0.distributereward(asset_name="STOCK8", snapshot_height=tgtBlockHeight, distribution_asset_name="PAYOUT8", gross_distribution_amount=10, exception_addresses=distAddr0)
+        n0.distributereward(asset_name="STOCK8", snapshot_height=tgt_block_height, distribution_asset_name="PAYOUT8",
+                            gross_distribution_amount=10, exception_addresses=dist_addr0)
         n0.generate(10)
         self.sync_all()
 
-        ##  Inexplicably, order matters here. We need to verify the amount
-        ##      using the node that created the address (?!)
+        #  Inexplicably, order matters here. We need to verify the amount
+        #     using the node that created the address (?!)
         self.log.info("Verifying PAYOUT8 holdings after payout")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)["PAYOUT8"], 3)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["PAYOUT8"], 3)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["PAYOUT8"], 3)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)["PAYOUT8"], 3)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["PAYOUT8"], 3)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["PAYOUT8"], 3)
 
     def basic_test_asset_even_distribution(self):
         self.log.info("Running ASSET reward test (units = 0)!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
-        # self.log.info(f"Owner address: {ownerAddr0}")
+        owner_addr0 = n0.getnewaddress()
+        # self.log.info(f"Owner address: {owner_addr0}")
 
         self.log.info("Creating distributor address")
-        distAddr0 = n0.getnewaddress()
-        # self.log.info(f"Distributor address: {distAddr0}")
+        dist_addr0 = n0.getnewaddress()
+        # self.log.info(f"Distributor address: {dist_addr0}")
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing STOCK9 asset")
-        n0.issue(asset_name="STOCK9", qty=10000, to_address=distAddr0, change_address="", \
-                 units=0, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="STOCK9", qty=10000, to_address=dist_addr0, change_address="", units=0, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Creating shareholder addresses")
-        shareholderAddr0 = n0.getnewaddress()
-        shareholderAddr1 = n1.getnewaddress()
-        shareholderAddr2 = n2.getnewaddress()
+        shareholder_addr0 = n0.getnewaddress()
+        shareholder_addr1 = n1.getnewaddress()
+        shareholder_addr2 = n2.getnewaddress()
 
         self.log.info("Distributing shares")
-        n0.transferfromaddress(asset_name="STOCK9", from_address=distAddr0, qty=300, to_address=shareholderAddr0, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK9", from_address=distAddr0, qty=300, to_address=shareholderAddr1, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK9", from_address=distAddr0, qty=400, to_address=shareholderAddr2, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
+        n0.transferfromaddress(asset_name="STOCK9", from_address=dist_addr0, qty=300, to_address=shareholder_addr0,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK9", from_address=dist_addr0, qty=300, to_address=shareholder_addr1,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK9", from_address=dist_addr0, qty=400, to_address=shareholder_addr2,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
         n0.generate(150)
         self.sync_all()
 
         self.log.info("Verifying share distribution")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)['STOCK9'], 300)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["STOCK9"], 300)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["STOCK9"], 400)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)['STOCK9'], 300)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["STOCK9"], 300)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["STOCK9"], 400)
 
         self.log.info("Mining blocks")
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing PAYOUT9 asset")
-        n0.issue(asset_name="PAYOUT9", qty=10, to_address=ownerAddr0, change_address="", \
-                 units=0, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="PAYOUT9", qty=10, to_address=owner_addr0, change_address="", units=0, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 5
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 5
 
         self.log.info("Requesting snapshot of STOCK9 ownership in 5 blocks")
-        n0.requestsnapshot(asset_name="STOCK9", block_height=tgtBlockHeight)
+        n0.requestsnapshot(asset_name="STOCK9", block_height=tgt_block_height)
 
         # Mine 10 blocks to make sure snapshot is created
         n0.generate(10)
 
         self.log.info("Retrieving snapshot request")
-        snapShotReq = n0.getsnapshotrequest(asset_name="STOCK9", block_height=tgtBlockHeight)
-        assert_equal(snapShotReq["asset_name"], "STOCK9")
-        assert_equal(snapShotReq["block_height"], tgtBlockHeight)
+        snap_shot_req = n0.getsnapshotrequest(asset_name="STOCK9", block_height=tgt_block_height)
+        assert_equal(snap_shot_req["asset_name"], "STOCK9")
+        assert_equal(snap_shot_req["block_height"], tgt_block_height)
 
         self.log.info("Skipping forward to allow snapshot to process")
         n0.generate(61)
         self.sync_all()
 
         self.log.info("Retrieving snapshot for ownership validation")
-        snapShot = n0.getsnapshot(asset_name="STOCK9", block_height=tgtBlockHeight)
-        assert_equal(snapShot["name"], "STOCK9")
-        assert_equal(snapShot["height"], tgtBlockHeight)
+        snap_shot = n0.getsnapshot(asset_name="STOCK9", block_height=tgt_block_height)
+        assert_equal(snap_shot["name"], "STOCK9")
+        assert_equal(snap_shot["height"], tgt_block_height)
         owner0 = False
         owner1 = False
         owner2 = False
-        for ownerAddr in snapShot["owners"]:
-            if ownerAddr["address"] == shareholderAddr0:
+        for ownerAddr in snap_shot["owners"]:
+            if ownerAddr["address"] == shareholder_addr0:
                 assert_equal(ownerAddr["amount_owned"], 300)
                 owner0 = True
-            elif ownerAddr["address"] == shareholderAddr1:
+            elif ownerAddr["address"] == shareholder_addr1:
                 assert_equal(ownerAddr["amount_owned"], 300)
                 owner1 = True
-            elif ownerAddr["address"] == shareholderAddr2:
+            elif ownerAddr["address"] == shareholder_addr2:
                 assert_equal(ownerAddr["amount_owned"], 400)
                 owner2 = True
         assert_equal(owner0, True)
@@ -812,100 +807,103 @@ class RewardsTest(RavenTestFramework):
         assert_equal(owner2, True)
 
         self.log.info("Initiating reward payout")
-        n0.distributereward(asset_name="STOCK9", snapshot_height=tgtBlockHeight, distribution_asset_name="PAYOUT9", gross_distribution_amount=10, exception_addresses=distAddr0)
+        n0.distributereward(asset_name="STOCK9", snapshot_height=tgt_block_height, distribution_asset_name="PAYOUT9",
+                            gross_distribution_amount=10, exception_addresses=dist_addr0)
         n0.generate(10)
         self.sync_all()
 
-        ##  Inexplicably, order matters here. We need to verify the amount
-        ##      using the node that created the address (?!)
+        #  Inexplicably, order matters here. We need to verify the amount
+        #      using the node that created the address (?!)
         self.log.info("Verifying PAYOUT9 holdings after payout")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)["PAYOUT9"], 3)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["PAYOUT9"], 3)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["PAYOUT9"], 4)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)["PAYOUT9"], 3)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["PAYOUT9"], 3)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["PAYOUT9"], 4)
 
     def basic_test_asset_round_down_uneven_distribution(self):
         self.log.info("Running ASSET reward test with uneven distribution (units = 0)!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
-        # self.log.info(f"Owner address: {ownerAddr0}")
+        owner_addr0 = n0.getnewaddress()
+        # self.log.info(f"Owner address: {owner_addr0}")
 
         self.log.info("Creating distributor address")
-        distAddr0 = n0.getnewaddress()
-        # self.log.info(f"Distributor address: {distAddr0}")
+        dist_addr0 = n0.getnewaddress()
+        # self.log.info(f"Distributor address: {dist_addr0}")
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing STOCK10 asset")
-        n0.issue(asset_name="STOCK10", qty=10000, to_address=distAddr0, change_address="", \
-                 units=0, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="STOCK10", qty=10000, to_address=dist_addr0, change_address="", units=0, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Creating shareholder addresses")
-        shareholderAddr0 = n0.getnewaddress()
-        shareholderAddr1 = n1.getnewaddress()
-        shareholderAddr2 = n2.getnewaddress()
+        shareholder_addr0 = n0.getnewaddress()
+        shareholder_addr1 = n1.getnewaddress()
+        shareholder_addr2 = n2.getnewaddress()
 
         self.log.info("Distributing shares")
-        n0.transferfromaddress(asset_name="STOCK10", from_address=distAddr0, qty=300, to_address=shareholderAddr0, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK10", from_address=distAddr0, qty=300, to_address=shareholderAddr1, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK10", from_address=distAddr0, qty=500, to_address=shareholderAddr2, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
+        n0.transferfromaddress(asset_name="STOCK10", from_address=dist_addr0, qty=300, to_address=shareholder_addr0,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK10", from_address=dist_addr0, qty=300, to_address=shareholder_addr1,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK10", from_address=dist_addr0, qty=500, to_address=shareholder_addr2,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
         n0.generate(150)
         self.sync_all()
 
         self.log.info("Verifying share distribution")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)['STOCK10'], 300)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["STOCK10"], 300)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["STOCK10"], 500)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)['STOCK10'], 300)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["STOCK10"], 300)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["STOCK10"], 500)
 
         self.log.info("Mining blocks")
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing PAYOUT10 asset")
-        n0.issue(asset_name="PAYOUT10", qty=10, to_address=ownerAddr0, change_address="", \
-                 units=0, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="PAYOUT10", qty=10, to_address=owner_addr0, change_address="", units=0, reissuable=True,
+                 has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 5
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 5
 
         self.log.info("Requesting snapshot of STOCK10 ownership in 5 blocks")
-        n0.requestsnapshot(asset_name="STOCK10", block_height=tgtBlockHeight)
+        n0.requestsnapshot(asset_name="STOCK10", block_height=tgt_block_height)
 
         # Mine 10 blocks to make sure snapshot is created
         n0.generate(10)
 
         self.log.info("Retrieving snapshot request")
-        snapShotReq = n0.getsnapshotrequest(asset_name="STOCK10", block_height=tgtBlockHeight)
-        assert_equal(snapShotReq["asset_name"], "STOCK10")
-        assert_equal(snapShotReq["block_height"], tgtBlockHeight)
+        snap_shot_req = n0.getsnapshotrequest(asset_name="STOCK10", block_height=tgt_block_height)
+        assert_equal(snap_shot_req["asset_name"], "STOCK10")
+        assert_equal(snap_shot_req["block_height"], tgt_block_height)
 
         self.log.info("Skipping forward to allow snapshot to process")
         n0.generate(61)
         self.sync_all()
 
         self.log.info("Retrieving snapshot for ownership validation")
-        snapShot = n0.getsnapshot(asset_name="STOCK10", block_height=tgtBlockHeight)
-        assert_equal(snapShot["name"], "STOCK10")
-        assert_equal(snapShot["height"], tgtBlockHeight)
+        snap_shot = n0.getsnapshot(asset_name="STOCK10", block_height=tgt_block_height)
+        assert_equal(snap_shot["name"], "STOCK10")
+        assert_equal(snap_shot["height"], tgt_block_height)
         owner0 = False
         owner1 = False
         owner2 = False
-        for ownerAddr in snapShot["owners"]:
-            if ownerAddr["address"] == shareholderAddr0:
+        for ownerAddr in snap_shot["owners"]:
+            if ownerAddr["address"] == shareholder_addr0:
                 assert_equal(ownerAddr["amount_owned"], 300)
                 owner0 = True
-            elif ownerAddr["address"] == shareholderAddr1:
+            elif ownerAddr["address"] == shareholder_addr1:
                 assert_equal(ownerAddr["amount_owned"], 300)
                 owner1 = True
-            elif ownerAddr["address"] == shareholderAddr2:
+            elif ownerAddr["address"] == shareholder_addr2:
                 assert_equal(ownerAddr["amount_owned"], 500)
                 owner2 = True
         assert_equal(owner0, True)
@@ -913,107 +911,110 @@ class RewardsTest(RavenTestFramework):
         assert_equal(owner2, True)
 
         self.log.info("Initiating reward payout")
-        n0.distributereward(asset_name="STOCK10", snapshot_height=tgtBlockHeight, distribution_asset_name="PAYOUT10", gross_distribution_amount=10, exception_addresses=distAddr0)
+        n0.distributereward(asset_name="STOCK10", snapshot_height=tgt_block_height, distribution_asset_name="PAYOUT10",
+                            gross_distribution_amount=10, exception_addresses=dist_addr0)
         n0.generate(10)
         self.sync_all()
 
-        ##  Inexplicably, order matters here. We need to verify the amount
-        ##      using the node that created the address (?!)
+        #  Inexplicably, order matters here. We need to verify the amount
+        #      using the node that created the address (?!)
         self.log.info("Verifying PAYOUT10 holdings after payout")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)["PAYOUT10"], 2)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["PAYOUT10"], 2)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["PAYOUT10"], 4)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)["PAYOUT10"], 2)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["PAYOUT10"], 2)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["PAYOUT10"], 4)
 
     def basic_test_asset_round_down_uneven_distribution_2(self):
         self.log.info("Running ASSET reward test with uneven distribution (units = 0)!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
-        # self.log.info(f"Owner address: {ownerAddr0}")
+        owner_addr0 = n0.getnewaddress()
+        # self.log.info(f"Owner address: {owner_addr0}")
 
         self.log.info("Creating distributor address")
-        distAddr0 = n0.getnewaddress()
-        # self.log.info(f"Distributor address: {distAddr0}")
+        dist_addr0 = n0.getnewaddress()
+        # self.log.info(f"Distributor address: {dist_addr0}")
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing STOCK11 asset")
-        n0.issue(asset_name="STOCK11", qty=10000, to_address=distAddr0, change_address="", \
-                 units=0, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="STOCK11", qty=10000, to_address=dist_addr0, change_address="", units=0, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Creating shareholder addresses")
-        shareholderAddr0 = n0.getnewaddress()
-        shareholderAddr1 = n1.getnewaddress()
-        shareholderAddr2 = n2.getnewaddress()
-        shareholderAddr3 = n2.getnewaddress()
+        shareholder_addr0 = n0.getnewaddress()
+        shareholder_addr1 = n1.getnewaddress()
+        shareholder_addr2 = n2.getnewaddress()
+        shareholder_addr3 = n2.getnewaddress()
 
         self.log.info("Distributing shares")
-        n0.transferfromaddress(asset_name="STOCK11", from_address=distAddr0, qty=9, to_address=shareholderAddr0, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK11", from_address=distAddr0, qty=3, to_address=shareholderAddr1, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK11", from_address=distAddr0, qty=2, to_address=shareholderAddr2, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK11", from_address=distAddr0, qty=1, to_address=shareholderAddr3, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
+        n0.transferfromaddress(asset_name="STOCK11", from_address=dist_addr0, qty=9, to_address=shareholder_addr0,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK11", from_address=dist_addr0, qty=3, to_address=shareholder_addr1,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK11", from_address=dist_addr0, qty=2, to_address=shareholder_addr2,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK11", from_address=dist_addr0, qty=1, to_address=shareholder_addr3,
+                               message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
 
         n0.generate(150)
         self.sync_all()
 
         self.log.info("Verifying share distribution")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)['STOCK11'], 9)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["STOCK11"], 3)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["STOCK11"], 2)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr3)["STOCK11"], 1)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)['STOCK11'], 9)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["STOCK11"], 3)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["STOCK11"], 2)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr3)["STOCK11"], 1)
 
         self.log.info("Mining blocks")
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing PAYOUT11 asset")
-        n0.issue(asset_name="PAYOUT11", qty=10, to_address=ownerAddr0, change_address="", \
-                 units=0, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="PAYOUT11", qty=10, to_address=owner_addr0, change_address="", units=0, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 5
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 5
 
         self.log.info("Requesting snapshot of STOCK11 ownership in 5 blocks")
-        n0.requestsnapshot(asset_name="STOCK11", block_height=tgtBlockHeight)
+        n0.requestsnapshot(asset_name="STOCK11", block_height=tgt_block_height)
 
         # Mine 10 blocks to make sure snapshot is created
         n0.generate(10)
 
         self.log.info("Retrieving snapshot request")
-        snapShotReq = n0.getsnapshotrequest(asset_name="STOCK11", block_height=tgtBlockHeight)
-        assert_equal(snapShotReq["asset_name"], "STOCK11")
-        assert_equal(snapShotReq["block_height"], tgtBlockHeight)
+        snap_shot_req = n0.getsnapshotrequest(asset_name="STOCK11", block_height=tgt_block_height)
+        assert_equal(snap_shot_req["asset_name"], "STOCK11")
+        assert_equal(snap_shot_req["block_height"], tgt_block_height)
 
         self.log.info("Skipping forward to allow snapshot to process")
         n0.generate(61)
         self.sync_all()
 
         self.log.info("Retrieving snapshot for ownership validation")
-        snapShot = n0.getsnapshot(asset_name="STOCK11", block_height=tgtBlockHeight)
-        assert_equal(snapShot["name"], "STOCK11")
-        assert_equal(snapShot["height"], tgtBlockHeight)
+        snap_shot = n0.getsnapshot(asset_name="STOCK11", block_height=tgt_block_height)
+        assert_equal(snap_shot["name"], "STOCK11")
+        assert_equal(snap_shot["height"], tgt_block_height)
         owner0 = False
         owner1 = False
         owner2 = False
-        for ownerAddr in snapShot["owners"]:
-            if ownerAddr["address"] == shareholderAddr0:
+        for ownerAddr in snap_shot["owners"]:
+            if ownerAddr["address"] == shareholder_addr0:
                 assert_equal(ownerAddr["amount_owned"], 9)
                 owner0 = True
-            elif ownerAddr["address"] == shareholderAddr1:
+            elif ownerAddr["address"] == shareholder_addr1:
                 assert_equal(ownerAddr["amount_owned"], 3)
                 owner1 = True
-            elif ownerAddr["address"] == shareholderAddr2:
+            elif ownerAddr["address"] == shareholder_addr2:
                 assert_equal(ownerAddr["amount_owned"], 2)
                 owner2 = True
-            elif ownerAddr["address"] == shareholderAddr3:
+            elif ownerAddr["address"] == shareholder_addr3:
                 assert_equal(ownerAddr["amount_owned"], 1)
                 owner2 = True
         assert_equal(owner0, True)
@@ -1021,107 +1022,106 @@ class RewardsTest(RavenTestFramework):
         assert_equal(owner2, True)
 
         self.log.info("Initiating reward payout")
-        n0.distributereward(asset_name="STOCK11", snapshot_height=tgtBlockHeight, distribution_asset_name="PAYOUT11", gross_distribution_amount=10, exception_addresses=distAddr0)
+        n0.distributereward(asset_name="STOCK11", snapshot_height=tgt_block_height, distribution_asset_name="PAYOUT11",
+                            gross_distribution_amount=10, exception_addresses=dist_addr0)
         n0.generate(10)
         self.sync_all()
 
-        ##  Inexplicably, order matters here. We need to verify the amount
-        ##      using the node that created the address (?!)
+        #  Inexplicably, order matters here. We need to verify the amount
+        #      using the node that created the address (?!)
         self.log.info("Verifying PAYOUT11 holdings after payout")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)["PAYOUT11"], 6)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["PAYOUT11"], 2)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["PAYOUT11"], 1)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)["PAYOUT11"], 6)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["PAYOUT11"], 2)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["PAYOUT11"], 1)
 
     def basic_test_asset_round_down_uneven_distribution_3(self):
         self.log.info("Running ASSET reward test with uneven distribution (units = 1)!")
         n0, n1, n2 = self.nodes[0], self.nodes[1], self.nodes[2]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
-        # self.log.info(f"Owner address: {ownerAddr0}")
+        owner_addr0 = n0.getnewaddress()
+        # self.log.info(f"Owner address: {owner_addr0}")
 
         self.log.info("Creating distributor address")
-        distAddr0 = n0.getnewaddress()
-        # self.log.info(f"Distributor address: {distAddr0}")
+        dist_addr0 = n0.getnewaddress()
+        # self.log.info(f"Distributor address: {dist_addr0}")
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing STOCK12 asset")
-        n0.issue(asset_name="STOCK12", qty=10000, to_address=distAddr0, change_address="", \
-                 units=0, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="STOCK12", qty=10000, to_address=dist_addr0, change_address="", units=0, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Creating shareholder addresses")
-        shareholderAddr0 = n0.getnewaddress()
-        shareholderAddr1 = n1.getnewaddress()
-        shareholderAddr2 = n2.getnewaddress()
-        shareholderAddr3 = n2.getnewaddress()
+        shareholder_addr0 = n0.getnewaddress()
+        shareholder_addr1 = n1.getnewaddress()
+        shareholder_addr2 = n2.getnewaddress()
+        shareholder_addr3 = n2.getnewaddress()
 
         self.log.info("Distributing shares")
-        n0.transferfromaddress(asset_name="STOCK12", from_address=distAddr0, qty=9, to_address=shareholderAddr0, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK12", from_address=distAddr0, qty=3, to_address=shareholderAddr1, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK12", from_address=distAddr0, qty=2, to_address=shareholderAddr2, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
-        n0.transferfromaddress(asset_name="STOCK12", from_address=distAddr0, qty=1, to_address=shareholderAddr3, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
+        n0.transferfromaddress(asset_name="STOCK12", from_address=dist_addr0, qty=9, to_address=shareholder_addr0, message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK12", from_address=dist_addr0, qty=3, to_address=shareholder_addr1, message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK12", from_address=dist_addr0, qty=2, to_address=shareholder_addr2, message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
+        n0.transferfromaddress(asset_name="STOCK12", from_address=dist_addr0, qty=1, to_address=shareholder_addr3,  message="", expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
 
         n0.generate(150)
         self.sync_all()
 
         self.log.info("Verifying share distribution")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)['STOCK12'], 9)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["STOCK12"], 3)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["STOCK12"], 2)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr3)["STOCK12"], 1)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)['STOCK12'], 9)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["STOCK12"], 3)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["STOCK12"], 2)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr3)["STOCK12"], 1)
 
         self.log.info("Mining blocks")
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Issuing PAYOUT12 asset")
-        n0.issue(asset_name="PAYOUT12", qty=10, to_address=ownerAddr0, change_address="", \
-                 units=1, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="PAYOUT12", qty=10, to_address=owner_addr0, change_address="", units=1, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 5
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 5
 
         self.log.info("Requesting snapshot of STOCK12 ownership in 5 blocks")
-        n0.requestsnapshot(asset_name="STOCK12", block_height=tgtBlockHeight)
+        n0.requestsnapshot(asset_name="STOCK12", block_height=tgt_block_height)
 
         # Mine 10 blocks to make sure snapshot is created
         n0.generate(10)
 
         self.log.info("Retrieving snapshot request")
-        snapShotReq = n0.getsnapshotrequest(asset_name="STOCK12", block_height=tgtBlockHeight)
-        assert_equal(snapShotReq["asset_name"], "STOCK12")
-        assert_equal(snapShotReq["block_height"], tgtBlockHeight)
+        snap_shot_req = n0.getsnapshotrequest(asset_name="STOCK12", block_height=tgt_block_height)
+        assert_equal(snap_shot_req["asset_name"], "STOCK12")
+        assert_equal(snap_shot_req["block_height"], tgt_block_height)
 
         self.log.info("Skipping forward to allow snapshot to process")
         n0.generate(61)
         self.sync_all()
 
         self.log.info("Retrieving snapshot for ownership validation")
-        snapShot = n0.getsnapshot(asset_name="STOCK12", block_height=tgtBlockHeight)
-        assert_equal(snapShot["name"], "STOCK12")
-        assert_equal(snapShot["height"], tgtBlockHeight)
+        snap_shot = n0.getsnapshot(asset_name="STOCK12", block_height=tgt_block_height)
+        assert_equal(snap_shot["name"], "STOCK12")
+        assert_equal(snap_shot["height"], tgt_block_height)
         owner0 = False
         owner1 = False
         owner2 = False
-        for ownerAddr in snapShot["owners"]:
-            if ownerAddr["address"] == shareholderAddr0:
+        for ownerAddr in snap_shot["owners"]:
+            if ownerAddr["address"] == shareholder_addr0:
                 assert_equal(ownerAddr["amount_owned"], 9)
                 owner0 = True
-            elif ownerAddr["address"] == shareholderAddr1:
+            elif ownerAddr["address"] == shareholder_addr1:
                 assert_equal(ownerAddr["amount_owned"], 3)
                 owner1 = True
-            elif ownerAddr["address"] == shareholderAddr2:
+            elif ownerAddr["address"] == shareholder_addr2:
                 assert_equal(ownerAddr["amount_owned"], 2)
                 owner2 = True
-            elif ownerAddr["address"] == shareholderAddr3:
+            elif ownerAddr["address"] == shareholder_addr3:
                 assert_equal(ownerAddr["amount_owned"], 1)
                 owner2 = True
         assert_equal(owner0, True)
@@ -1129,63 +1129,63 @@ class RewardsTest(RavenTestFramework):
         assert_equal(owner2, True)
 
         self.log.info("Initiating reward payout")
-        n0.distributereward(asset_name="STOCK12", snapshot_height=tgtBlockHeight, distribution_asset_name="PAYOUT12", gross_distribution_amount=10, exception_addresses=distAddr0)
+        n0.distributereward(asset_name="STOCK12", snapshot_height=tgt_block_height, distribution_asset_name="PAYOUT12",
+                            gross_distribution_amount=10, exception_addresses=dist_addr0)
         n0.generate(10)
         self.sync_all()
 
-        ##  Inexplicably, order matters here. We need to verify the amount
-        ##      using the node that created the address (?!)
+        #  Inexplicably, order matters here. We need to verify the amount
+        #      using the node that created the address (?!)
         self.log.info("Verifying PAYOUT12 holdings after payout")
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr0)["PAYOUT12"], 6)
-        assert_equal(n1.listassetbalancesbyaddress(shareholderAddr1)["PAYOUT12"], 2)
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr2)["PAYOUT12"], Decimal(str(1.3)))
-        assert_equal(n0.listassetbalancesbyaddress(shareholderAddr3)["PAYOUT12"], Decimal(str(0.6)))
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr0)["PAYOUT12"], 6)
+        assert_equal(n1.listassetbalancesbyaddress(shareholder_addr1)["PAYOUT12"], 2)
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr2)["PAYOUT12"], Decimal(str(1.3)))
+        assert_equal(n0.listassetbalancesbyaddress(shareholder_addr3)["PAYOUT12"], Decimal(str(0.6)))
 
     def test_rvn_bulk(self):
         self.log.info("Running basic RVN reward test!")
         n0, n1, n2, n3 = self.nodes[0], self.nodes[1], self.nodes[2], self.nodes[3]
 
         self.log.info("Creating owner address")
-        ownerAddr0 = n0.getnewaddress()
-        # self.log.info(f"Owner address: {ownerAddr0}")
+        owner_addr0 = n0.getnewaddress()
+        # self.log.info(f"Owner address: {owner_addr0}")
 
         self.log.info("Creating distributor address")
-        distAddr0 = n0.getnewaddress()
-        # self.log.info(f"Distributor address: {distAddr0}")
+        dist_addr0 = n0.getnewaddress()
+        # self.log.info(f"Distributor address: {dist_addr0}")
 
         self.log.info("Providing funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 1000)
+        self.nodes[0].sendtoaddress(owner_addr0, 1000)
         n0.generate(100)
         self.sync_all()
 
         self.log.info("Issuing BULK1 asset")
-        n0.issue(asset_name="BULK1", qty=100000, to_address=ownerAddr0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=False)
-        n0.issue(asset_name="TTTTTTTTTTTTTTTTTTTTTTTTTTTTT1", qty=100000, to_address=ownerAddr0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="BULK1", qty=100000, to_address=owner_addr0, change_address="", units=4, reissuable=True, has_ipfs=False)
+        n0.issue(asset_name="TTTTTTTTTTTTTTTTTTTTTTTTTTTTT1", qty=100000, to_address=owner_addr0, change_address="", units=4, reissuable=True, has_ipfs=False)
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Checking listassetbalancesbyaddress()...")
-        assert_equal(n0.listassetbalancesbyaddress(ownerAddr0)["BULK1"], 100000)
+        assert_equal(n0.listassetbalancesbyaddress(owner_addr0)["BULK1"], 100000)
 
         self.log.info("Transferring all assets to a single address for tracking")
-        n0.transfer(asset_name="BULK1", qty=100000, to_address=distAddr0)
+        n0.transfer(asset_name="BULK1", qty=100000, to_address=dist_addr0)
         n0.generate(10)
         self.sync_all()
-        assert_equal(n0.listassetbalancesbyaddress(distAddr0)["BULK1"], 100000)
+        assert_equal(n0.listassetbalancesbyaddress(dist_addr0)["BULK1"], 100000)
 
         self.log.info("Creating shareholder addresses")
-        address_list = [None]*9999
+        address_list = [None] * 9999
         for i in range(0, 9999, 3):
             address_list[i] = n1.getnewaddress()
-            address_list[i+1] = n2.getnewaddress()
-            address_list[i+2] = n3.getnewaddress()
+            address_list[i + 1] = n2.getnewaddress()
+            address_list[i + 2] = n3.getnewaddress()
 
         self.log.info("Distributing shares")
         count = 0
         for address in address_list:
-            n0.transferfromaddress(asset_name="BULK1", from_address=distAddr0, qty=10, to_address=address, message="", expire_time=0, rvn_change_address="", asset_change_address=distAddr0)
+            n0.transferfromaddress(asset_name="BULK1", from_address=dist_addr0, qty=10, to_address=address, message="",
+                                   expire_time=0, rvn_change_address="", asset_change_address=dist_addr0)
             count += 1
             if count > 190:
                 n0.generate(1)
@@ -1198,42 +1198,44 @@ class RewardsTest(RavenTestFramework):
         self.log.info("Verifying share distribution")
         for i in range(0, 9999, 3):
             assert_equal(n1.listassetbalancesbyaddress(address_list[i])["BULK1"], 10)
-            assert_equal(n2.listassetbalancesbyaddress(address_list[i+1])["BULK1"], 10)
-            assert_equal(n3.listassetbalancesbyaddress(address_list[i+2])["BULK1"], 10)
+            assert_equal(n2.listassetbalancesbyaddress(address_list[i + 1])["BULK1"], 10)
+            assert_equal(n3.listassetbalancesbyaddress(address_list[i + 2])["BULK1"], 10)
 
         self.log.info("Mining blocks")
         n0.generate(10)
         self.sync_all()
 
         self.log.info("Providing additional funding")
-        self.nodes[0].sendtoaddress(ownerAddr0, 2000)
+        self.nodes[0].sendtoaddress(owner_addr0, 2000)
         n0.generate(100)
         self.sync_all()
 
         self.log.info("Retrieving chain height")
-        tgtBlockHeight = n0.getblockchaininfo()["blocks"] + 5
+        tgt_block_height = n0.getblockchaininfo()["blocks"] + 5
 
         self.log.info("Requesting snapshot of BULK1 ownership in 100 blocks")
-        n0.requestsnapshot(asset_name="BULK1", block_height=tgtBlockHeight)
+        n0.requestsnapshot(asset_name="BULK1", block_height=tgt_block_height)
 
         self.log.info("Skipping forward to allow snapshot to process")
         n0.generate(66)
         self.sync_all()
 
         self.log.info("Retrieving snapshot request")
-        snapShotReq = n0.getsnapshotrequest(asset_name="BULK1", block_height=tgtBlockHeight)
-        assert_equal(snapShotReq["asset_name"], "BULK1")
-        assert_equal(snapShotReq["block_height"], tgtBlockHeight)
+        snap_shot_req = n0.getsnapshotrequest(asset_name="BULK1", block_height=tgt_block_height)
+        assert_equal(snap_shot_req["asset_name"], "BULK1")
+        assert_equal(snap_shot_req["block_height"], tgt_block_height)
 
         self.log.info("Retrieving snapshot for ownership validation")
-        snapShot = n0.getsnapshot(asset_name="BULK1", block_height=tgtBlockHeight)
-        assert_equal(snapShot["name"], "BULK1")
-        assert_equal(snapShot["height"], tgtBlockHeight)
-        for ownerAddr in snapShot["owners"]:
+        snap_shot = n0.getsnapshot(asset_name="BULK1", block_height=tgt_block_height)
+        assert_equal(snap_shot["name"], "BULK1")
+        assert_equal(snap_shot["height"], tgt_block_height)
+        for ownerAddr in snap_shot["owners"]:
             assert_equal(ownerAddr["amount_owned"], 10)
 
         self.log.info("Initiating reward payout")
-        result = n0.distributereward(asset_name="BULK1", snapshot_height=tgtBlockHeight, distribution_asset_name="TTTTTTTTTTTTTTTTTTTTTTTTTTTTT1", gross_distribution_amount=100000, exception_addresses=distAddr0, change_address="", dry_run=False)
+        n0.distributereward(asset_name="BULK1", snapshot_height=tgt_block_height,
+                            distribution_asset_name="TTTTTTTTTTTTTTTTTTTTTTTTTTTTT1", gross_distribution_amount=100000,
+                            exception_addresses=dist_addr0, change_address="", dry_run=False)
         # print(result)
         n0.generate(10)
         self.sync_all()
@@ -1242,8 +1244,8 @@ class RewardsTest(RavenTestFramework):
         self.log.info("Checking reward payout")
         for i in range(0, 9999, 3):
             assert_equal(n1.listassetbalancesbyaddress(address_list[i])['TTTTTTTTTTTTTTTTTTTTTTTTTTTTT1'], Decimal(str(10.0010)))
-            assert_equal(n2.listassetbalancesbyaddress(address_list[i+1])['TTTTTTTTTTTTTTTTTTTTTTTTTTTTT1'], Decimal(str(10.0010)))
-            assert_equal(n3.listassetbalancesbyaddress(address_list[i+2])['TTTTTTTTTTTTTTTTTTTTTTTTTTTTT1'], Decimal(str(10.0010)))
+            assert_equal(n2.listassetbalancesbyaddress(address_list[i + 1])['TTTTTTTTTTTTTTTTTTTTTTTTTTTTT1'], Decimal(str(10.0010)))
+            assert_equal(n3.listassetbalancesbyaddress(address_list[i + 2])['TTTTTTTTTTTTTTTTTTTTTTTTTTTTT1'], Decimal(str(10.0010)))
 
     def run_test(self):
         self.activate_assets()
@@ -1253,15 +1255,15 @@ class RewardsTest(RavenTestFramework):
         self.payout_with_invalid_ownership_asset()
         self.payout_with_invalid_payout_asset()
         self.payout_before_minimum_height_is_reached()
-        self.listsnapshotrequests()
+        self.list_snapshot_requests()
         self.payout_custom_height_set_with_low_funds()
-        self.payout_with_insufficent_asset_amount()
+        self.payout_with_insufficient_asset_amount()
         self.basic_test_asset_uneven_distribution()
         self.basic_test_asset_even_distribution()
         self.basic_test_asset_round_down_uneven_distribution()
         self.basic_test_asset_round_down_uneven_distribution_2()
         self.basic_test_asset_round_down_uneven_distribution_3()
-        #self.test_asset_bulk()
+        # self.test_asset_bulk()
 
 
 if __name__ == "__main__":

--- a/test/functional/feature_shutdown.py
+++ b/test/functional/feature_shutdown.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test ravend shutdown."""
+
+from threading import Thread
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import assert_equal, get_rpc_proxy, wait_until
+
+def test_long_call(node):
+    block = node.waitfornewblock()
+    assert_equal(block['height'], 0)
+
+class ShutdownTest(RavenTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = get_rpc_proxy(self.nodes[0].url, 1, timeout=600, coverage_dir=self.nodes[0].coverage_dir)
+        # Force connection establishment by executing a dummy command.
+        node.getblockcount()
+        Thread(target=test_long_call, args=(node,)).start()
+        # Wait until the server is executing the above `waitfornewblock`.
+        wait_until(lambda: len(self.nodes[0].getrpcinfo()['active_commands']) == 2, err_msg="wait until getrpcinfo active commands")
+        # Wait 1 second after requesting shutdown but not before the `stop` call
+        # finishes. This is to ensure event loop waits for current connections
+        # to close.
+        self.stop_node(0) #, wait=1000)
+
+if __name__ == '__main__':
+    ShutdownTest().main()

--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the -uacomment option."""
 
 from test_framework.test_framework import RavenTestFramework

--- a/test/functional/feature_unique_assets.py
+++ b/test/functional/feature_unique_assets.py
@@ -3,17 +3,12 @@
 # Copyright (c) 2017-2018 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Testing unique asset use cases
 
-"""
+"""Testing unique asset use cases"""
+
 import random
-
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_contains,
-                                assert_does_not_contain_key,
-                                assert_equal,
-                                assert_raises_rpc_error)
-
+from test_framework.util import assert_contains, assert_does_not_contain_key, assert_equal, assert_raises_rpc_error
 
 def gen_root_asset_name():
     size = random.randint(3, 14)
@@ -97,7 +92,7 @@ class UniqueAssetTest(RavenTestFramework):
         assert_raises_rpc_error(-8, f"Invalid parameter: asset_name '{asset_name}' has already been used", n0.issue, asset_name)
 
 
-    def issueunique_test(self):
+    def issue_unique_test(self):
         self.log.info("Testing issueunique RPC...")
         n0, n1 = self.nodes[0], self.nodes[1]
         n0.sendtoaddress(n1.getnewaddress(), 501)
@@ -109,6 +104,7 @@ class UniqueAssetTest(RavenTestFramework):
         n0.issueunique(root, asset_tags, ipfs_hashes)
         block_hash = n0.generate(1)[0]
 
+        asset_name = ""
         for tag in asset_tags:
             asset_name = f"{root}#{tag}"
             assert_equal(1, n0.listmyassets()[asset_name])
@@ -138,7 +134,7 @@ class UniqueAssetTest(RavenTestFramework):
 
     def run_test(self):
         self.activate_assets()
-        self.issueunique_test()
+        self.issue_unique_test()
         self.issue_one()
         self.issue_invalid()
 

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -3,16 +3,18 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test version bits warning system.
+
+"""
+Test version bits warning system.
 
 Generate chains with block versions that appear to be signalling unknown
 soft-forks, and test that warning alerts are generated.
 """
 
-from test_framework.mininode import (NodeConn, NodeConnCB, msg_block, NetworkThread)
+from re import compile
+from test_framework.mininode import NodeConn, NodeConnCB, MsgBlock, NetworkThread
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (os, p2p_port)
-import re
+from test_framework.util import os, p2p_port
 from test_framework.blocktools import create_block, create_coinbase
 
 VB_PERIOD = 144 # versionbits period length for regtest
@@ -22,7 +24,7 @@ VB_UNKNOWN_BIT = 27 # Choose a bit unassigned to any deployment
 
 WARN_UNKNOWN_RULES_MINED = "Unknown block versions being mined! It's possible unknown rules are in effect"
 WARN_UNKNOWN_RULES_ACTIVE = "unknown new rules activated (versionbit {})".format(VB_UNKNOWN_BIT)
-VB_PATTERN = re.compile("^Warning.*versionbit")
+VB_PATTERN = compile("^Warning.*versionbit")
 
 class TestNode(NodeConnCB):
     def on_inv(self, conn, message):
@@ -42,7 +44,7 @@ class VersionBitsWarningTest(RavenTestFramework):
         self.setup_nodes()
 
     # Send numblocks blocks via peer with nVersionToUse set.
-    def send_blocks_with_version(self, peer, numblocks, nVersionToUse):
+    def send_blocks_with_version(self, peer, numblocks, n_version_to_use):
         tip = self.nodes[0].getbestblockhash()
         height = self.nodes[0].getblockcount()
         block_time = self.nodes[0].getblockheader(tip)["time"]+1
@@ -50,12 +52,12 @@ class VersionBitsWarningTest(RavenTestFramework):
 
         for _ in range(numblocks):
             block = create_block(tip, create_coinbase(height+1), block_time)
-            block.nVersion = nVersionToUse
+            block.nVersion = n_version_to_use
             block.solve()
-            peer.send_message(msg_block(block))
+            peer.send_message(MsgBlock(block))
             block_time += 1
             height += 1
-            tip = block.sha256
+            tip = block.x16r
         peer.sync_with_ping()
 
     def test_versionbits_in_alert_file(self):
@@ -67,8 +69,7 @@ class VersionBitsWarningTest(RavenTestFramework):
         # Setup the p2p connection and start up the network thread.
         test_node = TestNode()
 
-        connections = []
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_node))
+        connections = [NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_node)]
         test_node.add_connection(connections[0])
 
         NetworkThread().start() # Start up network handling in another thread
@@ -81,8 +82,8 @@ class VersionBitsWarningTest(RavenTestFramework):
 
         # 2. Now build one period of blocks on the tip, with < VB_THRESHOLD
         # blocks signaling some unknown bit.
-        nVersion = VB_TOP_BITS | (1<<VB_UNKNOWN_BIT)
-        self.send_blocks_with_version(test_node, VB_THRESHOLD-1, nVersion)
+        n_version = VB_TOP_BITS | (1<<VB_UNKNOWN_BIT)
+        self.send_blocks_with_version(test_node, VB_THRESHOLD-1, n_version)
 
         # Fill rest of period with regular version blocks
         self.nodes[0].generate(VB_PERIOD - VB_THRESHOLD + 1)
@@ -94,7 +95,7 @@ class VersionBitsWarningTest(RavenTestFramework):
 
         # 3. Now build one period of blocks with >= VB_THRESHOLD blocks signaling
         # some unknown bit
-        self.send_blocks_with_version(test_node, VB_THRESHOLD, nVersion)
+        self.send_blocks_with_version(test_node, VB_THRESHOLD, n_version)
         self.nodes[0].generate(VB_PERIOD - VB_THRESHOLD)
         # Might not get a versionbits-related alert yet, as we should
         # have gotten a different alert due to more than 51/100 blocks

--- a/test/functional/interface_http.py
+++ b/test/functional/interface_http.py
@@ -3,14 +3,15 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test the RPC HTTP basics."""
 
-from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (str_to_b64str, assert_equal)
+"""Test the RPC HTTP basics."""
 
 import http.client
 import urllib.parse
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import str_to_b64str, assert_equal
 
+# noinspection PyUnresolvedReferences
 class HTTPBasicsTest (RavenTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
@@ -32,13 +33,13 @@ class HTTPBasicsTest (RavenTestFramework):
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1)
-        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
+        assert(conn.sock is not None) #according to http/1.1 connection must still be open!
 
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1) #must also response with a correct json-rpc message
-        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
+        assert(conn.sock is not None) #according to http/1.1 connection must still be open!
         conn.close()
 
         #same should be if we add keep-alive because this should be the std. behaviour
@@ -49,13 +50,13 @@ class HTTPBasicsTest (RavenTestFramework):
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1)
-        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
+        assert(conn.sock is not None) #according to http/1.1 connection must still be open!
 
         #send 2nd request without closing connection
         conn.request('POST', '/', '{"method": "getchaintips"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1) #must also response with a correct json-rpc message
-        assert(conn.sock!=None) #according to http/1.1 connection must still be open!
+        assert(conn.sock is not None) #according to http/1.1 connection must still be open!
         conn.close()
 
         #now do the same with "Connection: close"
@@ -66,7 +67,7 @@ class HTTPBasicsTest (RavenTestFramework):
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1)
-        assert(conn.sock==None) #now the connection must be closed after the response
+        assert(conn.sock is None) #now the connection must be closed after the response
 
         #node1 (2nd node) is running with disabled keep-alive option
         urlNode1 = urllib.parse.urlparse(self.nodes[1].url)
@@ -89,7 +90,7 @@ class HTTPBasicsTest (RavenTestFramework):
         conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
         out1 = conn.getresponse().read()
         assert(b'"error":null' in out1)
-        assert(conn.sock!=None) #connection must be closed because ravend should use keep-alive by default
+        assert(conn.sock is not None) #connection must be closed because ravend should use keep-alive by default
 
         # Check excessive request size
         conn = http.client.HTTPConnection(urlNode2.hostname, urlNode2.port)

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -3,18 +3,14 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the REST API."""
 
-from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_nodes_bi, 
-                                assert_equal, 
-                                Decimal, 
-                                json, 
-                                hex_str_to_bytes, 
-                                assert_greater_than)
-from struct import (unpack, pack)
+from struct import unpack, pack
 from io import BytesIO
 from codecs import encode
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import connect_nodes_bi, assert_equal, Decimal, json, hex_str_to_bytes, assert_greater_than
 
 import http.client
 import urllib.parse
@@ -46,6 +42,8 @@ def http_post_call(host, port, path, requestdata = '', response_object = 0):
 
     return conn.getresponse().read()
 
+
+# noinspection PyTypeChecker
 class RESTTest (RavenTestFramework):
     FORMAT_SEPARATOR = "."
 
@@ -112,7 +110,7 @@ class RESTTest (RavenTestFramework):
         #check chainTip response
         assert_equal(json_obj['chaintipHash'], bb_hash)
 
-        #make sure there is no utox in the response because this oupoint has been spent
+        # make sure there is no utxo in the response because this oupoint has been spent
         assert_equal(len(json_obj['utxos']), 0)
 
         #check bitmap
@@ -156,7 +154,7 @@ class RESTTest (RavenTestFramework):
         txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
         json_string = http_get_call(url.hostname, url.port, '/rest/tx/'+txid+self.FORMAT_SEPARATOR+"json")
         json_obj = json.loads(json_string)
-        vintx = json_obj['vin'][0]['txid'] # get the vin to later check for utxo (should be spent by then)
+        #vintx = json_obj['vin'][0]['txid'] # get the vin to later check for utxo (should be spent by then)
         # get n of 0.1 outpoint
         n = 0
         for vout in json_obj['vout']:
@@ -285,10 +283,9 @@ class RESTTest (RavenTestFramework):
 
         # check block tx details
         # let's make 3 tx and mine them on node 1
-        txs = []
-        txs.append(self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11))
-        txs.append(self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11))
-        txs.append(self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11))
+        txs = [self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11),
+               self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11),
+               self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11)]
         self.sync_all()
 
         # check that there are exactly 3 transactions in the TX memory pool before generating the block

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -3,17 +3,18 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
 """Test the ZMQ notification interface."""
+
 import configparser
 import os
 import struct
+from test_framework.test_framework import RavenTestFramework, SkipTest
+from test_framework.util import assert_equal, bytes_to_hex_str, hash256, x16_hash_block
 
-from test_framework.test_framework import (RavenTestFramework, SkipTest)
-from test_framework.util import (assert_equal,
-                                 bytes_to_hex_str,
-                                 hash256,
-                                 x16_hash_block)
 
+# noinspection PyUnresolvedReferences
 class ZMQSubscriber:
     def __init__(self, socket, topic):
         self.sequence = 0
@@ -33,6 +34,7 @@ class ZMQSubscriber:
         return body
 
 
+# noinspection PyUnresolvedReferences
 class ZMQTest (RavenTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
@@ -93,15 +95,15 @@ class ZMQTest (RavenTestFramework):
             txid = self.hashtx.receive()
 
             # Should receive the coinbase raw transaction.
-            hex = self.rawtx.receive()
-            assert_equal(bytes_to_hex_str(hash256(hex)),
+            hex_data = self.rawtx.receive()
+            assert_equal(bytes_to_hex_str(hash256(hex_data)),
                          self.nodes[1].getrawtransaction(bytes_to_hex_str(txid), True)["hash"])
 
             # Should receive the generated block hash.
-            hash = bytes_to_hex_str(self.hashblock.receive())
-            assert_equal(genhashes[x], hash)
+            hash_data = bytes_to_hex_str(self.hashblock.receive())
+            assert_equal(genhashes[x], hash_data)
             # The block should only have the coinbase txid.
-            assert_equal([bytes_to_hex_str(txid)], self.nodes[1].getblock(hash)["tx"])
+            assert_equal([bytes_to_hex_str(txid)], self.nodes[1].getblock(hash_data)["tx"])
 
             # Should receive the generated raw block.
             block = self.rawblock.receive()
@@ -116,8 +118,8 @@ class ZMQTest (RavenTestFramework):
         assert_equal(payment_txid, bytes_to_hex_str(txid))
 
         # Should receive the broadcasted raw transaction.
-        hex = self.rawtx.receive()
-        assert_equal(payment_txid, bytes_to_hex_str(hash256(hex)))
+        hex_data = self.rawtx.receive()
+        assert_equal(payment_txid, bytes_to_hex_str(hash256(hex_data)))
 
 if __name__ == '__main__':
     ZMQTest().main()

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -3,62 +3,66 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test mempool limiting together/eviction with the wallet."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (gen_return_txouts, 
-                                create_confirmed_utxos, 
-                                satoshi_round, 
-                                create_lots_of_big_transactions)
+from test_framework.util import gen_return_txouts, create_confirmed_utxos, satoshi_round, \
+    create_lots_of_big_transactions
 
+
+# noinspection PyAttributeOutsideInit
 class MempoolLimitTest(RavenTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-maxmempool=9", "-spendzeroconfchange=0"]]
-        self.thirtyTransactions = 9  #tx are created in groups of 30.  Value here will be multiplied by thirty for the number of tx.
+        self.extra_args = [["-maxmempool=10", "-spendzeroconfchange=0"]]
+        self.thirtyTransactions = 9  # tx are created in groups of 30.  Value here will be multiplied by thirty for the number of tx.
 
     def run_test(self):
         txouts = gen_return_txouts()
         relayfee = self.nodes[0].getnetworkinfo()['relayfee']
 
         txids = []
-        utxos = create_confirmed_utxos(relayfee, self.nodes[0], self.thirtyTransactions*30)
+        utxos = create_confirmed_utxos(relayfee, self.nodes[0], self.thirtyTransactions * 30)
 
-        #create a mempool tx that will be evicted
+        # create a mempool tx that will be evicted
         us0 = utxos.pop()
-        inputs = [{ "txid" : us0["txid"], "vout" : us0["vout"]}]
-        outputs = {self.nodes[0].getnewaddress() : 0.1}
+        inputs = [{"txid": us0["txid"], "vout": us0["vout"]}]
+        outputs = {self.nodes[0].getnewaddress(): 0.1}
         tx = self.nodes[0].createrawtransaction(inputs, outputs)
 
         # Any fee calc method should work as longs as base_fee is set proportionally...
 
-        #1
-        txF = self.nodes[0].fundrawtransaction(tx)
-        base_fee = satoshi_round(0.01025*100)  # DEFAULT_FALLBACK_FEE (settxfee(0) is default and falls through to this)
+        # 1
+        tx_f = self.nodes[0].fundrawtransaction(tx)
+        base_fee = satoshi_round(
+            0.01025 * 100)  # DEFAULT_FALLBACK_FEE (settxfee(0) is default and falls through to this)
 
-        #2
+        # 2
         # self.nodes[0].settxfee(relayfee)  # specifically fund this tx with low fee (this is too low and will be bumped to MINFEE)
-        # txF = self.nodes[0].fundrawtransaction(tx)
+        # tx_f = self.nodes[0].fundrawtransaction(tx)
         # base_fee = satoshi_round(0.0005*100)  # DEFAULT_TRANSACTION_MINFEE
         # self.nodes[0].settxfee(0) # return to automatic fee selection
 
-        #3
-        # txF = self.nodes[0].fundrawtransaction(tx, {"feeRate": relayfee})
+        # 3
+        # tx_f = self.nodes[0].fundrawtransaction(tx, {"feeRate": relayfee})
         # relayfee = self.nodes[0].getnetworkinfo()['relayfee']
         # base_fee = relayfee*100
 
-        txFS = self.nodes[0].signrawtransaction(txF['hex'])
-        txid = self.nodes[0].sendrawtransaction(txFS['hex'])
+        tx_fs = self.nodes[0].signrawtransaction(tx_f['hex'])
+        txid = self.nodes[0].sendrawtransaction(tx_fs['hex'])
 
-        for i in range (self.thirtyTransactions):
+        for i in range(self.thirtyTransactions):
             txids.append([])
-            txids[i] = create_lots_of_big_transactions(self.nodes[0], txouts, utxos[30*i:30*i+30], 30, (i+1)*base_fee)
+            txids[i] = create_lots_of_big_transactions(self.nodes[0], txouts, utxos[30 * i:30 * i + 30], 30,
+                                                       (i + 1) * base_fee)
 
         # by now, the tx should be evicted, check confirmation state
-        assert(txid not in self.nodes[0].getrawmempool())
+        assert (txid not in self.nodes[0].getrawmempool())
         txdata = self.nodes[0].gettransaction(txid)
-        assert(txdata['confirmations'] ==  0) #confirmation should still be 0
+        assert (txdata['confirmations'] == 0)  # confirmation should still be 0
+
 
 if __name__ == '__main__':
     MempoolLimitTest().main()

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -3,15 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test descendant package tracking code."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (satoshi_round, 
-                                Decimal, 
-                                assert_equal, 
-                                assert_raises_rpc_error, 
-                                sync_blocks, 
-                                sync_mempools)
+from test_framework.util import satoshi_round, Decimal, assert_equal, assert_raises_rpc_error, sync_blocks, sync_mempools
 from test_framework.mininode import COIN
 
 MAX_ANCESTORS = 25
@@ -24,7 +20,8 @@ class MempoolPackagesTest(RavenTestFramework):
 
     # Build a transaction that spends parent_txid:vout
     # Return amount sent
-    def chain_transaction(self, node, parent_txid, vout, value, fee, num_outputs):
+    @staticmethod
+    def chain_transaction(node, parent_txid, vout, value, fee, num_outputs):
         send_value = satoshi_round((value - fee)/num_outputs)
         inputs = [ {'txid' : parent_txid, 'vout' : vout} ]
         outputs = {}
@@ -35,10 +32,10 @@ class MempoolPackagesTest(RavenTestFramework):
         txid = node.sendrawtransaction(signedtx['hex'])
         fulltx = node.getrawtransaction(txid, 1)
         assert(len(fulltx['vout']) == num_outputs) # make sure we didn't generate a change output
-        return (txid, send_value)
+        return txid, send_value
 
     def run_test(self):
-        ''' Mine some blocks and have them mature. '''
+        """ Mine some blocks and have them mature. """
         self.nodes[0].generate(101)
         utxo = self.nodes[0].listunspent(10)
         txid = utxo[0]['txid']
@@ -141,7 +138,7 @@ class MempoolPackagesTest(RavenTestFramework):
         descendant_fees = 0
         for x in reversed(chain):
             descendant_fees += mempool[x]['fee']
-            if (x == chain[-1]):
+            if x == chain[-1]:
                 assert_equal(mempool[x]['modifiedfee'], mempool[x]['fee']+satoshi_round(0.00002))
             assert_equal(mempool[x]['descendantfees'], descendant_fees * COIN + 2000)
 
@@ -236,7 +233,7 @@ class MempoolPackagesTest(RavenTestFramework):
         outputs = { self.nodes[0].getnewaddress() : send_value + value - 4*fee }
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         signedtx = self.nodes[0].signrawtransaction(rawtx)
-        txid = self.nodes[0].sendrawtransaction(signedtx['hex'])
+        self.nodes[0].sendrawtransaction(signedtx['hex'])
         sync_mempools(self.nodes)
         
         # Now try to disconnect the tip on each node...

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test mempool persistence.
+
+"""
+Test mempool persistence.
 
 By default, ravend will dump mempool on shutdown and
 then reload it on startup. This can be overridden with
@@ -34,13 +36,12 @@ Test is as follows:
     mempool.
   - Verify that savemempool throws when the RPC is called if
     node1 can't write to disk.
-
 """
+
 import os
 import time
-
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, Decimal, wait_until, assert_raises_rpc_error)
+from test_framework.util import assert_equal, Decimal, wait_until, assert_raises_rpc_error
 
 class MempoolPersistTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test resurrection of mined transactions when the blockchain is re-organized."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (create_tx, assert_equal)
+from test_framework.util import create_tx, assert_equal
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(RavenTestFramework):

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -3,19 +3,19 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test longpolling with getblocktemplate."""
 
-from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (get_rpc_proxy, random_transaction, Decimal)
-
 import threading
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import get_rpc_proxy, random_transaction, Decimal
 
 class LongpollThread(threading.Thread):
     def __init__(self, node):
         threading.Thread.__init__(self)
         # query current longpollid
-        templat = node.getblocktemplate()
-        self.longpollid = templat['longpollid']
+        template = node.getblocktemplate()
+        self.longpollid = template['longpollid']
         # create a new connection to the node, we can't use the same
         # connection from two threads
         self.node = get_rpc_proxy(node.url, 1, timeout=600, coverage_dir=node.coverage_dir)
@@ -30,11 +30,11 @@ class GetBlockTemplateLPTest(RavenTestFramework):
     def run_test(self):
         self.log.info("Warning: this test will take about 70 seconds in the best case. Be patient.")
         self.nodes[0].generate(10)
-        templat = self.nodes[0].getblocktemplate()
-        longpollid = templat['longpollid']
+        template = self.nodes[0].getblocktemplate()
+        longpollid = template['longpollid']
         # longpollid should not change between successive invocations if nothing else happens
-        templat2 = self.nodes[0].getblocktemplate()
-        assert(templat2['longpollid'] == longpollid)
+        template_2 = self.nodes[0].getblocktemplate()
+        assert(template_2['longpollid'] == longpollid)
 
         # Test 1: test that the longpolling wait if we do nothing
         thr = LongpollThread(self.nodes[0])

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -3,11 +3,12 @@
 # Copyright (c) 2017-2018 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the prioritisetransaction mining RPC."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (gen_return_txouts, create_confirmed_utxos, create_lots_of_big_transactions, assert_raises_rpc_error, assert_equal, time)
-from test_framework.mininode import (COIN, MAX_BLOCK_BASE_SIZE)
+from test_framework.util import gen_return_txouts, create_confirmed_utxos, create_lots_of_big_transactions, assert_raises_rpc_error, assert_equal, time
+from test_framework.mininode import COIN, MAX_BLOCK_BASE_SIZE
 
 class PrioritiseTransactionTest(RavenTestFramework):
     def set_test_params(self):
@@ -60,7 +61,7 @@ class PrioritiseTransactionTest(RavenTestFramework):
                 high_fee_tx = x
 
         # Something high-fee should have been mined!
-        assert(high_fee_tx != None)
+        assert(high_fee_tx is not None)
 
         # Add a prioritisation before a tx is in the mempool (de-prioritising a
         # high-fee transaction so that it's now low fee).
@@ -76,7 +77,7 @@ class PrioritiseTransactionTest(RavenTestFramework):
         # Now verify the modified-high feerate transaction isn't mined before
         # the other high fee transactions. Keep mining until our mempool has
         # decreased by all the high fee size that we calculated above.
-        while (self.nodes[0].getmempoolinfo()['bytes'] > sizes[0] + sizes[1]):
+        while self.nodes[0].getmempoolinfo()['bytes'] > sizes[0] + sizes[1]:
             self.nodes[0].generate(1)
 
         # High fee transaction should not have been mined, but other high fee rate
@@ -85,7 +86,7 @@ class PrioritiseTransactionTest(RavenTestFramework):
         self.log.info("Assert that de-prioritised transaction is still in mempool")
         assert(high_fee_tx in mempool)
         for x in txids[2]:
-            if (x != high_fee_tx):
+            if x != high_fee_tx:
                 assert(x not in mempool)
 
         # Create a free transaction.  Should be rejected.

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -3,14 +3,12 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test node disconnect and ban behavior"""
-import time
 
+"""Test node disconnect and ban behavior"""
+
+import time
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal,
-                                assert_raises_rpc_error,
-                                connect_nodes_bi,
-                                wait_until)
+from test_framework.util import assert_equal, assert_raises_rpc_error, connect_nodes_bi, wait_until
 
 class DisconnectBanTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test node responses to invalid blocks.
+
+"""
+Test node responses to invalid blocks.
 
 In this test we connect to one node over p2p, and test block requests:
 1) Valid blocks should be requested and become chain tip.
@@ -12,18 +14,19 @@ In this test we connect to one node over p2p, and test block requests:
 re-requested.
 """
 
-from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import assert_equal
-from test_framework.comptool import (TestManager, TestInstance, RejectResult)
-from test_framework.blocktools import (NetworkThread, create_block, create_coinbase, create_transaction, COIN)
 import copy
 import time
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import assert_equal
+from test_framework.comptool import TestManager, TestInstance, RejectResult
+from test_framework.blocktools import create_block, create_coinbase, create_transaction, COIN
+from test_framework.mininode import NetworkThread
 
 # Use the ComparisonTestFramework with 1 node: only use --testbinary.
 class InvalidBlockRequestTest(ComparisonTestFramework):
 
-    ''' Can either run this test as 1 node with expected answers, or two and compare them. 
-        Change the "outcome" variable from each TestInstance object to only do the comparison. '''
+    """ Can either run this test as 1 node with expected answers, or two and compare them.
+        Change the "outcome" variable from each TestInstance object to only do the comparison. """
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
@@ -105,7 +108,7 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         self.block_time += 1
         block3.vtx[0].vout[0].nValue = 100 * COIN # Too high!
         block3.vtx[0].sha256=None
-        block3.vtx[0].calc_sha256()
+        block3.vtx[0].calc_x16r()
         block3.hashMerkleRoot = block3.calc_merkle_root()
         block3.rehash()
         block3.solve()

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -3,23 +3,24 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test node responses to invalid transactions.
+
+"""
+Test node responses to invalid transactions.
 
 In this test we connect to one node over p2p, and test tx requests.
 """
 
-from test_framework.test_framework import ComparisonTestFramework
-from test_framework.comptool import (TestManager, TestInstance, RejectResult)
-from test_framework.blocktools import (NetworkThread, create_block, create_coinbase, create_transaction, COIN)
 import time
-
-
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.comptool import TestManager, TestInstance, RejectResult
+from test_framework.blocktools import create_block, create_coinbase, create_transaction, COIN
+from test_framework.mininode import NetworkThread
 
 # Use the ComparisonTestFramework with 1 node: only use --testbinary.
 class InvalidTxRequestTest(ComparisonTestFramework):
 
-    ''' Can either run this test as 1 node with expected answers, or two and compare them. 
-        Change the "outcome" variable from each TestInstance object to only do the comparison. '''
+    """ Can either run this test as 1 node with expected answers, or two and compare them.
+        Change the "outcome" variable from each TestInstance object to only do the comparison. """
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2018 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test that we don't leak txs to inbound peers that we haven't yet announced to"""
+
+from test_framework.mininode import MsgGetdata, CInv, NetworkThread, NodeConn, NodeConnCB
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import assert_equal, p2p_port
+
+class TestNode(NodeConnCB):
+    def on_inv(self, conn, message):
+        pass
+
+
+class P2PLeakTxTest(RavenTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+
+    def run_test(self):
+        gen_node = self.nodes[0]  # The block and tx generating node
+        gen_node.generate(1)
+
+        # Setup the attacking p2p connection and start up the network thread.
+        self.inbound_peer = TestNode()
+        connections = [NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.inbound_peer)]
+        self.inbound_peer.add_connection(connections[0])
+        NetworkThread().start() # Start up network handling in another thread
+
+
+        max_repeats = 48
+        self.log.info("Running test up to {} times.".format(max_repeats))
+        for i in range(max_repeats):
+            self.log.info('Run repeat {}'.format(i + 1))
+            txid = gen_node.sendtoaddress(gen_node.getnewaddress(), 0.01)
+
+            want_tx = MsgGetdata()
+            want_tx.inv.append(CInv(t=1, h=int(txid, 16)))
+            self.inbound_peer.last_message.pop('notfound', None)
+            connections[0].send_message(want_tx)
+            self.inbound_peer.sync_with_ping()
+
+            if self.inbound_peer.last_message.get('notfound'):
+                self.log.debug('tx {} was not yet announced to us.'.format(txid))
+                self.log.debug("node has responded with a notfound message. End test.")
+                assert_equal(self.inbound_peer.last_message['notfound'].vec[0].hash, int(txid, 16))
+                self.inbound_peer.last_message.pop('notfound')
+                break
+            else:
+                self.log.debug('tx {} was already announced to us. Try test again.'.format(txid))
+                assert int(txid, 16) in [inv.hash for inv in self.inbound_peer.last_message['inv'].inv]
+
+
+if __name__ == '__main__':
+    P2PLeakTxTest().main()

--- a/test/functional/p2p_mempool.py
+++ b/test/functional/p2p_mempool.py
@@ -3,15 +3,17 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test p2p mempool message.
+
+"""
+Test p2p mempool message.
 
 Test that nodes are disconnected if they send mempool messages when bloom
 filters are not enabled.
 """
 
-from test_framework.mininode import (NodeConn, NodeConnCB, NetworkThread, msg_mempool)
+from test_framework.mininode import NodeConn, NodeConnCB, NetworkThread, MsgMempool
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (p2p_port, assert_equal)
+from test_framework.util import p2p_port, assert_equal
 
 class P2PMempoolTests(RavenTestFramework):
     def set_test_params(self):
@@ -28,7 +30,7 @@ class P2PMempoolTests(RavenTestFramework):
         aTestNode.wait_for_verack()
 
         #request mempool
-        aTestNode.send_message(msg_mempool())
+        aTestNode.send_message(MsgMempool())
         aTestNode.wait_for_disconnect()
 
         #mininode must be disconnected at this point

--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test various net timeouts.
+
+"""
+Test various net timeouts.
 
 - Create three ravend nodes:
 
@@ -23,8 +25,7 @@
 """
 
 from time import sleep
-
-from test_framework.mininode import (NodeConn, NodeConnCB, NetworkThread, msg_ping)
+from test_framework.mininode import NodeConn, NodeConnCB, NetworkThread, MsgPing
 from test_framework.test_framework import RavenTestFramework
 from test_framework.util import p2p_port
 
@@ -44,10 +45,9 @@ class TimeoutsTest(RavenTestFramework):
         self.no_version_node = TestNode() # never send version (just ping)
         self.no_send_node = TestNode() # never send anything
 
-        connections = []
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_verack_node))
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_version_node, send_version=False))
-        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_send_node, send_version=False))
+        connections = [NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_verack_node),
+                       NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_version_node, send_version=False),
+                       NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], self.no_send_node, send_version=False)]
         self.no_verack_node.add_connection(connections[0])
         self.no_version_node.add_connection(connections[1])
         self.no_send_node.add_connection(connections[2])
@@ -56,11 +56,11 @@ class TimeoutsTest(RavenTestFramework):
 
         sleep(1)
 
-        assert(self.no_verack_node.connected)
-        assert(self.no_version_node.connected)
-        assert(self.no_send_node.connected)
+        assert self.no_verack_node.connected
+        assert self.no_version_node.connected
+        assert self.no_send_node.connected
 
-        ping_msg = msg_ping()
+        ping_msg = MsgPing()
         connections[0].send_message(ping_msg)
         connections[1].send_message(ping_msg)
 
@@ -68,9 +68,9 @@ class TimeoutsTest(RavenTestFramework):
 
         assert "version" in self.no_verack_node.last_message
 
-        assert(self.no_verack_node.connected)
-        assert(self.no_version_node.connected)
-        assert(self.no_send_node.connected)
+        assert self.no_verack_node.connected
+        assert self.no_version_node.connected
+        assert self.no_send_node.connected
 
         connections[0].send_message(ping_msg)
         connections[1].send_message(ping_msg)

--- a/test/functional/rpc_addressindex.py
+++ b/test/functional/rpc_addressindex.py
@@ -4,16 +4,14 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#
-# Test addressindex generation and fetching
-#
+"""Test addressindex generation and fetching"""
 
+import binascii
 import time
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_nodes_bi, assert_equal)
-from test_framework.script import (CScript, OP_HASH160, OP_EQUAL, OP_DUP, OP_EQUALVERIFY, OP_CHECKSIG)
-from test_framework.mininode import (CTransaction, CTxIn, CTxOut, COutPoint)
-import binascii
+from test_framework.util import connect_nodes_bi, assert_equal
+from test_framework.script import CScript, OP_HASH160, OP_EQUAL, OP_DUP, OP_EQUALVERIFY, OP_CHECKSIG
+from test_framework.mininode import CTransaction, CTxIn, CTxOut, COutPoint
 
 class AddressIndexTest(RavenTestFramework):
 
@@ -55,37 +53,37 @@ class AddressIndexTest(RavenTestFramework):
         # Check p2pkh and p2sh address indexes
         self.log.info("Testing p2pkh and p2sh address index...")
 
-        txid0 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 10)
+        tx_id0 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 10)
         self.nodes[0].generate(1)
 
-        txidb0 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 10)
+        tx_idb0 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 10)
         self.nodes[0].generate(1)
 
-        txid1 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 15)
+        tx_id1 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 15)
         self.nodes[0].generate(1)
 
-        txidb1 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 15)
+        tx_idb1 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 15)
         self.nodes[0].generate(1)
 
-        txid2 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 20)
+        tx_id2 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 20)
         self.nodes[0].generate(1)
 
-        txidb2 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 20)
+        tx_idb2 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 20)
         self.nodes[0].generate(1)
 
         self.sync_all()
 
         txids = self.nodes[1].getaddresstxids("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs")
         assert_equal(len(txids), 3)
-        assert_equal(txids[0], txid0)
-        assert_equal(txids[1], txid1)
-        assert_equal(txids[2], txid2)
+        assert_equal(txids[0], tx_id0)
+        assert_equal(txids[1], tx_id1)
+        assert_equal(txids[2], tx_id2)
 
-        txidsb = self.nodes[1].getaddresstxids("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
-        assert_equal(len(txidsb), 3)
-        assert_equal(txidsb[0], txidb0)
-        assert_equal(txidsb[1], txidb1)
-        assert_equal(txidsb[2], txidb2)
+        tx_idsb = self.nodes[1].getaddresstxids("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
+        assert_equal(len(tx_idsb), 3)
+        assert_equal(tx_idsb[0], tx_idb0)
+        assert_equal(tx_idsb[1], tx_idb1)
+        assert_equal(tx_idsb[2], tx_idb2)
 
         # Check that limiting by height works
         self.log.info("Testing querying txids by range of block heights..")
@@ -95,18 +93,18 @@ class AddressIndexTest(RavenTestFramework):
             "end": 110
         })
         assert_equal(len(height_txids), 2)
-        assert_equal(height_txids[0], txidb0)
-        assert_equal(height_txids[1], txidb1)
+        assert_equal(height_txids[0], tx_idb0)
+        assert_equal(height_txids[1], tx_idb1)
 
         # Check that multiple addresses works
-        multitxids = self.nodes[1].getaddresstxids({"addresses": ["2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs"]})
-        assert_equal(len(multitxids), 6)
-        assert_equal(multitxids[0], txid0)
-        assert_equal(multitxids[1], txidb0)
-        assert_equal(multitxids[2], txid1)
-        assert_equal(multitxids[3], txidb1)
-        assert_equal(multitxids[4], txid2)
-        assert_equal(multitxids[5], txidb2)
+        multi_tx_ids = self.nodes[1].getaddresstxids({"addresses": ["2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs"]})
+        assert_equal(len(multi_tx_ids), 6)
+        assert_equal(multi_tx_ids[0], tx_id0)
+        assert_equal(multi_tx_ids[1], tx_idb0)
+        assert_equal(multi_tx_ids[2], tx_id1)
+        assert_equal(multi_tx_ids[3], tx_idb1)
+        assert_equal(multi_tx_ids[4], tx_id2)
+        assert_equal(multi_tx_ids[5], tx_idb2)
 
         # Check that balances are correct
         balance0 = self.nodes[1].getaddressbalance("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
@@ -114,12 +112,12 @@ class AddressIndexTest(RavenTestFramework):
 
         # Check that outputs with the same address will only return one txid
         self.log.info("Testing for txid uniqueness...")
-        addressHash = bytes([99,73,164,24,252,69,120,209,10,55,43,84,180,92,40,12,200,196,56,47])
-        scriptPubKey = CScript([OP_HASH160, addressHash, OP_EQUAL])
+        address_hash = bytes([99,73,164,24,252,69,120,209,10,55,43,84,180,92,40,12,200,196,56,47])
+        script_pub_key = CScript([OP_HASH160, address_hash, OP_EQUAL])
         unspent = self.nodes[0].listunspent()
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
-        tx.vout = [CTxOut(10, scriptPubKey), CTxOut(11, scriptPubKey)]
+        tx.vout = [CTxOut(10, script_pub_key), CTxOut(11, script_pub_key)]
         tx.rehash()
 
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
@@ -128,9 +126,9 @@ class AddressIndexTest(RavenTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
-        txidsmany = self.nodes[1].getaddresstxids("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
-        assert_equal(len(txidsmany), 4)
-        assert_equal(txidsmany[3], sent_txid)
+        tx_ids_many = self.nodes[1].getaddresstxids("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
+        assert_equal(len(tx_ids_many), 4)
+        assert_equal(tx_ids_many[3], sent_txid)
 
         # Check that balances are correct
         self.log.info("Testing balances...")
@@ -141,15 +139,15 @@ class AddressIndexTest(RavenTestFramework):
         self.log.info("Testing balances after spending...")
         privkey2 = "cSdkPxkAjA4HDr5VHgsebAPDEh9Gyub4HK8UJr2DFGGqKKy4K5sG"
         address2 = "mgY65WSfEmsyYaYPQaXhmXMeBhwp4EcsQW"
-        addressHash2 = bytes([11,47,10,12,49,191,224,64,107,12,204,19,129,253,190,49,25,70,218,220])
-        scriptPubKey2 = CScript([OP_DUP, OP_HASH160, addressHash2, OP_EQUALVERIFY, OP_CHECKSIG])
+        address_hash2 = bytes([11,47,10,12,49,191,224,64,107,12,204,19,129,253,190,49,25,70,218,220])
+        script_pub_key2 = CScript([OP_DUP, OP_HASH160, address_hash2, OP_EQUALVERIFY, OP_CHECKSIG])
         self.nodes[0].importprivkey(privkey2)
 
         unspent = self.nodes[0].listunspent()
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
         amount = int(unspent[0]["amount"] * 100000000 - 230000)
-        tx.vout = [CTxOut(amount, scriptPubKey2)]
+        tx.vout = [CTxOut(amount, script_pub_key2)]
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
         spending_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
         self.nodes[0].generate(1)
@@ -161,11 +159,11 @@ class AddressIndexTest(RavenTestFramework):
         tx.vin = [CTxIn(COutPoint(int(spending_txid, 16), 0))]
         send_amount = 1 * 100000000 + 12840
         change_amount = amount - send_amount - 230000
-        tx.vout = [CTxOut(change_amount, scriptPubKey2), CTxOut(send_amount, scriptPubKey)]
+        tx.vout = [CTxOut(change_amount, script_pub_key2), CTxOut(send_amount, script_pub_key)]
         tx.rehash()
 
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
-        sent_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
+        self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
         self.nodes[0].generate(1)
         self.sync_all()
 
@@ -182,8 +180,8 @@ class AddressIndexTest(RavenTestFramework):
         assert_equal(deltas[0]["blockindex"], 1)
 
         # Check that entire range will be queried
-        deltasAll = self.nodes[1].getaddressdeltas({"addresses": [address2]})
-        assert_equal(len(deltasAll), len(deltas))
+        deltas_all = self.nodes[1].getaddressdeltas({"addresses": [address2]})
+        assert_equal(len(deltas_all), len(deltas))
 
         # Check that deltas can be returned from range of block heights
         deltas = self.nodes[1].getaddressdeltas({"addresses": [address2], "start": 113, "end": 113})
@@ -230,45 +228,45 @@ class AddressIndexTest(RavenTestFramework):
         # Check mempool indexing
         self.log.info("Testing mempool indexing...")
 
-        privKey3 = "cVfUn53hAbRrDEuMexyfgDpZPhF7KqXpS8UZevsyTDaugB7HZ3CD"
+        priv_key3 = "cVfUn53hAbRrDEuMexyfgDpZPhF7KqXpS8UZevsyTDaugB7HZ3CD"
         address3 = "mw4ynwhS7MmrQ27hr82kgqu7zryNDK26JB"
-        addressHash3 = bytes([170,152,114,181,187,205,181,17,216,158,14,17,170,39,218,115,253,44,63,80])
-        scriptPubKey3 = CScript([OP_DUP, OP_HASH160, addressHash3, OP_EQUALVERIFY, OP_CHECKSIG])
+        address_hash3 = bytes([170,152,114,181,187,205,181,17,216,158,14,17,170,39,218,115,253,44,63,80])
+        script_pub_key3 = CScript([OP_DUP, OP_HASH160, address_hash3, OP_EQUALVERIFY, OP_CHECKSIG])
         #address4 = "2N8oFVB2vThAKury4vnLquW2zVjsYjjAkYQ"
-        scriptPubKey4 = CScript([OP_HASH160, addressHash3, OP_EQUAL])
+        script_pub_key4 = CScript([OP_HASH160, address_hash3, OP_EQUAL])
         unspent = self.nodes[2].listunspent()
 
         tx = CTransaction()
         tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
         amount = int(unspent[0]["amount"] * 100000000 - 230000)
-        tx.vout = [CTxOut(amount, scriptPubKey3)]
+        tx.vout = [CTxOut(amount, script_pub_key3)]
         tx.rehash()
         signed_tx = self.nodes[2].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
-        memtxid1 = self.nodes[2].sendrawtransaction(signed_tx["hex"], True)
+        mem_txid1 = self.nodes[2].sendrawtransaction(signed_tx["hex"], True)
         time.sleep(2)
 
         tx2 = CTransaction()
         tx2.vin = [CTxIn(COutPoint(int(unspent[1]["txid"], 16), unspent[1]["vout"]))]
         amount = int(unspent[1]["amount"] * 100000000 - 300000)
         tx2.vout = [
-            CTxOut(int(amount / 4), scriptPubKey3),
-            CTxOut(int(amount / 4), scriptPubKey3),
-            CTxOut(int(amount / 4), scriptPubKey4),
-            CTxOut(int(amount / 4), scriptPubKey4)
+            CTxOut(int(amount / 4), script_pub_key3),
+            CTxOut(int(amount / 4), script_pub_key3),
+            CTxOut(int(amount / 4), script_pub_key4),
+            CTxOut(int(amount / 4), script_pub_key4)
         ]
         tx2.rehash()
         signed_tx2 = self.nodes[2].signrawtransaction(binascii.hexlify(tx2.serialize()).decode("utf-8"))
-        memtxid2 = self.nodes[2].sendrawtransaction(signed_tx2["hex"], True)
+        mem_txid2 = self.nodes[2].sendrawtransaction(signed_tx2["hex"], True)
         time.sleep(2)
 
         mempool = self.nodes[2].getaddressmempool({"addresses": [address3]})
         assert_equal(len(mempool), 3)
-        assert_equal(mempool[0]["txid"], memtxid1)
+        assert_equal(mempool[0]["txid"], mem_txid1)
         assert_equal(mempool[0]["address"], address3)
         assert_equal(mempool[0]["index"], 0)
-        assert_equal(mempool[1]["txid"], memtxid2)
+        assert_equal(mempool[1]["txid"], mem_txid2)
         assert_equal(mempool[1]["index"], 0)
-        assert_equal(mempool[2]["txid"], memtxid2)
+        assert_equal(mempool[2]["txid"], mem_txid2)
         assert_equal(mempool[2]["index"], 1)
 
         self.nodes[2].generate(1)
@@ -278,21 +276,21 @@ class AddressIndexTest(RavenTestFramework):
 
         tx = CTransaction()
         tx.vin = [
-            CTxIn(COutPoint(int(memtxid2, 16), 0)),
-            CTxIn(COutPoint(int(memtxid2, 16), 1))
+            CTxIn(COutPoint(int(mem_txid2, 16), 0)),
+            CTxIn(COutPoint(int(mem_txid2, 16), 1))
         ]
-        tx.vout = [CTxOut(int(amount / 2 - 340000), scriptPubKey2)]
+        tx.vout = [CTxOut(int(amount / 2 - 340000), script_pub_key2)]
         tx.rehash()
-        self.nodes[2].importprivkey(privKey3)
+        self.nodes[2].importprivkey(priv_key3)
         signed_tx3 = self.nodes[2].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
         self.nodes[2].sendrawtransaction(signed_tx3["hex"], True)
         time.sleep(2)
 
         mempool3 = self.nodes[2].getaddressmempool({"addresses": [address3]})
         assert_equal(len(mempool3), 2)
-        assert_equal(mempool3[0]["prevtxid"], memtxid2)
+        assert_equal(mempool3[0]["prevtxid"], mem_txid2)
         assert_equal(mempool3[0]["prevout"], 0)
-        assert_equal(mempool3[1]["prevtxid"], memtxid2)
+        assert_equal(mempool3[1]["prevtxid"], mem_txid2)
         assert_equal(mempool3[1]["prevout"], 1)
 
         # sending and receiving to the same address

--- a/test/functional/rpc_assettransfer.py
+++ b/test/functional/rpc_assettransfer.py
@@ -4,16 +4,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#
-# Test transferring assets rpc calls
-#
+"""Test transferring assets rpc calls"""
 
-import time
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import *
-from test_framework.script import *
-from test_framework.mininode import *
-import binascii
+from test_framework.util import connect_all_nodes_bi, assert_equal, assert_raises_rpc_error
 
 class AssetTransferTest(RavenTestFramework):
 
@@ -50,8 +44,7 @@ class AssetTransferTest(RavenTestFramework):
         self.log.info("Calling issue()...")
         address0 = n0.getnewaddress()
         ipfs_hash = "QmcvyefkqQX3PpjpY5L8B2yMd47XrVwAipr6cxUt2zvYU8"
-        n0.issue(asset_name="TRANSFER_TEST", qty=1000, to_address=address0, change_address="", \
-                 units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
+        n0.issue(asset_name="TRANSFER_TEST", qty=1000, to_address=address0, change_address="", units=4, reissuable=True, has_ipfs=True, ipfs_hash=ipfs_hash)
 
         n0.generate(1)
 
@@ -101,7 +94,6 @@ class AssetTransferTest(RavenTestFramework):
 
         n0_from_addresses = [n0_asset_change, n0_new_address]
 
-        n0_from_address = n0_asset_change
         n1_already_received_address_2 = n1_address
 
         n1_address = n1.getnewaddress()
@@ -123,8 +115,7 @@ class AssetTransferTest(RavenTestFramework):
         # Add the address the only contain 150 TRANSFER_TEST assets
         n0_from_addresses = [n0_asset_change]
 
-        assert_raises_rpc_error(-25, "Insufficient asset funds", \
-                                n0.transferfromaddresses, "TRANSFER_TEST", n0_from_addresses, 450, n1_address, '', 0, n0_rvn_change, n0_asset_change)
+        assert_raises_rpc_error(-25, "Insufficient asset funds", n0.transferfromaddresses, "TRANSFER_TEST", n0_from_addresses, 450, n1_address, '', 0, n0_rvn_change, n0_asset_change)
 
         # Verify that the failed transaction doesn't change the already mined address values on the wallet
         assert_equal(n0.listassetbalancesbyaddress(n1_already_received_address)["TRANSFER_TEST"], 200)

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -3,14 +3,14 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test running ravend with the -rpcbind and -rpcallowip options."""
 
 import socket
 import sys
-
-from test_framework.test_framework import (RavenTestFramework, SkipTest)
-from test_framework.util import (assert_equal, get_rpc_proxy, rpc_url, get_datadir_path, rpc_port, assert_raises_rpc_error)
-from test_framework.netutil import (addr_to_hex, get_bind_addrs, all_interfaces)
+from test_framework.test_framework import RavenTestFramework, SkipTest
+from test_framework.util import assert_equal, get_rpc_proxy, rpc_url, get_datadir_path, rpc_port, assert_raises_rpc_error
+from test_framework.netutil import addr_to_hex, get_bind_addrs, all_interfaces
 
 class RPCBindTest(RavenTestFramework):
     def set_test_params(self):
@@ -21,11 +21,11 @@ class RPCBindTest(RavenTestFramework):
         self.add_nodes(self.num_nodes, None)
 
     def run_bind_test(self, allow_ips, connect_to, addresses, expected):
-        '''
+        """
         Start a node with requested rpcallowip and rpcbind parameters,
         then try to connect, and check if the set of bound addresses
         matches the expected set.
-        '''
+        """
         self.log.info("Bind test for %s" % str(addresses))
         expected = [(addr_to_hex(addr), port) for (addr, port) in expected]
         base_args = ['-disablewallet', '-nolisten']
@@ -39,10 +39,10 @@ class RPCBindTest(RavenTestFramework):
         self.stop_nodes()
 
     def run_allowip_test(self, allow_ips, rpchost, rpcport):
-        '''
+        """
         Start a node with rpcallow IP, and request getnetworkinfo
         at a non-localhost IP.
-        '''
+        """
         self.log.info("Allow IP test for %s:%d" % (rpchost, rpcport))
         base_args = ['-disablewallet', '-nolisten'] + ['-rpcallowip='+x for x in allow_ips]
         self.nodes[0].rpchost = None
@@ -67,23 +67,23 @@ class RPCBindTest(RavenTestFramework):
         try:
             s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
             s.connect(("::1",1))
-            s.close
+            s.close()
         except OSError:
             raise SkipTest("This test requires IPv6 support.")
 
         self.log.info("Using interface %s for testing" % non_loopback_ip)
 
-        defaultport = rpc_port(0)
+        default_port = rpc_port(0)
 
         # check default without rpcallowip (IPv4 and IPv6 localhost)
         self.run_bind_test(None, '127.0.0.1', [],
-            [('127.0.0.1', defaultport), ('::1', defaultport)])
+            [('127.0.0.1', default_port), ('::1', default_port)])
         # check default with rpcallowip (IPv6 any)
         self.run_bind_test(['127.0.0.1'], '127.0.0.1', [],
-            [('::0', defaultport)])
+            [('::0', default_port)])
         # check only IPv4 localhost (explicit)
         self.run_bind_test(['127.0.0.1'], '127.0.0.1', ['127.0.0.1'],
-            [('127.0.0.1', defaultport)])
+            [('127.0.0.1', default_port)])
         # check only IPv4 localhost (explicit) with alternative port
         self.run_bind_test(['127.0.0.1'], '127.0.0.1:32171', ['127.0.0.1:32171'],
             [('127.0.0.1', 32171)])
@@ -92,17 +92,17 @@ class RPCBindTest(RavenTestFramework):
             [('127.0.0.1', 32171), ('127.0.0.1', 32172)])
         # check only IPv6 localhost (explicit)
         self.run_bind_test(['[::1]'], '[::1]', ['[::1]'],
-            [('::1', defaultport)])
+            [('::1', default_port)])
         # check both IPv4 and IPv6 localhost (explicit)
         self.run_bind_test(['127.0.0.1'], '127.0.0.1', ['127.0.0.1', '[::1]'],
-            [('127.0.0.1', defaultport), ('::1', defaultport)])
+            [('127.0.0.1', default_port), ('::1', default_port)])
         # check only non-loopback interface
         self.run_bind_test([non_loopback_ip], non_loopback_ip, [non_loopback_ip],
-            [(non_loopback_ip, defaultport)])
+            [(non_loopback_ip, default_port)])
 
         # Check that with invalid rpcallowip, we are denied
-        self.run_allowip_test([non_loopback_ip], non_loopback_ip, defaultport)
-        assert_raises_rpc_error(-342, "non-JSON HTTP response with '403 Forbidden' from server", self.run_allowip_test, ['1.1.1.1'], non_loopback_ip, defaultport)
+        self.run_allowip_test([non_loopback_ip], non_loopback_ip, default_port)
+        assert_raises_rpc_error(-342, "non-JSON HTTP response with '403 Forbidden' from server", self.run_allowip_test, ['1.1.1.1'], non_loopback_ip, default_port)
 
 if __name__ == '__main__':
     RPCBindTest().main()

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test RPCs related to blockchainstate.
+
+"""
+Test RPCs related to blockchainstate.
 
 Test the following RPCs:
     - gettxoutsetinfo
@@ -21,15 +23,8 @@ Tests correspond to code in rpc/blockchain.cpp.
 from decimal import Decimal
 import http.client
 import subprocess
-
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, 
-                                assert_greater_than, 
-                                assert_greater_than_or_equal,
-                                assert_raises,
-                                assert_raises_rpc_error,
-                                assert_is_hex_string,
-                                assert_is_hash_string,)
+from test_framework.util import assert_equal, assert_greater_than, assert_greater_than_or_equal, assert_raises, assert_raises_rpc_error, assert_is_hex_string, assert_is_hash_string
 
 class BlockchainTest(RavenTestFramework):
     def set_test_params(self):
@@ -98,32 +93,32 @@ class BlockchainTest(RavenTestFramework):
         assert_greater_than(res['size_on_disk'], 0)
 
     def _test_getchaintxstats(self):
-        chaintxstats = self.nodes[0].getchaintxstats(1)
+        chain_tx_stats = self.nodes[0].getchaintxstats(1)
         # 200 txs plus genesis tx
-        assert_equal(chaintxstats['txcount'], 201)
+        assert_equal(chain_tx_stats['txcount'], 201)
         # tx rate should be 1 per 1 minutes, or 1/60
         # we have to round because of binary math
-        assert_equal(round(chaintxstats['txrate'] * 60, 1), Decimal(1))
+        assert_equal(round(chain_tx_stats['txrate'] * 60, 1), Decimal(1))
 
         b1 = self.nodes[0].getblock(self.nodes[0].getblockhash(1))
         b200 = self.nodes[0].getblock(self.nodes[0].getblockhash(200))
         time_diff = b200['mediantime'] - b1['mediantime']
 
-        chaintxstats = self.nodes[0].getchaintxstats()
-        assert_equal(chaintxstats['time'], b200['time'])
-        assert_equal(chaintxstats['txcount'], 201)
-        assert_equal(chaintxstats['window_block_count'], 199)
-        assert_equal(chaintxstats['window_tx_count'], 199)
-        assert_equal(chaintxstats['window_interval'], time_diff)
-        assert_equal(round(chaintxstats['txrate'] * time_diff, 10), Decimal(199))
+        chain_tx_stats = self.nodes[0].getchaintxstats()
+        assert_equal(chain_tx_stats['time'], b200['time'])
+        assert_equal(chain_tx_stats['txcount'], 201)
+        assert_equal(chain_tx_stats['window_block_count'], 199)
+        assert_equal(chain_tx_stats['window_tx_count'], 199)
+        assert_equal(chain_tx_stats['window_interval'], time_diff)
+        assert_equal(round(chain_tx_stats['txrate'] * time_diff, 10), Decimal(199))
 
-        chaintxstats = self.nodes[0].getchaintxstats(blockhash=b1['hash'])
-        assert_equal(chaintxstats['time'], b1['time'])
-        assert_equal(chaintxstats['txcount'], 2)
-        assert_equal(chaintxstats['window_block_count'], 0)
-        assert('window_tx_count' not in chaintxstats)
-        assert('window_interval' not in chaintxstats)
-        assert('txrate' not in chaintxstats)
+        chain_tx_stats = self.nodes[0].getchaintxstats(blockhash=b1['hash'])
+        assert_equal(chain_tx_stats['time'], b1['time'])
+        assert_equal(chain_tx_stats['txcount'], 2)
+        assert_equal(chain_tx_stats['window_block_count'], 0)
+        assert('window_tx_count' not in chain_tx_stats)
+        assert('window_interval' not in chain_tx_stats)
+        assert('txrate' not in chain_tx_stats)
 
         assert_raises_rpc_error(-8, "Invalid block count: should be between 0 and the block's height - 1", self.nodes[0].getchaintxstats, 201)
 
@@ -174,14 +169,14 @@ class BlockchainTest(RavenTestFramework):
         assert_raises_rpc_error(-5, "Block not found",
                               node.getblockheader, "nonsense")
 
-        besthash = node.getbestblockhash()
-        secondbesthash = node.getblockhash(199)
-        header = node.getblockheader(besthash)
+        best_hash = node.getbestblockhash()
+        second_best_hash = node.getblockhash(199)
+        header = node.getblockheader(best_hash)
 
-        assert_equal(header['hash'], besthash)
+        assert_equal(header['hash'], best_hash)
         assert_equal(header['height'], 200)
         assert_equal(header['confirmations'], 1)
-        assert_equal(header['previousblockhash'], secondbesthash)
+        assert_equal(header['previousblockhash'], second_best_hash)
         assert_is_hex_string(header['chainwork'])
         assert_is_hash_string(header['hash'])
         assert_is_hash_string(header['previousblockhash'])

--- a/test/functional/rpc_decodescript.py
+++ b/test/functional/rpc_decodescript.py
@@ -3,12 +3,13 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test decoding scripts via decodescript RPC command."""
 
+from io import BytesIO
 from test_framework.test_framework import RavenTestFramework
 from test_framework.util import assert_equal
-from test_framework.mininode import (CTransaction, hex_str_to_bytes, bytes_to_hex_str)
-from io import BytesIO
+from test_framework.mininode import CTransaction, hex_str_to_bytes, bytes_to_hex_str
 
 class DecodeScriptTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test deprecation of RPC calls."""
+
 from test_framework.test_framework import RavenTestFramework
 from test_framework.util import assert_raises_rpc_error
 

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -3,17 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the fundrawtransaction RPC."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_nodes_bi, 
-                                assert_equal, 
-                                Decimal, 
-                                assert_raises_rpc_error, 
-                                assert_greater_than, 
-                                count_bytes, 
-                                assert_fee_amount, 
-                                assert_greater_than_or_equal)
+from test_framework.util import connect_nodes_bi, assert_equal, Decimal, assert_raises_rpc_error, assert_greater_than, count_bytes, assert_fee_amount, assert_greater_than_or_equal
 
 def get_unspent(listunspent, amount):
     for utx in listunspent:
@@ -56,9 +50,9 @@ class RawTransactionsTest(RavenTestFramework):
         self.sync_all()
 
         # ensure that setting changePosition in fundraw with an exact match is handled properly
-        rawmatch = self.nodes[2].createrawtransaction([], {self.nodes[2].getnewaddress():5000})
-        rawmatch = self.nodes[2].fundrawtransaction(rawmatch, {"changePosition":1, "subtractFeeFromOutputs":[0]})
-        assert_equal(rawmatch["changepos"], -1)
+        raw_match = self.nodes[2].createrawtransaction([], {self.nodes[2].getnewaddress():5000})
+        raw_match = self.nodes[2].fundrawtransaction(raw_match, {"changePosition":1, "subtractFeeFromOutputs":[0]})
+        assert_equal(raw_match["changepos"], -1)
 
         watchonly_address = self.nodes[0].getnewaddress()
         watchonly_pubkey = self.nodes[0].validateaddress(watchonly_address)["pubkey"]
@@ -80,9 +74,10 @@ class RawTransactionsTest(RavenTestFramework):
         inputs  = [ ]
         outputs = { self.nodes[0].getnewaddress() : 1.0 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
-        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+        self.nodes[2].decoderawtransaction(rawtx)
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         fee = rawtxfund['fee']
+        assert_greater_than(fee, 0.0, err_msg="Fee Greater Than Zero")
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         assert(len(dec_tx['vin']) > 0) #test that we have enough inputs
 
@@ -92,10 +87,11 @@ class RawTransactionsTest(RavenTestFramework):
         inputs  = [ ]
         outputs = { self.nodes[0].getnewaddress() : 2.2 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
-        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+        self.nodes[2].decoderawtransaction(rawtx)
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         fee = rawtxfund['fee']
+        assert_greater_than(fee, 0.0, err_msg="Fee Greater Than Zero")
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         assert(len(dec_tx['vin']) > 0) #test if we have enough inputs
 
@@ -105,10 +101,11 @@ class RawTransactionsTest(RavenTestFramework):
         inputs  = [ ]
         outputs = { self.nodes[0].getnewaddress() : 2.6 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
-        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+        self.nodes[2].decoderawtransaction(rawtx)
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         fee = rawtxfund['fee']
+        assert_greater_than(fee, 0.0, err_msg="Fee Greater Than Zero")
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         assert(len(dec_tx['vin']) > 0)
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
@@ -120,10 +117,11 @@ class RawTransactionsTest(RavenTestFramework):
         inputs  = [ ]
         outputs = { self.nodes[0].getnewaddress() : 2.6, self.nodes[1].getnewaddress() : 2.5 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
-        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
+        self.nodes[2].decoderawtransaction(rawtx)
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         fee = rawtxfund['fee']
+        assert_greater_than(fee, 0.0, err_msg="Fee Greater Than Zero")
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         totalOut = 0
         for out in dec_tx['vout']:
@@ -151,7 +149,7 @@ class RawTransactionsTest(RavenTestFramework):
         for out in dec_tx['vout']:
             totalOut += out['value']
 
-        assert_equal(fee + totalOut, utx['amount']) #compare vin total and totalout+fee
+        assert_equal(fee + totalOut, utx['amount']) #compare vin total and totalOut+fee
 
 
         #####################################################################
@@ -239,6 +237,7 @@ class RawTransactionsTest(RavenTestFramework):
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         fee = rawtxfund['fee']
+        assert_greater_than(fee, 0.0, err_msg="Fee Greater Than Zero")
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         totalOut = 0
         matchingOuts = 0
@@ -270,6 +269,7 @@ class RawTransactionsTest(RavenTestFramework):
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         fee = rawtxfund['fee']
+        assert_greater_than(fee, 0.0, err_msg="Fee Greater Than Zero")
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         totalOut = 0
         matchingOuts = 0
@@ -303,6 +303,7 @@ class RawTransactionsTest(RavenTestFramework):
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
         fee = rawtxfund['fee']
+        assert_greater_than(fee, 0.0, err_msg="Fee Greater Than Zero")
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         totalOut = 0
         matchingOuts = 0
@@ -327,7 +328,7 @@ class RawTransactionsTest(RavenTestFramework):
 
         #compare fee
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert(feeDelta >= 0 and feeDelta <= feeTolerance)
+        assert(0 <= feeDelta <= feeTolerance)
         ############################################################
 
         ############################################################
@@ -342,7 +343,7 @@ class RawTransactionsTest(RavenTestFramework):
 
         #compare fee
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert(feeDelta >= 0 and feeDelta <= feeTolerance)
+        assert(0 <= feeDelta <= feeTolerance)
         ############################################################
 
 
@@ -369,7 +370,7 @@ class RawTransactionsTest(RavenTestFramework):
 
         #compare fee
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert(feeDelta >= 0 and feeDelta <= feeTolerance)
+        assert(0 <= feeDelta <= feeTolerance)
         ############################################################
 
 
@@ -402,7 +403,7 @@ class RawTransactionsTest(RavenTestFramework):
 
         #compare fee
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert(feeDelta >= 0 and feeDelta <= feeTolerance)
+        assert(0 <= feeDelta <= feeTolerance)
         ############################################################
 
 
@@ -420,7 +421,7 @@ class RawTransactionsTest(RavenTestFramework):
 
 
         # send 1.2 RVN to msig addr
-        txId = self.nodes[0].sendtoaddress(mSigObj, 1.2)
+        self.nodes[0].sendtoaddress(mSigObj, 1.2)
         self.sync_all()
         self.nodes[1].generate(1)
         self.sync_all()
@@ -432,7 +433,7 @@ class RawTransactionsTest(RavenTestFramework):
         fundedTx = self.nodes[2].fundrawtransaction(rawtx)
 
         signedTx = self.nodes[2].signrawtransaction(fundedTx['hex'])
-        txId = self.nodes[2].sendrawtransaction(signedTx['hex'])
+        self.nodes[2].sendrawtransaction(signedTx['hex'])
         self.sync_all()
         self.nodes[1].generate(1)
         self.sync_all()
@@ -486,7 +487,7 @@ class RawTransactionsTest(RavenTestFramework):
         #now we need to unlock
         self.nodes[1].walletpassphrase("test", 600)
         signedTx = self.nodes[1].signrawtransaction(fundedTx['hex'])
-        txId = self.nodes[1].sendrawtransaction(signedTx['hex'])
+        self.nodes[1].sendrawtransaction(signedTx['hex'])
         self.nodes[1].generate(1)
         self.sync_all()
 
@@ -521,7 +522,7 @@ class RawTransactionsTest(RavenTestFramework):
 
         #compare fee
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert(feeDelta >= 0 and feeDelta <= feeTolerance*19) #~19 inputs
+        assert(0 <= feeDelta <= feeTolerance * 19) #~19 inputs
 
 
         #############################################
@@ -547,7 +548,7 @@ class RawTransactionsTest(RavenTestFramework):
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawtx)
         fundedAndSignedTx = self.nodes[1].signrawtransaction(fundedTx['hex'])
-        txId = self.nodes[1].sendrawtransaction(fundedAndSignedTx['hex'])
+        self.nodes[1].sendrawtransaction(fundedAndSignedTx['hex'])
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
@@ -641,9 +642,9 @@ class RawTransactionsTest(RavenTestFramework):
             if out['value'] > 1.0:
                 changeaddress += out['scriptPubKey']['addresses'][0]
         assert(changeaddress != "")
-        nextaddr = self.nodes[3].getnewaddress()
+        next_addr = self.nodes[3].getnewaddress()
         # Now the change address key should be removed from the keypool
-        assert(changeaddress != nextaddr)
+        assert(changeaddress != next_addr)
 
         ######################################
         # Test subtractFeeFromOutputs option #

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test the getchaintips RPC.
+
+"""
+Test the getchaintips RPC.
 
 - introduce a network split
 - work on chains of different lengths

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the invalidateblock RPC."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_nodes_bi, sync_blocks, time, assert_equal)
+from test_framework.util import connect_nodes_bi, sync_blocks, time, assert_equal
 
 class InvalidateTest(RavenTestFramework):
     def set_test_params(self):
@@ -22,7 +23,7 @@ class InvalidateTest(RavenTestFramework):
         self.log.info("Mine 4 blocks on Node 0")
         self.nodes[0].generate(4)
         assert(self.nodes[0].getblockcount() == 4)
-        besthash = self.nodes[0].getbestblockhash()
+        best_hash = self.nodes[0].getbestblockhash()
 
         self.log.info("Mine competing 6 blocks on Node 1")
         self.nodes[1].generate(6)
@@ -32,14 +33,14 @@ class InvalidateTest(RavenTestFramework):
         connect_nodes_bi(self.nodes,0,1)
         sync_blocks(self.nodes[0:2])
         assert(self.nodes[0].getblockcount() == 6)
-        badhash = self.nodes[1].getblockhash(2)
+        bad_hash = self.nodes[1].getblockhash(2)
 
         self.log.info("Invalidate block 2 on node 0 and verify we reorg to node 0's original chain")
-        self.nodes[0].invalidateblock(badhash)
-        newheight = self.nodes[0].getblockcount()
-        newhash = self.nodes[0].getbestblockhash()
-        if (newheight != 4 or newhash != besthash):
-            raise AssertionError("Wrong tip for node0, hash %s, height %d"%(newhash,newheight))
+        self.nodes[0].invalidateblock(bad_hash)
+        new_height = self.nodes[0].getblockcount()
+        new_hash = self.nodes[0].getbestblockhash()
+        if new_height != 4 or new_hash != best_hash:
+            raise AssertionError("Wrong tip for node0, hash %s, height %d"%(new_hash,new_height))
 
         self.log.info("Make sure we won't reorg to a lower work chain:")
         connect_nodes_bi(self.nodes,1,2)

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test RPC misc output."""
+
+import xml.etree.ElementTree as ElementTree
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import assert_raises_rpc_error, assert_equal, assert_greater_than, assert_greater_than_or_equal
+from test_framework.authproxy import JSONRPCException
+
+
+class RpcMiscTest(RavenTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        #self.log.info("test CHECK_NONFATAL")
+        #assert_raises_rpc_error(-1, "Internal bug detected: 'request.params.size() != 100'", lambda: node.echo(*[0] * 100),)
+
+        self.log.info("test getmemoryinfo")
+        memory = node.getmemoryinfo()['locked']
+        assert_greater_than(memory['used'], 0)
+        assert_greater_than(memory['free'], 0)
+        assert_greater_than(memory['total'], 0)
+        # assert_greater_than_or_equal() for locked in case locking pages failed at some point
+        assert_greater_than_or_equal(memory['locked'], 0)
+        assert_greater_than(memory['chunks_used'], 0)
+        assert_greater_than(memory['chunks_free'], 0)
+        assert_equal(memory['used'] + memory['free'], memory['total'])
+
+        self.log.info("test mallocinfo")
+        try:
+            mallocinfo = node.getmemoryinfo(mode="mallocinfo")
+            self.log.info('getmemoryinfo(mode="mallocinfo") call succeeded')
+            tree = ElementTree.fromstring(mallocinfo)
+            assert_equal(tree.tag, 'malloc')
+        except JSONRPCException:
+            self.log.info('getmemoryinfo(mode="mallocinfo") not available')
+            assert_raises_rpc_error(-8, 'mallocinfo is only available when compiled with glibc 2.10+', node.getmemoryinfo, mode="mallocinfo")
+
+        assert_raises_rpc_error(-8, "unknown mode foobar", node.getmemoryinfo, mode="foobar")
+
+        self.log.info("test logging")
+        assert_equal(node.logging()['qt'], True)
+        node.logging(exclude=['qt'])
+        assert_equal(node.logging()['qt'], False)
+        node.logging(include=['qt'])
+        assert_equal(node.logging()['qt'], True)
+
+
+if __name__ == '__main__':
+    RpcMiscTest().main()

--- a/test/functional/rpc_named_arguments.py
+++ b/test/functional/rpc_named_arguments.py
@@ -3,11 +3,14 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test using named arguments for RPCs."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, assert_raises_rpc_error)
+from test_framework.util import assert_equal, assert_raises_rpc_error
 
+
+# noinspection PyTypeChecker
 class NamedArgumentTest(RavenTestFramework):
     def set_test_params(self):
         self.num_nodes = 1

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -3,15 +3,16 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test RPC calls related to net.
+
+"""
+Test RPC calls related to net.
 
 Tests correspond to code in rpc/net.cpp.
 """
 
 import time
-
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, assert_raises_rpc_error, connect_nodes_bi, p2p_port)
+from test_framework.util import assert_equal, assert_raises_rpc_error, connect_nodes_bi, p2p_port
 
 class NetTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/rpc_preciousblock.py
+++ b/test/functional/rpc_preciousblock.py
@@ -3,11 +3,13 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the preciousblock RPC."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, connect_nodes_bi, sync_chain, sync_blocks)
+from test_framework.util import assert_equal, connect_nodes_bi, sync_chain, sync_blocks
 
+# noinspection PyBroadException
 def unidirectional_node_sync_via_rpc(node_src, node_dest):
     blocks_to_copy = []
     blockhash = node_src.getbestblockhash()
@@ -20,8 +22,8 @@ def unidirectional_node_sync_via_rpc(node_src, node_dest):
             blockhash = node_src.getblockheader(blockhash, True)['previousblockhash']
     blocks_to_copy.reverse()
     for blockhash in blocks_to_copy:
-        blockdata = node_src.getblock(blockhash, False)
-        assert(node_dest.submitblock(blockdata) in (None, 'inconclusive'))
+        block_data = node_src.getblock(blockhash, False)
+        assert(node_dest.submitblock(block_data) in (None, 'inconclusive'))
 
 def node_sync_via_rpc(nodes):
     for node_src in nodes:

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test the rawtransaction RPCs.
+
+"""
+Test the rawtransaction RPCs.
 
 Test the following RPCs:
    - createrawtransaction
@@ -14,7 +16,7 @@ Test the following RPCs:
 """
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_nodes_bi, assert_raises_rpc_error, assert_equal, Decimal)
+from test_framework.util import connect_nodes_bi, assert_raises_rpc_error, assert_equal, Decimal
 
 # Create one-input, one-output, no-fee transaction:
 class RawTransactionsTest(RavenTestFramework):
@@ -67,7 +69,7 @@ class RawTransactionsTest(RavenTestFramework):
         bal = self.nodes[2].getbalance()
 
         # send 1.2 RVN to msig adr
-        txId = self.nodes[0].sendtoaddress(mSigObj, 1.2)
+        self.nodes[0].sendtoaddress(mSigObj, 1.2)
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
@@ -88,7 +90,7 @@ class RawTransactionsTest(RavenTestFramework):
 
         txId = self.nodes[0].sendtoaddress(mSigObj, 2.2)
         decTx = self.nodes[0].gettransaction(txId)
-        rawTx = self.nodes[0].decoderawtransaction(decTx['hex'])
+        self.nodes[0].decoderawtransaction(decTx['hex'])
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
@@ -135,7 +137,7 @@ class RawTransactionsTest(RavenTestFramework):
 
         txId = self.nodes[0].sendtoaddress(mSigObj, 2.2)
         decTx = self.nodes[0].gettransaction(txId)
-        rawTx2 = self.nodes[0].decoderawtransaction(decTx['hex'])
+        self.nodes[0].decoderawtransaction(decTx['hex'])
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
@@ -164,7 +166,7 @@ class RawTransactionsTest(RavenTestFramework):
         rawTxComb = self.nodes[2].combinerawtransaction([rawTxPartialSigned1['hex'], rawTxPartialSigned2['hex']])
         self.log.debug(rawTxComb)
         self.nodes[2].sendrawtransaction(rawTxComb)
-        rawTx2 = self.nodes[0].decoderawtransaction(rawTxComb)
+        self.nodes[0].decoderawtransaction(rawTxComb)
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
@@ -200,8 +202,8 @@ class RawTransactionsTest(RavenTestFramework):
         inputs  = [ {'txid' : "1d1d4e24ed99057e84c3f80fd8fbec79ed9e1acee37da269356ecea000000000", 'vout' : 1, 'sequence' : 1000}]
         outputs = { self.nodes[0].getnewaddress() : 1 }
         rawtx   = self.nodes[0].createrawtransaction(inputs, outputs)
-        decrawtx= self.nodes[0].decoderawtransaction(rawtx)
-        assert_equal(decrawtx['vin'][0]['sequence'], 1000)
+        dec_raw_tx= self.nodes[0].decoderawtransaction(rawtx)
+        assert_equal(dec_raw_tx['vin'][0]['sequence'], 1000)
 
         # 9. invalid parameters - sequence number out of range
         inputs  = [ {'txid' : "1d1d4e24ed99057e84c3f80fd8fbec79ed9e1acee37da269356ecea000000000", 'vout' : 1, 'sequence' : -1}]
@@ -216,8 +218,8 @@ class RawTransactionsTest(RavenTestFramework):
         inputs  = [ {'txid' : "1d1d4e24ed99057e84c3f80fd8fbec79ed9e1acee37da269356ecea000000000", 'vout' : 1, 'sequence' : 4294967294}]
         outputs = { self.nodes[0].getnewaddress() : 1 }
         rawtx   = self.nodes[0].createrawtransaction(inputs, outputs)
-        decrawtx= self.nodes[0].decoderawtransaction(rawtx)
-        assert_equal(decrawtx['vin'][0]['sequence'], 4294967294)
+        dec_raw_tx= self.nodes[0].decoderawtransaction(rawtx)
+        assert_equal(dec_raw_tx['vin'][0]['sequence'], 4294967294)
 
 if __name__ == '__main__':
     RawTransactionsTest().main()

--- a/test/functional/rpc_setban.py
+++ b/test/functional/rpc_setban.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2019 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test the setban rpc call."""
+
+import time
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import connect_nodes, p2p_port, assert_equal
+
+class SetBanTests(RavenTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.extra_args = [[],[]]
+
+    def run_test(self):
+        # Node 0 connects to Node 1, check that the noban permission is not granted
+        connect_nodes(self.nodes[0], 1)
+        assert_equal(self.nodes[0].getconnectioncount(), 2)
+        assert_equal(self.nodes[1].getconnectioncount(), 2)
+
+        # Node 0 get banned by Node 1
+        self.nodes[1].setban("127.0.0.1", "add")
+
+        # Node 0 should not be able to reconnect
+        self.restart_node(1, [])
+        self.nodes[0].addnode("127.0.0.1:" + str(p2p_port(1)), "onetry")
+        time.sleep(1)
+        assert_equal(self.nodes[0].getconnectioncount(), 0)
+        self.nodes[1].assert_debug_log(expected_msgs=['dropped (banned)\n'], timeout=5)
+        assert_equal(self.nodes[1].getconnectioncount(), 0)
+
+        # However, node 0 should be able to reconnect if it has noban permission
+        self.restart_node(1, ['-whitelist=127.0.0.1'])
+        connect_nodes(self.nodes[0], 1)
+        assert_equal(self.nodes[0].getconnectioncount(), 1)
+        assert_equal(self.nodes[1].getconnectioncount(), 1)
+
+        # If we remove the ban, Node 0 should be able to reconnect even without noban permission
+        self.nodes[1].setban("127.0.0.1", "remove")
+        self.restart_node(1, [])
+        connect_nodes(self.nodes[0], 1)
+        assert_equal(self.nodes[0].getconnectioncount(), 1)
+        assert_equal(self.nodes[1].getconnectioncount(), 1)
+
+if __name__ == '__main__':
+    SetBanTests().main()

--- a/test/functional/rpc_signmessage.py
+++ b/test/functional/rpc_signmessage.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test RPC commands for signing and verifying messages."""
 
 from test_framework.test_framework import RavenTestFramework

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -3,11 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test transaction signing using the signrawtransaction RPC."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, assert_raises_rpc_error)
-
+from test_framework.util import assert_equal, assert_raises_rpc_error
 
 class SignRawTransactionsTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/rpc_spentindex.py
+++ b/test/functional/rpc_spentindex.py
@@ -4,16 +4,13 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#
-# Test RPC addressindex generation and fetching
-#
+"""Test RPC addressindex generation and fetching"""
 
-import time
-from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_nodes_bi, assert_equal)
-from test_framework.script import (CScript, OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG)
-from test_framework.mininode import (CTransaction, CTxIn, COutPoint, CTxOut)
 import binascii
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import connect_nodes_bi, assert_equal
+from test_framework.script import CScript, OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG
+from test_framework.mininode import CTransaction, CTxIn, COutPoint, CTxOut
 
 class SpentIndexTest(RavenTestFramework):
 
@@ -49,16 +46,16 @@ class SpentIndexTest(RavenTestFramework):
         # Check that
         self.log.info("Testing spent index...")
 
-        feeSatoshis = 192000
+        fee_satoshis = 192000
         privkey = "cSdkPxkAjA4HDr5VHgsebAPDEh9Gyub4HK8UJr2DFGGqKKy4K5sG"
         #address = "mgY65WSfEmsyYaYPQaXhmXMeBhwp4EcsQW"
-        addressHash = bytes([11,47,10,12,49,191,224,64,107,12,204,19,129,253,190,49,25,70,218,220])
-        scriptPubKey = CScript([OP_DUP, OP_HASH160, addressHash, OP_EQUALVERIFY, OP_CHECKSIG])
+        address_hash = bytes([11,47,10,12,49,191,224,64,107,12,204,19,129,253,190,49,25,70,218,220])
+        script_pub_key = CScript([OP_DUP, OP_HASH160, address_hash, OP_EQUALVERIFY, OP_CHECKSIG])
         unspent = self.nodes[0].listunspent()
         tx = CTransaction()
-        amount = int(unspent[0]["amount"] * 100000000 - feeSatoshis)
+        amount = int(unspent[0]["amount"] * 100000000 - fee_satoshis)
         tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
-        tx.vout = [CTxOut(amount, scriptPubKey)]
+        tx.vout = [CTxOut(amount, script_pub_key)]
         tx.rehash()
 
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
@@ -77,25 +74,25 @@ class SpentIndexTest(RavenTestFramework):
         self.log.info("Testing getrawtransaction method...")
 
         # Check that verbose raw transaction includes spent info
-        txVerbose = self.nodes[3].getrawtransaction(unspent[0]["txid"], 1)
-        assert_equal(txVerbose["vout"][unspent[0]["vout"]]["spentTxId"], txid)
-        assert_equal(txVerbose["vout"][unspent[0]["vout"]]["spentIndex"], 0)
-        assert_equal(txVerbose["vout"][unspent[0]["vout"]]["spentHeight"], 106)
+        tx_verbose = self.nodes[3].getrawtransaction(unspent[0]["txid"], 1)
+        assert_equal(tx_verbose["vout"][unspent[0]["vout"]]["spentTxId"], txid)
+        assert_equal(tx_verbose["vout"][unspent[0]["vout"]]["spentIndex"], 0)
+        assert_equal(tx_verbose["vout"][unspent[0]["vout"]]["spentHeight"], 106)
 
         # Check that verbose raw transaction includes input values
-        txVerbose2 = self.nodes[3].getrawtransaction(txid, 1)
-        assert_equal(float(txVerbose2["vin"][0]["value"]), (amount + feeSatoshis) / 100000000)
-        assert_equal(txVerbose2["vin"][0]["valueSat"], amount + feeSatoshis)
+        tx_verbose2 = self.nodes[3].getrawtransaction(txid, 1)
+        assert_equal(float(tx_verbose2["vin"][0]["value"]), (amount + fee_satoshis) / 100000000)
+        assert_equal(tx_verbose2["vin"][0]["valueSat"], amount + fee_satoshis)
 
         # Check that verbose raw transaction includes address values and input values
         #privkey2 = "cSdkPxkAjA4HDr5VHgsebAPDEh9Gyub4HK8UJr2DFGGqKKy4K5sG"
         address2 = "mgY65WSfEmsyYaYPQaXhmXMeBhwp4EcsQW"
-        addressHash2 = bytes([11,47,10,12,49,191,224,64,107,12,204,19,129,253,190,49,25,70,218,220])
-        scriptPubKey2 = CScript([OP_DUP, OP_HASH160, addressHash2, OP_EQUALVERIFY, OP_CHECKSIG])
+        address_hash2 = bytes([11, 47, 10, 12, 49, 191, 224, 64, 107, 12, 204, 19, 129, 253, 190, 49, 25, 70, 218, 220])
+        script_pub_key2 = CScript([OP_DUP, OP_HASH160, address_hash2, OP_EQUALVERIFY, OP_CHECKSIG])
         tx2 = CTransaction()
         tx2.vin = [CTxIn(COutPoint(int(txid, 16), 0))]
-        amount = int(amount - feeSatoshis)
-        tx2.vout = [CTxOut(amount, scriptPubKey2)]
+        amount = int(amount - fee_satoshis)
+        tx2.vout = [CTxOut(amount, script_pub_key2)]
         tx.rehash()
         self.nodes[0].importprivkey(privkey)
         signed_tx2 = self.nodes[0].signrawtransaction(binascii.hexlify(tx2.serialize()).decode("utf-8"))
@@ -103,20 +100,20 @@ class SpentIndexTest(RavenTestFramework):
 
         # Check the mempool index
         self.sync_all()
-        txVerbose3 = self.nodes[1].getrawtransaction(txid2, 1)
-        assert_equal(txVerbose3["vin"][0]["address"], address2)
-        assert_equal(txVerbose3["vin"][0]["valueSat"], amount + feeSatoshis)
-        assert_equal(float(txVerbose3["vin"][0]["value"]), (amount + feeSatoshis) / 100000000)
+        tx_verbose3 = self.nodes[1].getrawtransaction(txid2, 1)
+        assert_equal(tx_verbose3["vin"][0]["address"], address2)
+        assert_equal(tx_verbose3["vin"][0]["valueSat"], amount + fee_satoshis)
+        assert_equal(float(tx_verbose3["vin"][0]["value"]), (amount + fee_satoshis) / 100000000)
 
 
         # Check the database index
         block_hash = self.nodes[0].generate(1)
         self.sync_all()
 
-        txVerbose4 = self.nodes[3].getrawtransaction(txid2, 1)
-        assert_equal(txVerbose4["vin"][0]["address"], address2)
-        assert_equal(txVerbose4["vin"][0]["valueSat"], amount + feeSatoshis)
-        assert_equal(float(txVerbose4["vin"][0]["value"]), (amount + feeSatoshis) / 100000000)
+        tx_verbose4 = self.nodes[3].getrawtransaction(txid2, 1)
+        assert_equal(tx_verbose4["vin"][0]["address"], address2)
+        assert_equal(tx_verbose4["vin"][0]["valueSat"], amount + fee_satoshis)
+        assert_equal(float(tx_verbose4["vin"][0]["value"]), (amount + fee_satoshis) / 100000000)
 
         # Check block deltas
         self.log.info("Testing getblockdeltas...")
@@ -130,7 +127,7 @@ class SpentIndexTest(RavenTestFramework):
         assert_equal(block["deltas"][1]["txid"], txid2)
         assert_equal(block["deltas"][1]["inputs"][0]["index"], 0)
         assert_equal(block["deltas"][1]["inputs"][0]["address"], "mgY65WSfEmsyYaYPQaXhmXMeBhwp4EcsQW")
-        assert_equal(block["deltas"][1]["inputs"][0]["satoshis"], (amount + feeSatoshis) * -1)
+        assert_equal(block["deltas"][1]["inputs"][0]["satoshis"], (amount + fee_satoshis) * -1)
         assert_equal(block["deltas"][1]["inputs"][0]["prevtxid"], txid)
         assert_equal(block["deltas"][1]["inputs"][0]["prevout"], 0)
         assert_equal(block["deltas"][1]["outputs"][0]["index"], 0)

--- a/test/functional/rpc_timestampindex.py
+++ b/test/functional/rpc_timestampindex.py
@@ -4,15 +4,11 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#
-# Test timestampindex generation and fetching
-#
+"""Test timestampindex generation and fetching"""
 
 import time
-
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_nodes_bi, assert_equal)
-
+from test_framework.util import connect_nodes_bi, assert_equal
 
 class TimestampIndexTest(RavenTestFramework):
 

--- a/test/functional/rpc_txindex.py
+++ b/test/functional/rpc_txindex.py
@@ -4,16 +4,13 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#
-# Test txindex generation and fetching
-#
+"""Test txindex generation and fetching"""
 
-import time
-from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_nodes_bi, assert_equal)
-from test_framework.script import (CScript, OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG)
-from test_framework.mininode import (CTransaction, CTxIn, CTxOut, COutPoint)
 import binascii
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import connect_nodes_bi, assert_equal
+from test_framework.script import CScript, OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG
+from test_framework.mininode import CTransaction, CTxIn, CTxOut, COutPoint
 
 class TxIndexTest(RavenTestFramework):
 
@@ -50,13 +47,13 @@ class TxIndexTest(RavenTestFramework):
 
         #privkey = "cSdkPxkAjA4HDr5VHgsebAPDEh9Gyub4HK8UJr2DFGGqKKy4K5sG"
         #address = "mgY65WSfEmsyYaYPQaXhmXMeBhwp4EcsQW"
-        addressHash = bytes([11,47,10,12,49,191,224,64,107,12,204,19,129,253,190,49,25,70,218,220])
-        scriptPubKey = CScript([OP_DUP, OP_HASH160, addressHash, OP_EQUALVERIFY, OP_CHECKSIG])
+        address_hash = bytes([11,47,10,12,49,191,224,64,107,12,204,19,129,253,190,49,25,70,218,220])
+        script_pub_key = CScript([OP_DUP, OP_HASH160, address_hash, OP_EQUALVERIFY, OP_CHECKSIG])
         unspent = self.nodes[0].listunspent()
         tx = CTransaction()
         amount = int(unspent[0]["amount"] * 10000000)
         tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
-        tx.vout = [CTxOut(amount, scriptPubKey)]
+        tx.vout = [CTxOut(amount, script_pub_key)]
         tx.rehash()
 
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test gettxoutproof and verifytxoutproof RPCs."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_nodes, assert_equal, assert_raises_rpc_error)
+from test_framework.util import connect_nodes, assert_equal, assert_raises_rpc_error
 
 class MerkleBlockTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/rpc_users.py
+++ b/test/functional/rpc_users.py
@@ -3,14 +3,14 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test multiple RPC users."""
 
-from test_framework.test_framework import RavenTestFramework
-from test_framework.util import str_to_b64str, assert_equal
+"""Test multiple RPC users."""
 
 import os
 import http.client
 import urllib.parse
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import str_to_b64str, assert_equal
 
 class HTTPBasicsTest (RavenTestFramework):
     def set_test_params(self):
@@ -38,16 +38,16 @@ class HTTPBasicsTest (RavenTestFramework):
         url = urllib.parse.urlparse(self.nodes[0].url)
 
         #Old authpair
-        authpair = url.username + ':' + url.password
+        auth_pair = url.username + ':' + url.password
 
         #New authpair generated via share/rpcuser tool
         password = "cA773lm788buwYe4g4WT+05pKyNruVKjQ25x3n0DQcM="
 
         #Second authpair with different username
         password2 = "8/F3uMDw4KSEbw96U3CA1C4X05dkHDN2BPFjTgZW4KI="
-        authpairnew = "rt:"+password
+        auth_pair_new = "rt:"+password
 
-        headers = {"Authorization": "Basic " + str_to_b64str(authpair)}
+        headers = {"Authorization": "Basic " + str_to_b64str(auth_pair)}
 
         conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -57,7 +57,7 @@ class HTTPBasicsTest (RavenTestFramework):
         conn.close()
         
         #Use new authpair to confirm both work
-        headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
+        headers = {"Authorization": "Basic " + str_to_b64str(auth_pair_new)}
 
         conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -67,8 +67,8 @@ class HTTPBasicsTest (RavenTestFramework):
         conn.close()
 
         #Wrong login name with rt's password
-        authpairnew = "rtwrong:"+password
-        headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
+        auth_pair_new = "rtwrong:"+password
+        headers = {"Authorization": "Basic " + str_to_b64str(auth_pair_new)}
 
         conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -78,8 +78,8 @@ class HTTPBasicsTest (RavenTestFramework):
         conn.close()
 
         #Wrong password for rt
-        authpairnew = "rt:"+password+"wrong"
-        headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
+        auth_pair_new = "rt:"+password+"wrong"
+        headers = {"Authorization": "Basic " + str_to_b64str(auth_pair_new)}
 
         conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -89,8 +89,8 @@ class HTTPBasicsTest (RavenTestFramework):
         conn.close()
 
         #Correct for rt2
-        authpairnew = "rt2:"+password2
-        headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
+        auth_pair_new = "rt2:"+password2
+        headers = {"Authorization": "Basic " + str_to_b64str(auth_pair_new)}
 
         conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -100,8 +100,8 @@ class HTTPBasicsTest (RavenTestFramework):
         conn.close()
 
         #Wrong password for rt2
-        authpairnew = "rt2:"+password2+"wrong"
-        headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
+        auth_pair_new = "rt2:"+password2+"wrong"
+        headers = {"Authorization": "Basic " + str_to_b64str(auth_pair_new)}
 
         conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -116,9 +116,9 @@ class HTTPBasicsTest (RavenTestFramework):
         url = urllib.parse.urlparse(self.nodes[1].url)
 
         # rpcuser and rpcpassword authpair
-        rpcuserauthpair = "rpcuser💻:rpcpassword🔑"
+        rpc_user_auth_pair = "rpcuser💻:rpcpassword🔑"
 
-        headers = {"Authorization": "Basic " + str_to_b64str(rpcuserauthpair)}
+        headers = {"Authorization": "Basic " + str_to_b64str(rpc_user_auth_pair)}
 
         conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -128,8 +128,8 @@ class HTTPBasicsTest (RavenTestFramework):
         conn.close()
 
         #Wrong login name with rpcuser's password
-        rpcuserauthpair = "rpcuserwrong:rpcpassword"
-        headers = {"Authorization": "Basic " + str_to_b64str(rpcuserauthpair)}
+        rpc_user_auth_pair = "rpcuserwrong:rpcpassword"
+        headers = {"Authorization": "Basic " + str_to_b64str(rpc_user_auth_pair)}
 
         conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()
@@ -139,8 +139,8 @@ class HTTPBasicsTest (RavenTestFramework):
         conn.close()
 
         #Wrong password for rpcuser
-        rpcuserauthpair = "rpcuser:rpcpasswordwrong"
-        headers = {"Authorization": "Basic " + str_to_b64str(rpcuserauthpair)}
+        rpc_user_auth_pair = "rpcuser:rpcpasswordwrong"
+        headers = {"Authorization": "Basic " + str_to_b64str(rpc_user_auth_pair)}
 
         conn = http.client.HTTPConnection(url.hostname, url.port)
         conn.connect()

--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -3,39 +3,42 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Encode and decode BASE58, P2PKH and P2SH addresses."""
 
-from .script import (hash256, hash160, sha256, CScript, OP_0)
-from .util import (bytes_to_hex_str, hex_str_to_bytes)
+from .script import hash256, hash160, sha256, CScript, OP_0
+from .util import bytes_to_hex_str, hex_str_to_bytes
+
+ADDRESS_BCRT1_UNSPENDABLE = 'n1BurnXXXXXXXXXXXXXXXXXXXXXXU1qejP'
 
 chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
 def byte_to_base58(b, version):
     result = ''
-    str = bytes_to_hex_str(b)
-    str = bytes_to_hex_str(chr(version).encode('latin-1')) + str
-    checksum = bytes_to_hex_str(hash256(hex_str_to_bytes(str)))
-    str += checksum[:8]
-    value = int('0x'+str,0)
+    hex_str = bytes_to_hex_str(b)
+    hex_str = bytes_to_hex_str(chr(version).encode('latin-1')) + hex_str
+    checksum = bytes_to_hex_str(hash256(hex_str_to_bytes(hex_str)))
+    hex_str += checksum[:8]
+    value = int('0x' + hex_str, 0)
     while value > 0:
         result = chars[value % 58] + result
         value //= 58
-    while (str[:2] == '00'):
+    while hex_str[:2] == '00':
         result = chars[0] + result
-        str = str[2:]
+        hex_str = hex_str[2:]
     return result
 
 # TODO: def base58_decode
 
-def keyhash_to_p2pkh(hash, main = False):
-    assert (len(hash) == 20)
+def keyhash_to_p2pkh(hash_input, main = False):
+    assert (len(hash_input) == 20)
     version = 0 if main else 111
-    return byte_to_base58(hash, version)
+    return byte_to_base58(hash_input, version)
 
-def scripthash_to_p2sh(hash, main = False):
-    assert (len(hash) == 20)
+def scripthash_to_p2sh(hash_in, main = False):
+    assert (len(hash_in) == 20)
     version = 5 if main else 196
-    return byte_to_base58(hash, version)
+    return byte_to_base58(hash_in, version)
 
 def key_to_p2pkh(key, main = False):
     key = check_key(key)
@@ -45,16 +48,26 @@ def script_to_p2sh(script, main = False):
     script = check_script(script)
     return scripthash_to_p2sh(hash160(script), main)
 
+def key_to_p2sh_p2wpkh(key, main = False):
+    key = check_key(key)
+    p2shscript = CScript([OP_0, hash160(key)])
+    return script_to_p2sh(p2shscript, main)
+
+def script_to_p2sh_p2wsh(script, main = False):
+    script = check_script(script)
+    p2shscript = CScript([OP_0, sha256(script)])
+    return script_to_p2sh(p2shscript, main)
+
 def check_key(key):
-    if (type(key) is str):
+    if type(key) is str:
         key = hex_str_to_bytes(key) # Assuming this is hex string
-    if (type(key) is bytes and (len(key) == 33 or len(key) == 65)):
+    if type(key) is bytes and (len(key) == 33 or len(key) == 65):
         return key
-    assert(False)
+    assert False
 
 def check_script(script):
-    if (type(script) is str):
+    if type(script) is str:
         script = hex_str_to_bytes(script) # Assuming this is hex string
-    if (type(script) is bytes or type(script) is CScript):
+    if type(script) is bytes or type(script) is CScript:
         return script
-    assert(False)
+    assert False

--- a/test/functional/test_framework/bignum.py
+++ b/test/functional/test_framework/bignum.py
@@ -2,13 +2,14 @@
 #
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Big number routines.
+
+"""
+Big number routines.
 
 This file is copied from python-ravenlib.
 """
 
 import struct
-
 
 # generic big endian MPI format
 

--- a/test/functional/test_framework/comptool.py
+++ b/test/functional/test_framework/comptool.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Compare two or more ravends to each other.
+
+"""
+Compare two or more ravends to each other.
 
 To use, create a class that implements get_tests(), and pass it in
 as the test generator to TestManager.  get_tests() should be a python
@@ -18,30 +20,18 @@ TestNode behaves as follows:
     on_getdata: provide blocks via BlockStore
 """
 
-from .mininode import (NodeConn, 
-                        CBlock, 
-                        msg_inv, 
-                        CInv, 
-                        msg_headers, 
-                        msg_mempool, 
-                        mininode_lock, 
-                        NodeConnCB, 
-                        msg_getheaders, 
-                        msg_ping, 
-                        msg_block, 
-                        CBlockHeader, 
-                        MAX_INV_SZ, 
-                        CTransaction)
-from .blockstore import (BlockStore, TxStore)
-from .util import (p2p_port, wait_until)
+from .mininode import (NodeConn, CBlock, MsgInv, CInv, MsgHeaders, MsgMempool, mininode_lock, NodeConnCB,
+                       MsgGetHeaders, MsgPing, MsgBlock, CBlockHeader, MAX_INV_SZ, CTransaction)
+from .blockstore import BlockStore, TxStore
+from .util import p2p_port, wait_until
 
 import logging
 
 logger=logging.getLogger("TestFramework.comptool")
 
-global mininode_lock
+#global mininode_lock
 
-class RejectResult():
+class RejectResult:
     """Outcome that expects rejection of a transaction or block."""
     def __init__(self, code, reason=b''):
         self.code = code
@@ -81,7 +71,7 @@ class TestNode(NodeConnCB):
     def on_headers(self, conn, message):
         if len(message.headers) > 0:
             best_header = message.headers[-1]
-            best_header.calc_sha256()
+            best_header.calc_x16r()
             self.bestblockhash = best_header.sha256
 
     def on_getheaders(self, conn, message):
@@ -116,30 +106,30 @@ class TestNode(NodeConnCB):
 
     def send_inv(self, obj):
         mtype = 2 if isinstance(obj, CBlock) else 1
-        self.conn.send_message(msg_inv([CInv(mtype, obj.sha256)]))
+        self.conn.send_message(MsgInv([CInv(mtype, obj.sha256)]))
 
     def send_getheaders(self):
         # We ask for headers from their last tip.
-        m = msg_getheaders()
+        m = MsgGetHeaders()
         m.locator = self.block_store.get_locator(self.bestblockhash)
         self.conn.send_message(m)
 
     def send_header(self, header):
-        m = msg_headers()
+        m = MsgHeaders()
         m.headers.append(header)
         self.conn.send_message(m)
 
     # This assumes BIP31
     def send_ping(self, nonce):
         self.pingMap[nonce] = True
-        self.conn.send_message(msg_ping(nonce))
+        self.conn.send_message(MsgPing(nonce))
 
     def received_ping_response(self, nonce):
         return nonce not in self.pingMap
 
     def send_mempool(self):
         self.lastInv = []
-        self.conn.send_message(msg_mempool())
+        self.conn.send_message(MsgMempool())
 
 # TestInstance:
 #
@@ -170,13 +160,13 @@ class TestNode(NodeConnCB):
 #    across all connections.  (If outcome of final tx is specified as true
 #    or false, then only the last tx is tested against outcome.)
 
-class TestInstance():
+class TestInstance:
     def __init__(self, objects=None, sync_every_block=True, sync_every_tx=False):
         self.blocks_and_transactions = objects if objects else []
         self.sync_every_block = sync_every_block
         self.sync_every_tx = sync_every_tx
 
-class TestManager():
+class TestManager:
 
     def __init__(self, testgen, datadir):
         self.test_generator = testgen
@@ -203,7 +193,7 @@ class TestManager():
     def wait_for_disconnections(self):
         def disconnected():
             return all(node.closed for node in self.test_nodes)
-        wait_until(disconnected, timeout=10, lock=mininode_lock)
+        wait_until(disconnected, timeout=10, lock=mininode_lock, err_msg="wait_for_disconnections")
 
     def wait_for_verack(self):
         return all(node.wait_for_verack() for node in self.test_nodes)
@@ -211,7 +201,7 @@ class TestManager():
     def wait_for_pings(self, counter):
         def received_pongs():
             return all(node.received_ping_response(counter) for node in self.test_nodes)
-        wait_until(received_pongs, lock=mininode_lock)
+        wait_until(received_pongs, lock=mininode_lock, err_msg="wait_for_pings")
 
     # sync_blocks: Wait for all connections to request the blockhash given
     # then send get_headers to find out the tip of each node, and synchronize
@@ -224,7 +214,7 @@ class TestManager():
             )
 
         # --> error if not requested
-        wait_until(blocks_requested, attempts=20*num_blocks, lock=mininode_lock)
+        wait_until(blocks_requested, attempts=20*num_blocks, lock=mininode_lock, err_msg="sync_blocks")
 
         # Send getheaders message
         [ c.cb.send_getheaders() for c in self.connections ]
@@ -244,7 +234,7 @@ class TestManager():
             )
 
         # --> error if not requested
-        wait_until(transaction_requested, attempts=20*num_events, lock=mininode_lock)
+        wait_until(transaction_requested, attempts=20*num_events, lock=mininode_lock, err_msg="sync_transaction")
 
         # Get the mempool
         [ c.cb.send_mempool() for c in self.connections ]
@@ -270,12 +260,12 @@ class TestManager():
                     if c.cb.bestblockhash == blockhash:
                         return False
                     if blockhash not in c.cb.block_reject_map:
-                        logger.error('Block not in reject map: %064x' % (blockhash))
+                        logger.error('Block not in reject map: %064x' % blockhash)
                         return False
                     if not outcome.match(c.cb.block_reject_map[blockhash]):
                         logger.error('Block rejected with %s instead of expected %s: %064x' % (c.cb.block_reject_map[blockhash], outcome, blockhash))
                         return False
-                elif ((c.cb.bestblockhash == blockhash) != outcome):
+                elif (c.cb.bestblockhash == blockhash) != outcome:
                     return False
             return True
 
@@ -296,12 +286,12 @@ class TestManager():
                     if txhash in c.cb.lastInv:
                         return False
                     if txhash not in c.cb.tx_reject_map:
-                        logger.error('Tx not in reject map: %064x' % (txhash))
+                        logger.error('Tx not in reject map: %064x' % txhash)
                         return False
                     if not outcome.match(c.cb.tx_reject_map[txhash]):
                         logger.error('Tx rejected with %s instead of expected %s: %064x' % (c.cb.tx_reject_map[txhash], outcome, txhash))
                         return False
-                elif ((txhash in c.cb.lastInv) != outcome):
+                elif (txhash in c.cb.lastInv) != outcome:
                     return False
             return True
 
@@ -316,7 +306,7 @@ class TestManager():
             # if we're not syncing on every block or every tx.
             [ block, block_outcome, tip ] = [ None, None, None ]
             [ tx, tx_outcome ] = [ None, None ]
-            invqueue = []
+            inv_queue = []
 
             for test_obj in test_instance.blocks_and_transactions:
                 b_or_t = test_obj[0]
@@ -325,7 +315,7 @@ class TestManager():
                 if isinstance(b_or_t, CBlock):  # Block test runner
                     block = b_or_t
                     block_outcome = outcome
-                    tip = block.sha256
+                    tip = block.x16r
                     # each test_obj can have an optional third argument
                     # to specify the tip we should compare with
                     # (default is to use the block being tested)
@@ -339,35 +329,35 @@ class TestManager():
                     # node wouldn't send another getdata request while
                     # the earlier one is outstanding.
                     first_block_with_hash = True
-                    if self.block_store.get(block.sha256) is not None:
+                    if self.block_store.get(block.x16r) is not None:
                         first_block_with_hash = False
                     with mininode_lock:
                         self.block_store.add_block(block)
                         for c in self.connections:
-                            if first_block_with_hash and block.sha256 in c.cb.block_request_map and c.cb.block_request_map[block.sha256] == True:
+                            if first_block_with_hash and block.x16r in c.cb.block_request_map and c.cb.block_request_map[block.x16r] == True:
                                 # There was a previous request for this block hash
                                 # Most likely, we delivered a header for this block
                                 # but never had the block to respond to the getdata
-                                c.send_message(msg_block(block))
+                                c.send_message(MsgBlock(block))
                             else:
-                                c.cb.block_request_map[block.sha256] = False
+                                c.cb.block_request_map[block.x16r] = False
                     # Either send inv's to each node and sync, or add
-                    # to invqueue for later inv'ing.
-                    if (test_instance.sync_every_block):
+                    # to inv_queue for later inv'ing.
+                    if test_instance.sync_every_block:
                         # if we expect success, send inv and sync every block
                         # if we expect failure, just push the block and see what happens.
-                        if outcome == True:
+                        if outcome:
                             [ c.cb.send_inv(block) for c in self.connections ]
-                            self.sync_blocks(block.sha256, 1)
+                            self.sync_blocks(block.x16r, 1)
                         else:
-                            [ c.send_message(msg_block(block)) for c in self.connections ]
+                            [c.send_message(MsgBlock(block)) for c in self.connections]
                             [ c.cb.send_ping(self.ping_counter) for c in self.connections ]
                             self.wait_for_pings(self.ping_counter)
                             self.ping_counter += 1
-                        if (not self.check_results(tip, outcome)):
+                        if not self.check_results(tip, outcome):
                             raise AssertionError("Test failed at test %d" % test_number)
                     else:
-                        invqueue.append(CInv(2, block.sha256))
+                        inv_queue.append(CInv(2, block.x16r))
                 elif isinstance(b_or_t, CBlockHeader):
                     block_header = b_or_t
                     self.block_store.add_header(block_header)
@@ -381,34 +371,33 @@ class TestManager():
                     with mininode_lock:
                         self.tx_store.add_transaction(tx)
                         for c in self.connections:
-                            c.cb.tx_request_map[tx.sha256] = False
+                            c.cb.tx_request_map[tx.x16r] = False
                     # Again, either inv to all nodes or save for later
-                    if (test_instance.sync_every_tx):
+                    if test_instance.sync_every_tx:
                         [ c.cb.send_inv(tx) for c in self.connections ]
-                        self.sync_transaction(tx.sha256, 1)
-                        if (not self.check_mempool(tx.sha256, outcome)):
+                        self.sync_transaction(tx.x16r, 1)
+                        if not self.check_mempool(tx.x16r, outcome):
                             raise AssertionError("Test failed at test %d" % test_number)
                     else:
-                        invqueue.append(CInv(1, tx.sha256))
+                        inv_queue.append(CInv(1, tx.x16r))
                 # Ensure we're not overflowing the inv queue
-                if len(invqueue) == MAX_INV_SZ:
-                    [ c.send_message(msg_inv(invqueue)) for c in self.connections ]
-                    invqueue = []
+                if len(inv_queue) == MAX_INV_SZ:
+                    [c.send_message(MsgInv(inv_queue)) for c in self.connections]
+                    inv_queue = []
 
             # Do final sync if we weren't syncing on every block or every tx.
-            if (not test_instance.sync_every_block and block is not None):
-                if len(invqueue) > 0:
-                    [ c.send_message(msg_inv(invqueue)) for c in self.connections ]
-                    invqueue = []
-                self.sync_blocks(block.sha256, len(test_instance.blocks_and_transactions))
-                if (not self.check_results(tip, block_outcome)):
+            if not test_instance.sync_every_block and block is not None:
+                if len(inv_queue) > 0:
+                    [c.send_message(MsgInv(inv_queue)) for c in self.connections]
+                    inv_queue = []
+                self.sync_blocks(block.x16r, len(test_instance.blocks_and_transactions))
+                if not self.check_results(tip, block_outcome):
                     raise AssertionError("Block test failed at test %d" % test_number)
-            if (not test_instance.sync_every_tx and tx is not None):
-                if len(invqueue) > 0:
-                    [ c.send_message(msg_inv(invqueue)) for c in self.connections ]
-                    invqueue = []
-                self.sync_transaction(tx.sha256, len(test_instance.blocks_and_transactions))
-                if (not self.check_mempool(tx.sha256, tx_outcome)):
+            if not test_instance.sync_every_tx and tx is not None:
+                if len(inv_queue) > 0:
+                    [c.send_message(MsgInv(inv_queue)) for c in self.connections]
+                self.sync_transaction(tx.x16r, len(test_instance.blocks_and_transactions))
+                if not self.check_mempool(tx.x16r, tx_outcome):
                     raise AssertionError("Mempool test failed at test %d" % test_number)
 
             logger.info("Test %d: PASS" % test_number)

--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Utilities for doing coverage analysis on the RPC interface.
+
+"""
+Utilities for doing coverage analysis on the RPC interface.
 
 Provides a way to track which RPC commands are exercised during
 testing.
@@ -11,11 +13,10 @@ testing.
 
 import os
 
-
 REFERENCE_FILENAME = 'rpc_interface.txt'
 
 
-class AuthServiceProxyWrapper():
+class AuthServiceProxyWrapper:
     """
     An object that wraps AuthServiceProxy to record specific RPC calls.
 
@@ -49,6 +50,7 @@ class AuthServiceProxyWrapper():
         self._log_call()
         return return_val
 
+    # noinspection PyProtectedMember
     def _log_call(self):
         rpc_method = self.auth_service_proxy_instance._service_name
 
@@ -63,6 +65,7 @@ class AuthServiceProxyWrapper():
     def get_request(self, *args, **kwargs):
         self._log_call()
         return self.auth_service_proxy_instance.get_request(*args, **kwargs)
+
 
 def get_filename(dirname, n_node):
     """

--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Linux network utilities.
+
+"""
+Linux network utilities.
 
 Roughly based on http://voorloopnul.com/blog/a-python-netstat-in-less-than-100-lines-of-code/ by Ricardo Pascal
 """
@@ -14,7 +16,7 @@ import fcntl
 import struct
 import array
 import os
-from binascii import (unhexlify, hexlify)
+from binascii import unhexlify, hexlify
 
 # STATE_ESTABLISHED = '01'
 # STATE_SYN_SENT  = '02'
@@ -29,9 +31,9 @@ STATE_LISTEN = '0A'
 # STATE_CLOSING = '0B'
 
 def get_socket_inodes(pid):
-    '''
+    """
     Get list of socket inodes for process pid.
-    '''
+    """
     base = '/proc/%i/fd' % pid
     inodes = []
     for item in os.listdir(base):
@@ -40,11 +42,11 @@ def get_socket_inodes(pid):
             inodes.append(int(target[8:-1]))
     return inodes
 
-def _remove_empty(array):
-    return [x for x in array if x !='']
+def _remove_empty(array_in):
+    return [x for x in array_in if x != '']
 
-def _convert_ip_port(array):
-    host,port = array.split(':')
+def _convert_ip_port(array_in):
+    host,port = array_in.split(':')
     # convert host from mangled-per-four-bytes form as used by kernel
     host = unhexlify(host)
     host_out = ''
@@ -55,11 +57,11 @@ def _convert_ip_port(array):
     return host_out,int(port,16)
 
 def netstat(typ='tcp'):
-    '''
+    """
     Function to return a list with status of tcp connections at linux systems
     To get pid of all network process running on system, you must run this script
     as superuser
-    '''
+    """
     with open('/proc/net/'+typ,'r',encoding='utf8') as f:
         content = f.readlines()
         content.pop(0)
@@ -76,9 +78,9 @@ def netstat(typ='tcp'):
     return result
 
 def get_bind_addrs(pid):
-    '''
+    """
     Get bind addresses as (host,port) tuples for process pid.
-    '''
+    """
     inodes = get_socket_inodes(pid)
     bind_addrs = []
     for conn in netstat('tcp') + netstat('tcp6'):
@@ -88,22 +90,22 @@ def get_bind_addrs(pid):
 
 # from: http://code.activestate.com/recipes/439093/
 def all_interfaces():
-    '''
+    """
     Return all interfaces that are up
-    '''
+    """
     is_64bits = sys.maxsize > 2**32
     struct_size = 40 if is_64bits else 32
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     max_possible = 8 # initial value
     while True:
-        bytes = max_possible * struct_size
-        names = array.array('B', b'\0' * bytes)
+        byte_data = max_possible * struct_size
+        names = array.array('B', b'\0' * byte_data)
         outbytes = struct.unpack('iL', fcntl.ioctl(
             s.fileno(),
             0x8912,  # SIOCGIFCONF
-            struct.pack('iL', bytes, names.buffer_info()[0])
+            struct.pack('iL', byte_data, names.buffer_info()[0])
         ))[0]
-        if outbytes == bytes:
+        if outbytes == byte_data:
             max_possible *= 2
         else:
             break
@@ -113,11 +115,11 @@ def all_interfaces():
             for i in range(0, outbytes, struct_size)]
 
 def addr_to_hex(addr):
-    '''
+    """
     Convert string IPv4 or IPv6 address to binary address as returned by
     get_bind_addrs.
     Very naive implementation that certainly doesn't work for all IPv6 variants.
-    '''
+    """
     if '.' in addr: # IPv4
         addr = [int(x) for x in addr.split('.')]
     elif ':' in addr: # IPv6
@@ -142,9 +144,9 @@ def addr_to_hex(addr):
     return hexlify(bytearray(addr)).decode('ascii')
 
 def test_ipv6_local():
-    '''
+    """
     Check for (local) IPv6 support.
-    '''
+    """
     import socket
     # By using SOCK_DGRAM this will not actually make a connection, but it will
     # fail if there is no route to IPv6 localhost.

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -3,16 +3,19 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Functionality to build scripts, as well as SignatureHash().
+
+"""
+Functionality to build scripts, as well as signature_hash().
 
 This file is modified from python-ravenlib.
 """
 
-from .mininode import (CTransaction, CTxOut, sha256, hash256, uint256_from_str, ser_uint256, ser_string)
+from .mininode import CTransaction, CTxOut, sha256, hash256, uint256_from_str, ser_uint256, ser_string
 from binascii import hexlify
 import hashlib
 
 import sys
+
 bchr = chr
 bord = ord
 if sys.version > '3':
@@ -52,15 +55,15 @@ class CScriptOp(int):
             raise ValueError("Data too long to encode in a PUSHDATA op")
 
     @staticmethod
-    def encode_op_n(n):
+    def encode_op_n(number):
         """Encode a small integer op, returning an opcode"""
-        if not (0 <= n <= 16):
-            raise ValueError('Integer must be in range 0 <= n <= 16, got %d' % n)
+        if not (0 <= number <= 16):
+            raise ValueError('Integer must be in range 0 <= n <= 16, got %d' % number)
 
-        if n == 0:
+        if number == 0:
             return OP_0
         else:
-            return CScriptOp(OP_1 + n-1)
+            return CScriptOp(OP_1 + number - 1)
 
     def decode_op_n(self):
         """Decode a small integer opcode, returning an integer"""
@@ -88,13 +91,13 @@ class CScriptOp(int):
         else:
             return 'CScriptOp(0x%x)' % self
 
-    def __new__(cls, n):
+    def __new__(cls, number):
         try:
-            return _opcode_instances[n]
+            return _opcode_instances[number]
         except IndexError:
-            assert len(_opcode_instances) == n
-            _opcode_instances.append(super(CScriptOp, cls).__new__(cls, n))
-            return _opcode_instances[n]
+            assert len(_opcode_instances) == number
+            _opcode_instances.append(super(CScriptOp, cls).__new__(cls, number))
+            return _opcode_instances[number]
 
 # Populate opcode instance table
 for n in range(0xff+1):
@@ -374,7 +377,7 @@ class CScriptTruncatedPushDataError(CScriptInvalidError):
         super(CScriptTruncatedPushDataError, self).__init__(msg)
 
 # This is used, eg, for blockchain heights in coinbase scripts (bip34)
-class CScriptNum():
+class CScriptNum:
     def __init__(self, d=0):
         self.value = d
 
@@ -385,7 +388,7 @@ class CScriptNum():
             return bytes(r)
         neg = obj.value < 0
         absvalue = -obj.value if neg else obj.value
-        while (absvalue):
+        while absvalue:
             r.append(absvalue & 0xff)
             absvalue >>= 8
         if r[-1] & 0x80:
@@ -411,7 +414,7 @@ class CScript(bytes):
         if isinstance(other, CScriptOp):
             other = bchr(other)
         elif isinstance(other, CScriptNum):
-            if (other.value == 0):
+            if other.value == 0:
                 other = bchr(CScriptOp(OP_0))
             else:
                 other = CScriptNum.encode(other)
@@ -468,44 +471,42 @@ class CScript(bytes):
             if opcode > OP_PUSHDATA4:
                 yield (opcode, None, sop_idx)
             else:
-                datasize = None
-                pushdata_type = None
                 if opcode < OP_PUSHDATA1:
                     pushdata_type = 'PUSHDATA(%d)' % opcode
-                    datasize = opcode
+                    data_size = opcode
 
                 elif opcode == OP_PUSHDATA1:
                     pushdata_type = 'PUSHDATA1'
                     if i >= len(self):
                         raise CScriptInvalidError('PUSHDATA1: missing data length')
-                    datasize = bord(self[i])
+                    data_size = bord(self[i])
                     i += 1
 
                 elif opcode == OP_PUSHDATA2:
                     pushdata_type = 'PUSHDATA2'
                     if i + 1 >= len(self):
                         raise CScriptInvalidError('PUSHDATA2: missing data length')
-                    datasize = bord(self[i]) + (bord(self[i+1]) << 8)
+                    data_size = bord(self[i]) + (bord(self[i+1]) << 8)
                     i += 2
 
                 elif opcode == OP_PUSHDATA4:
                     pushdata_type = 'PUSHDATA4'
                     if i + 3 >= len(self):
                         raise CScriptInvalidError('PUSHDATA4: missing data length')
-                    datasize = bord(self[i]) + (bord(self[i+1]) << 8) + (bord(self[i+2]) << 16) + (bord(self[i+3]) << 24)
+                    data_size = bord(self[i]) + (bord(self[i+1]) << 8) + (bord(self[i+2]) << 16) + (bord(self[i+3]) << 24)
                     i += 4
 
                 else:
                     assert False # shouldn't happen
 
 
-                data = bytes(self[i:i+datasize])
+                data = bytes(self[i:i+data_size])
 
                 # Check for truncation
-                if len(data) < datasize:
+                if len(data) < data_size:
                     raise CScriptTruncatedPushDataError('%s: truncated data' % pushdata_type, data)
 
-                i += datasize
+                i += data_size
 
                 yield (opcode, data, sop_idx)
 
@@ -558,25 +559,25 @@ class CScript(bytes):
 
         return "CScript([%s])" % ', '.join(ops)
 
-    def GetSigOpCount(self, fAccurate):
+    def get_sig_op_count(self, f_accurate):
         """Get the SigOp count.
 
         fAccurate - Accurately count CHECKMULTISIG, see BIP16 for details.
 
         Note that this is consensus-critical.
         """
-        n = 0
-        lastOpcode = OP_INVALIDOPCODE
+        number = 0
+        last_opcode = OP_INVALIDOPCODE
         for (opcode, data, sop_idx) in self.raw_iter():
             if opcode in (OP_CHECKSIG, OP_CHECKSIGVERIFY):
-                n += 1
+                number += 1
             elif opcode in (OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY):
-                if fAccurate and (OP_1 <= lastOpcode <= OP_16):
-                    n += opcode.decode_op_n()
+                if f_accurate and (OP_1 <= last_opcode <= OP_16):
+                    number += opcode.decode_op_n()
                 else:
-                    n += 20
-            lastOpcode = opcode
-        return n
+                    number += 20
+            last_opcode = opcode
+        return number
 
 
 SIGHASH_ALL = 1
@@ -584,8 +585,10 @@ SIGHASH_NONE = 2
 SIGHASH_SINGLE = 3
 SIGHASH_ANYONECANPAY = 0x80
 
-def FindAndDelete(script, sig):
-    """Consensus critical, see FindAndDelete() in Satoshi codebase"""
+
+# noinspection PyUnusedLocal
+def find_and_delete(script, sig):
+    """Consensus critical, see find_and_delete() in Satoshi codebase"""
     r = b''
     last_sop_idx = sop_idx = 0
     skip = True
@@ -602,97 +605,97 @@ def FindAndDelete(script, sig):
     return CScript(r)
 
 
-def SignatureHash(script, txTo, inIdx, hashtype):
-    """Consensus-correct SignatureHash
+def signature_hash(script, tx_to, in_idx, hash_type):
+    """Consensus-correct signature_hash
 
     Returns (hash, err) to precisely match the consensus-critical behavior of
     the SIGHASH_SINGLE bug. (inIdx is *not* checked for validity)
     """
-    HASH_ONE = b'\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    hash_one = b'\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 
-    if inIdx >= len(txTo.vin):
-        return (HASH_ONE, "inIdx %d out of range (%d)" % (inIdx, len(txTo.vin)))
-    txtmp = CTransaction(txTo)
+    if in_idx >= len(tx_to.vin):
+        return hash_one, "inIdx %d out of range (%d)" % (in_idx, len(tx_to.vin))
+    tx_tmp = CTransaction(tx_to)
 
-    for txin in txtmp.vin:
+    for txin in tx_tmp.vin:
         txin.scriptSig = b''
-    txtmp.vin[inIdx].scriptSig = FindAndDelete(script, CScript([OP_CODESEPARATOR]))
+    tx_tmp.vin[in_idx].scriptSig = find_and_delete(script, CScript(OP_CODESEPARATOR))
 
-    if (hashtype & 0x1f) == SIGHASH_NONE:
-        txtmp.vout = []
+    if (hash_type & 0x1f) == SIGHASH_NONE:
+        tx_tmp.vout = []
 
-        for i in range(len(txtmp.vin)):
-            if i != inIdx:
-                txtmp.vin[i].nSequence = 0
+        for i in range(len(tx_tmp.vin)):
+            if i != in_idx:
+                tx_tmp.vin[i].nSequence = 0
 
-    elif (hashtype & 0x1f) == SIGHASH_SINGLE:
-        outIdx = inIdx
-        if outIdx >= len(txtmp.vout):
-            return (HASH_ONE, "outIdx %d out of range (%d)" % (outIdx, len(txtmp.vout)))
+    elif (hash_type & 0x1f) == SIGHASH_SINGLE:
+        out_idx = in_idx
+        if out_idx >= len(tx_tmp.vout):
+            return hash_one, "outIdx %d out of range (%d)" % (out_idx, len(tx_tmp.vout))
 
-        tmp = txtmp.vout[outIdx]
-        txtmp.vout = []
-        for i in range(outIdx):
-            txtmp.vout.append(CTxOut(-1))
-        txtmp.vout.append(tmp)
+        tmp = tx_tmp.vout[out_idx]
+        tx_tmp.vout = []
+        for i in range(out_idx):
+            tx_tmp.vout.append(CTxOut(-1))
+        tx_tmp.vout.append(tmp)
 
-        for i in range(len(txtmp.vin)):
-            if i != inIdx:
-                txtmp.vin[i].nSequence = 0
+        for i in range(len(tx_tmp.vin)):
+            if i != in_idx:
+                tx_tmp.vin[i].nSequence = 0
 
-    if hashtype & SIGHASH_ANYONECANPAY:
-        tmp = txtmp.vin[inIdx]
-        txtmp.vin = []
-        txtmp.vin.append(tmp)
+    if hash_type & SIGHASH_ANYONECANPAY:
+        tmp = tx_tmp.vin[in_idx]
+        tx_tmp.vin = []
+        tx_tmp.vin.append(tmp)
 
-    s = txtmp.serialize()
-    s += struct.pack(b"<I", hashtype)
+    s = tx_tmp.serialize()
+    s += struct.pack(b"<I", hash_type)
 
-    hash = hash256(s)
+    hash_data = hash256(s)
 
-    return (hash, None)
+    return hash_data, None
 
 # TODO: Allow cached hashPrevouts/hashSequence/hashOutputs to be provided.
 # Performance optimization probably not necessary for python tests, however.
 # Note that this corresponds to sigversion == 1 in EvalScript, which is used
 # for version 0 witnesses.
-def SegwitVersion1SignatureHash(script, txTo, inIdx, hashtype, amount):
+def segwit_version1_signature_hash(script, tx_to, in_idx, hash_type, amount):
 
-    hashPrevouts = 0
-    hashSequence = 0
-    hashOutputs = 0
+    hash_prevouts = 0
+    hash_sequence = 0
+    hash_outputs = 0
 
-    if not (hashtype & SIGHASH_ANYONECANPAY):
+    if not (hash_type & SIGHASH_ANYONECANPAY):
         serialize_prevouts = bytes()
-        for i in txTo.vin:
+        for i in tx_to.vin:
             serialize_prevouts += i.prevout.serialize()
-        hashPrevouts = uint256_from_str(hash256(serialize_prevouts))
+        hash_prevouts = uint256_from_str(hash256(serialize_prevouts))
 
-    if (not (hashtype & SIGHASH_ANYONECANPAY) and (hashtype & 0x1f) != SIGHASH_SINGLE and (hashtype & 0x1f) != SIGHASH_NONE):
+    if not (hash_type & SIGHASH_ANYONECANPAY) and (hash_type & 0x1f) != SIGHASH_SINGLE and (hash_type & 0x1f) != SIGHASH_NONE:
         serialize_sequence = bytes()
-        for i in txTo.vin:
+        for i in tx_to.vin:
             serialize_sequence += struct.pack("<I", i.nSequence)
-        hashSequence = uint256_from_str(hash256(serialize_sequence))
+        hash_sequence = uint256_from_str(hash256(serialize_sequence))
 
-    if ((hashtype & 0x1f) != SIGHASH_SINGLE and (hashtype & 0x1f) != SIGHASH_NONE):
+    if (hash_type & 0x1f) != SIGHASH_SINGLE and (hash_type & 0x1f) != SIGHASH_NONE:
         serialize_outputs = bytes()
-        for o in txTo.vout:
+        for o in tx_to.vout:
             serialize_outputs += o.serialize()
-        hashOutputs = uint256_from_str(hash256(serialize_outputs))
-    elif ((hashtype & 0x1f) == SIGHASH_SINGLE and inIdx < len(txTo.vout)):
-        serialize_outputs = txTo.vout[inIdx].serialize()
-        hashOutputs = uint256_from_str(hash256(serialize_outputs))
+        hash_outputs = uint256_from_str(hash256(serialize_outputs))
+    elif (hash_type & 0x1f) == SIGHASH_SINGLE and in_idx < len(tx_to.vout):
+        serialize_outputs = tx_to.vout[in_idx].serialize()
+        hash_outputs = uint256_from_str(hash256(serialize_outputs))
 
     ss = bytes()
-    ss += struct.pack("<i", txTo.nVersion)
-    ss += ser_uint256(hashPrevouts)
-    ss += ser_uint256(hashSequence)
-    ss += txTo.vin[inIdx].prevout.serialize()
+    ss += struct.pack("<i", tx_to.nVersion)
+    ss += ser_uint256(hash_prevouts)
+    ss += ser_uint256(hash_sequence)
+    ss += tx_to.vin[in_idx].prevout.serialize()
     ss += ser_string(script)
     ss += struct.pack("<q", amount)
-    ss += struct.pack("<I", txTo.vin[inIdx].nSequence)
-    ss += ser_uint256(hashOutputs)
-    ss += struct.pack("<i", txTo.nLockTime)
-    ss += struct.pack("<I", hashtype)
+    ss += struct.pack("<I", tx_to.vin[in_idx].nSequence)
+    ss += ser_uint256(hash_outputs)
+    ss += struct.pack("<i", tx_to.nLockTime)
+    ss += struct.pack("<I", hash_type)
 
     return hash256(ss)

--- a/test/functional/test_framework/socks5.py
+++ b/test/functional/test_framework/socks5.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Dummy Socks5 server for testing."""
 
 import socket, threading, queue
@@ -32,7 +33,7 @@ def recvall(s, n):
     return rv
 
 ### Implementation classes
-class Socks5Configuration():
+class Socks5Configuration:
     """Proxy configuration."""
     def __init__(self):
         self.addr = None # Bind address (must be set)
@@ -40,7 +41,7 @@ class Socks5Configuration():
         self.unauth = False  # Support unauthenticated
         self.auth = False  # Support authentication
 
-class Socks5Command():
+class Socks5Command:
     """Information about an incoming socks5 command."""
     def __init__(self, cmd, atyp, addr, port, username, password):
         self.cmd = cmd # Command (one of Command.*)
@@ -52,7 +53,7 @@ class Socks5Command():
     def __repr__(self):
         return 'Socks5Command(%s,%s,%s,%s,%s,%s)' % (self.cmd, self.atyp, self.addr, self.port, self.username, self.password)
 
-class Socks5Connection():
+class Socks5Connection:
     def __init__(self, serv, conn, peer):
         self.serv = serv
         self.conn = conn
@@ -123,7 +124,7 @@ class Socks5Connection():
         finally:
             self.conn.close()
 
-class Socks5Server():
+class Socks5Server:
     def __init__(self, conf):
         self.conf = conf
         self.s = socket.socket(conf.af)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Base class for RPC testing."""
 
 from enum import Enum
@@ -18,20 +19,8 @@ import time
 from .authproxy import JSONRPCException
 from . import coverage
 from .test_node import TestNode
-from .util import (
-    MAX_NODES,
-    PortSeed,
-    assert_equal,
-    check_json_precision,
-    connect_nodes_bi,
-    disconnect_nodes,
-    initialize_datadir,
-    log_filename,
-    p2p_port,
-    set_node_times,
-    sync_blocks,
-    sync_mempools,
-)
+from .util import (MAX_NODES, PortSeed, assert_equal, check_json_precision, connect_nodes_bi, disconnect_nodes,
+                   initialize_data_dir, log_filename, p2p_port, set_node_times, sync_blocks, sync_mempools)
 
 
 class TestStatus(Enum):
@@ -385,7 +374,7 @@ class RavenTestFramework:
 
             # Create cache directories, run ravends:
             for i in range(MAX_NODES):
-                datadir = initialize_datadir(self.options.cachedir, i)
+                datadir = initialize_data_dir(self.options.cachedir, i)
                 args = [os.getenv("RAVEND", "ravend"), "-server", "-keypool=1", "-datadir=" + datadir, "-discover=0"]
                 if i > 0:
                     args.append("-connect=127.0.0.1:" + str(p2p_port(0)))
@@ -431,7 +420,7 @@ class RavenTestFramework:
             from_dir = os.path.join(self.options.cachedir, "node" + str(i))
             to_dir = os.path.join(self.options.tmpdir, "node" + str(i))
             shutil.copytree(from_dir, to_dir)
-            initialize_datadir(self.options.tmpdir, i)  # Overwrite port/rpcport in raven.conf
+            initialize_data_dir(self.options.tmpdir, i)  # Overwrite port/rpcport in raven.conf
 
     def _initialize_chain_clean(self):
         """Initialize empty blockchain for use by the test.
@@ -439,7 +428,7 @@ class RavenTestFramework:
         Create an empty blockchain and num_nodes wallets.
         Useful if a test case wants complete control over initialization."""
         for i in range(self.num_nodes):
-            initialize_datadir(self.options.tmpdir, i)
+            initialize_data_dir(self.options.tmpdir, i)
 
 
 class ComparisonTestFramework(RavenTestFramework):
@@ -449,6 +438,9 @@ class ComparisonTestFramework(RavenTestFramework):
     - 1 binary: test binary
     - 2 binaries: 1 test binary, 1 ref binary
     - n>2 binaries: 1 test binary, n-1 ref binaries"""
+
+    def run_test(self):
+        pass
 
     def set_test_params(self):
         self.num_nodes = 2

--- a/test/functional/test_framework/wallet_util.py
+++ b/test/functional/test_framework/wallet_util.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Useful util functions for testing the wallet"""
+
+from collections import namedtuple
+
+Key = namedtuple('Key', ['privkey',
+                         'pubkey',
+                         'p2pkh_script',
+                         'p2pkh_addr',
+                         'p2wpkh_script',
+                         'p2wpkh_addr',
+                         'p2sh_p2wpkh_script',
+                         'p2sh_p2wpkh_redeem_script',
+                         'p2sh_p2wpkh_addr'])
+
+Multisig = namedtuple('Multisig', ['privkeys',
+                                   'pubkeys',
+                                   'p2sh_script',
+                                   'p2sh_addr',
+                                   'redeem_script',
+                                   'p2wsh_script',
+                                   'p2wsh_addr',
+                                   'p2sh_p2wsh_script',
+                                   'p2sh_p2wsh_addr'])
+
+
+def test_address(node, address, **kwargs):
+    """Get address info for `address` and test whether the returned values are as expected."""
+    addr_info = node.validateaddress(address)
+    for key, value in kwargs.items():
+        if value is None:
+            if key in addr_info.keys():
+                raise AssertionError("key {} unexpectedly returned in getaddressinfo.".format(key))
+        elif addr_info[key] != value:
+            raise AssertionError("key {} value {} did not match expected value {}".format(key, addr_info[key], value))

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Run regression test suite.
+
+"""
+Run regression test suite.
 
 This module calls down into individual test cases via subprocess. It will
 forward all unrecognized arguments onto the individual test scripts.
@@ -13,7 +15,9 @@ Functional tests are disabled on Windows by default. Use --force to run them any
 For a description of arguments recognized by test scripts, see
 `test/functional/test_framework/test_framework.py:RavenTestFramework.main`.
 
+
 """
+
 from collections import deque
 import argparse
 import configparser
@@ -30,6 +34,7 @@ import logging
 
 # Formatting. Default colors to empty strings.
 BOLD, GREEN, RED, GREY = ("", ""), ("", ""), ("", ""), ("", "")
+
 try:
     # Make sure python thinks it can write unicode to its stdout
     "\u2713".encode("utf_8").decode(sys.stdout.encoding)
@@ -55,14 +60,8 @@ TEST_EXIT_PASSED = 0
 TEST_EXIT_SKIPPED = 77
 
 EXTENDED_SCRIPTS = [
-    # These tests are not run by the travis build process.
+    # These tests are not run by the build process.
     # Longest test should go first, to favor running tests in parallel
-    # 'p2p_acceptblock.py',
-    # 'feature_rbf.py',
-    # 'feature_assumevalid.py',
-    # 'mempool_packages.py',
-    # 'feature_bip_softforks.py', # use this for future soft fork testing
-    # 'feature_pruning.py',
     # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv Tests less than 20m vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     'feature_fee_estimation.py',
     # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv Tests less than 5m vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
@@ -70,23 +69,8 @@ EXTENDED_SCRIPTS = [
 ]
 
 BASE_SCRIPTS= [
-    # Scripts that are run by the travis build process.
+    # Scripts that are run by the build process.
     # Longest test should go first, to favor running tests in parallel
-    # 'p2p_fingerprint.py',         TODO - fix mininode rehash methods to use X16R
-    # 'p2p_invalid_block.py',       TODO - fix mininode rehash methods to use X16R
-    # 'p2p_invalid_tx.py',          TODO - fix mininode rehash methods to use X16R
-    # 'feature_segwit.py',          TODO - fix mininode rehash methods to use X16R
-    # 'p2p_sendheaders.py',         TODO - fix mininode rehash methods to use X16R
-    # 'feature_nulldummy.py',       TODO - fix mininode rehash methods to use X16R
-    # 'mining_basic.py',            TODO - fix mininode rehash methods to use X16R
-    # 'feature_dersig.py',          TODO - fix mininode rehash methods to use X16R
-    # 'feature_cltv.py',            TODO - fix mininode rehash methods to use X16R
-    # 'p2p_fullblock.py',           TODO - fix comptool.TestInstance timeout
-    # 'p2p_compactblocks.py',       TODO - refactor to assume segwit is always active
-    # 'p2p_segwit.py',              TODO - refactor to assume segwit is always active
-    # 'feature_csv_activation.py',  TODO - currently testing softfork activations, we need to test the features
-    # 'wallet_bumpfee.py',          TODO - Now fails because we removed RBF
-    # 'example_test.py',
     # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv Tests less than 2m vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     'wallet_backup.py',
     'wallet_hd.py',
@@ -95,6 +79,7 @@ BASE_SCRIPTS= [
     'feature_maxuploadtarget.py',
     # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv Tests less than 45s vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     'rpc_fundrawtransaction.py',
+    'wallet_create_tx.py',
     # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv Tests less than 30s vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     'feature_rewards.py',
     'wallet_basic.py',
@@ -117,28 +102,32 @@ BASE_SCRIPTS= [
     'mempool_persist.py',
     'rpc_timestampindex.py',
     'wallet_listreceivedby.py',
+    'wallet_reorgsrestore.py',
     'interface_rest.py',
     'wallet_keypool_topup.py',
     'wallet_import_rescan.py',
     'wallet_abandonconflict.py',
+    'wallet_groups.py',
     'rpc_blockchain.py',
     'p2p_feefilter.py',
     'p2p_leak.py',
-    'p2p_versionbits.py',
+    'feature_versionbits_warning.py',
     'rpc_spentindex.py',
     'feature_rawassettransactions.py',
     'wallet_importmulti.py',
-    'wallet_accounts.py',
+    'wallet_labels.py',
+    'wallet_import_with_label.py',
     # vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv Tests less than 5s vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     'wallet_listtransactions.py',
     'feature_minchainwork.py',
     'wallet_encryption.py',
     'feature_listmyassets.py',
     'mempool_reorg.py',
-    'rpc_merkle_blocks.py',
+    'rpc_txoutproof.py',
     'feature_reindex.py',
     'rpc_decodescript.py',
     'wallet_keypool.py',
+    'rpc_setban.py',
     'wallet_listsinceblock.py',
     'wallet_zapwallettxes.py',
     'wallet_multiwallet.py',
@@ -159,6 +148,7 @@ BASE_SCRIPTS= [
     'rpc_preciousblock.py',
     'feature_notifications.py',
     'rpc_net.py',
+    'rpc_misc.py',
     'interface_raven_cli.py',
     'mempool_resurrect.py',
     'rpc_signrawtransaction.py',
@@ -166,7 +156,9 @@ BASE_SCRIPTS= [
     'wallet_txn_clone.py --mineblock',
     'rpc_signmessage.py',
     'rpc_deprecated.py',
+    'wallet_coinbase_category.py',
     'wallet_txn_doublespend.py',
+    'feature_shutdown.py',
     'wallet_disable.py',
     'interface_http.py',
     'mempool_spend_coinbase.py',
@@ -174,9 +166,36 @@ BASE_SCRIPTS= [
     'p2p_mempool.py',
     'rpc_named_arguments.py',
     'rpc_uptime.py',
-    'rpc_assettransfer.py'
+    'rpc_assettransfer.py',
+    'feature_loadblock.py',
+    'p2p_leak_tx.py'
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
+]
+
+SKIPPED_TESTS = [
+    # List of tests that are not going to be run (usually means test is broken)
+    'example_test.py',
+    'feature_assumevalid.py',
+    'feature_bip_softforks.py',     # use this for future soft fork testing
+    'feature_block.py',             #TODO - fix comptool.TestInstance timeout
+    'feature_cltv.py',              #TODO - fix mininode rehash methods to use X16R
+    'feature_csv_activation.py',    #TODO - currently testing softfork activations, we need to test the features
+    'feature_dersig.py',            #TODO - fix mininode rehash methods to use X16R
+    'feature_nulldummy.py',         #TODO - fix mininode rehash methods to use X16R
+    'feature_pruning.py',
+    'feature_rbf.py',
+    'feature_segwit.py',            #TODO - fix mininode rehash methods to use X16R
+    'mempool_packages.py',
+    'mining_basic.py',              #TODO - fix mininode rehash methods to use X16R
+    'p2p_compactblocks.py',         #TODO - refactor to assume segwit is always active
+    'p2p_fingerprint.py',           #TODO - fix mininode rehash methods to use X16R
+    'p2p_invalid_block.py',         #TODO - fix mininode rehash methods to use X16R
+    'p2p_invalid_tx.py',            #TODO - fix mininode rehash methods to use X16R
+    'p2p_segwit.py',                #TODO - refactor to assume segwit is always active
+    'p2p_sendheaders.py',           #TODO - fix mininode rehash methods to use X16R
+    'p2p_unrequested_blocks.py',
+    'wallet_bumpfee.py',            #TODO - Now fails because we removed RBF
 ]
 
 # Place EXTENDED_SCRIPTS first since it has the 3 longest running tests
@@ -192,25 +211,24 @@ NON_SCRIPTS = [
 
 def main():
     # Parse arguments and pass through unrecognised args
-    parser = argparse.ArgumentParser(add_help=False,
-                                     usage='%(prog)s [test_runner.py options] [script options] [scripts]',
-                                     description=__doc__,
-                                     epilog='Help text and arguments for individual test script:',
-                                     formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('--ansi', action='store_true', default=sys.stdout.isatty(), help="Use ANSI colors and dots in output (enabled by default when standard output is a TTY)")
+    parser = argparse.ArgumentParser(add_help=False, usage='%(prog)s [test_runner.py options] [script options] [scripts]', description=__doc__,
+                                     epilog='Help text and arguments for individual test script:', formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('--ansi', action='store_true', default=sys.stdout.isatty(), help='Use ANSI colors and dots in output (enabled by default when standard output is a TTY)')
     parser.add_argument('--combinedlogslen', type=int, default=0, metavar='n', help='On failure, print a log (of length n lines) to the console, combined from the test framework and all test nodes.')
-    parser.add_argument('--coverage', action='store_true', help='generate a basic coverage report for the RPC interface')
-    parser.add_argument('--exclude', help='specify a comma-separated-list of scripts to exclude.')
-    parser.add_argument('--extended', action='store_true', help='run the extended test suite in addition to the basic tests')
-    parser.add_argument('--failfast', action='store_true', help='stop execution after the first test failure')
-    parser.add_argument('--filter', help='filter scripts to run by regular expression')
-    parser.add_argument('--force', action='store_true', help='run tests even on platforms where they are disabled by default (e.g. windows).')
-    parser.add_argument('--help', action='store_true', help='print help text and exit')
-    parser.add_argument('--jobs', type=int, default=get_cpu_count(), help='how many test scripts to run in parallel. Default=.' + str(get_cpu_count()))
-    parser.add_argument('--keepcache', action='store_true', help='the default behavior is to flush the cache directory on startup. --keepcache retains the cache from the previous test-run.')
-    parser.add_argument('--onlyextended', action='store_true', help='run only the extended test suite')
-    parser.add_argument('--quiet',  action='store_true', help='only print results summary and failure logs')
-    parser.add_argument('--tmpdirprefix', default=tempfile.gettempdir(), help="Root directory for data")
+    parser.add_argument('--coverage', action='store_true', help='Generate a basic coverage report for the RPC interface.')
+    parser.add_argument('--exclude', metavar='', help='Specify a comma-separated-list of scripts to exclude.')
+    parser.add_argument('--extended', action='store_true', help='Run the extended test suite in addition to the basic tests.')
+    parser.add_argument('--failfast', action='store_true', help='Stop execution after the first test failure.')
+    parser.add_argument('--filter', metavar='', help='Filter scripts to run by regular expression.')
+    parser.add_argument('--force', action='store_true', help='Run tests even on platforms where they are disabled by default (e.g. windows).')
+    parser.add_argument('--help', action='store_true', help='Print help text and exit.')
+    parser.add_argument('--jobs', type=int, metavar='', default=get_cpu_count(), help='How many test scripts to run in parallel. Default=.' + str(get_cpu_count()))
+    parser.add_argument('--keepcache', action='store_true', help='The default behavior is to flush the cache directory on startup. --keepcache retains the cache from the previous test-run.')
+    parser.add_argument('--list', action='store_true', help='Print list of tests and exit.')
+    parser.add_argument('--loop', type=int, metavar='n', default=1, help='Run(loop) the tests n number of times.')
+    parser.add_argument('--onlyextended', action='store_true', help='Run only the extended test suite.')
+    parser.add_argument('--quiet',  action='store_true', help='Only print results summary and failure logs.')
+    parser.add_argument('--tmpdirprefix', metavar='', default=tempfile.gettempdir(), help='Root directory for data.')
 
 
     # Setup colours for ANSI terminals
@@ -224,13 +242,13 @@ def main():
 
     # args to be passed on always start with two dashes; tests are the remaining unknown args
     tests = [arg for arg in unknown_args if arg[:2] != "--"]
-    passon_args = [arg for arg in unknown_args if arg[:2] == "--"]
+    pass_on_args = [arg for arg in unknown_args if arg[:2] == "--"]
 
     # Read config generated by configure.
     config = configparser.ConfigParser()
     configfile = os.path.abspath(os.path.dirname(__file__)) + "/../config.ini"
     config.read_file(open(configfile, encoding="utf8"))
-    passon_args.append("--configfile=%s" % configfile)
+    pass_on_args.append("--configfile=%s" % configfile)
 
     # Set up logging
     logging_level = logging.INFO if args.quiet else logging.DEBUG
@@ -257,82 +275,94 @@ def main():
         print("Rerun `configure` with --enable-wallet, --with-cli and --with-daemon and rerun make")
         sys.exit(0)
 
-    # Build list of tests
-    test_list = []
-    if tests:
-        # Individual tests have been specified. Run specified tests that exist
-        # in the ALL_SCRIPTS list. Accept names with or without a .py extension.
-        # Specified tests can contain wildcards, but in that case the supplied
-        # paths should be coherent, e.g. the same path as that provided to call
-        # test_runner.py. Examples:
-        #   `test/functional/test_runner.py test/functional/wallet*`
-        #   `test/functional/test_runner.py ./test/functional/wallet*`
-        #   `test_runner.py wallet*`
-        #   but not:
-        #   `test/functional/test_runner.py wallet*`
-        # Multiple wildcards can be passed:
-        #   `test_runner.py tool* mempool*`
-        for test in tests:
-            script = test.split("/")[-1]
-            script = script + ".py" if ".py" not in script else script
-            if script in ALL_SCRIPTS:
-                test_list.append(script)
-            else:
-                print("{}WARNING!{} Test '{}' not found in full test list.".format(BOLD[1], BOLD[0], test))
-    elif args.extended:
-        # Include extended tests
-        test_list += ALL_SCRIPTS
-    else:
-        # Run base tests only
-        test_list += BASE_SCRIPTS
+    # Loop the running of tests
+    for i in range(0, args.loop):
+        print("Test Loop ", i+1, "of ", args.loop)
+        last_loop = False
+        if i+1 == args.loop:
+            last_loop = True
 
-    # Remove the test cases that the user has explicitly asked to exclude.
-    if args.exclude:
-        exclude_tests = [test.split('.py')[0] for test in args.exclude.split(',')]
-        for exclude_test in exclude_tests:
-            # Remove <test_name>.py and <test_name>.py --arg from the test list
-            exclude_list = [test for test in test_list if test.split('.py')[0] == exclude_test]
-            for exclude_item in exclude_list:
-                test_list.remove(exclude_item)
-            if not exclude_list:
-                print("{}WARNING!{} Test '{}' not found in current test list.".format(BOLD[1], BOLD[0], exclude_test))
+        # Build list of tests
+        test_list = []
+        if tests:
+            # Individual tests have been specified. Run specified tests that exist
+            # in the ALL_SCRIPTS list. Accept names with or without a .py extension.
+            # Specified tests can contain wildcards, but in that case the supplied
+            # paths should be coherent, e.g. the same path as that provided to call
+            # test_runner.py. Examples:
+            #   `test/functional/test_runner.py test/functional/wallet*`
+            #   `test/functional/test_runner.py ./test/functional/wallet*`
+            #   `test_runner.py wallet*`
+            #   but not:
+            #   `test/functional/test_runner.py wallet*`
+            # Multiple wildcards can be passed:
+            #   `test_runner.py tool* mempool*`
+            for test in tests:
+                script = test.split("/")[-1]
+                script = script + ".py" if ".py" not in script else script
+                if script in ALL_SCRIPTS:
+                    test_list.append(script)
+                else:
+                    print("{}WARNING!{} Test '{}' not found in full test list.".format(BOLD[1], BOLD[0], test))
+        elif args.extended:
+            # Include extended tests
+            test_list += ALL_SCRIPTS
+        else:
+            # Run base tests only
+            test_list += BASE_SCRIPTS
 
-    if args.filter:
-        test_list = list(filter(re.compile(args.filter).search, test_list))
+        # Remove the test cases that the user has explicitly asked to exclude.
+        if args.exclude:
+            exclude_tests = [test.split('.py')[0] for test in args.exclude.split(',')]
+            for exclude_test in exclude_tests:
+                # Remove <test_name>.py and <test_name>.py --arg from the test list
+                exclude_list = [test for test in test_list if test.split('.py')[0] == exclude_test]
+                for exclude_item in exclude_list:
+                    test_list.remove(exclude_item)
+                if not exclude_list:
+                    print("{}WARNING!{} Test '{}' not found in current test list.".format(BOLD[1], BOLD[0], exclude_test))
 
-    if not test_list:
-        print("No valid test scripts specified. Check that your test is in one "
-              "of the test lists in test_runner.py, or run test_runner.py with no arguments to run all tests")
-        sys.exit(0)
+        if args.filter:
+            test_list = list(filter(re.compile(args.filter).search, test_list))
 
-    if args.help:
-        # Print help for test_runner.py, then print help of the first script (with args removed) and exit.
-        parser.print_help()
-        subprocess.check_call([(config["environment"]["SRCDIR"] + '/test/functional/' + test_list[0].split()[0])] + ['-h'])
-        sys.exit(0)
+        if not test_list:
+            print("No valid test scripts specified. Check that your test is in one "
+                  "of the test lists in test_runner.py, or run test_runner.py with no arguments to run all tests")
+            sys.exit(0)
 
-    check_script_list(config["environment"]["SRCDIR"])
-    check_script_prefixes()
+        if args.help:
+            # Print help for test_runner.py, then print help of the first script (with args removed) and exit.
+            parser.print_help()
+            subprocess.check_call([(config["environment"]["SRCDIR"] + '/test/functional/' + test_list[0].split()[0])] + ['-h'])
+            sys.exit(0)
 
-    if not args.keepcache:
-        shutil.rmtree("%s/test/cache" % config["environment"]["BUILDDIR"], ignore_errors=True)
+        if args.list:
+            print(ALL_SCRIPTS)
+            sys.exit(0)
 
-    run_tests(
-        test_list=test_list,
-        src_dir=config["environment"]["SRCDIR"],
-        build_dir=config["environment"]["BUILDDIR"],
-        exeext=config["environment"]["EXEEXT"],
-        tmpdir=tmpdir,
-        use_term_control=args.ansi,
-        jobs=args.jobs,
-        enable_coverage=args.coverage,
-        args=passon_args,
-        combined_logs_len=args.combinedlogslen,
-        failfast=args.failfast
-    )
+        check_script_list(config["environment"]["SRCDIR"])
+        check_script_prefixes()
+
+        if not args.keepcache:
+            shutil.rmtree("%s/test/cache" % config["environment"]["BUILDDIR"], ignore_errors=True)
+
+        run_tests(
+            test_list=test_list,
+            src_dir=config["environment"]["SRCDIR"],
+            build_dir=config["environment"]["BUILDDIR"],
+            exeext=config["environment"]["EXEEXT"],
+            tmpdir=tmpdir,
+            use_term_control=args.ansi,
+            jobs=args.jobs,
+            enable_coverage=args.coverage,
+            args=pass_on_args,
+            combined_logs_len=args.combinedlogslen,
+            failfast=args.failfast,
+            last_loop=last_loop
+        )
 
 
-def run_tests(test_list, src_dir, build_dir, exeext, tmpdir, use_term_control, jobs=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False):
+def run_tests(test_list, src_dir, build_dir, exeext, tmpdir, use_term_control, jobs=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False, last_loop=False):
     # Warn if ravend is already running (unix only)
     if args is None:
         args = []
@@ -446,7 +476,8 @@ def run_tests(test_list, src_dir, build_dir, exeext, tmpdir, use_term_control, j
     # processes which need to be killed.
     job_queue.kill_and_join()
 
-    sys.exit(not all_passed)
+    if last_loop:
+        sys.exit(not all_passed)
 
 
 def print_results(test_results, max_len_name, runtime):
@@ -472,6 +503,7 @@ def print_results(test_results, max_len_name, runtime):
     print(results)
 
 
+# noinspection PyTypeChecker
 class TestHandler:
     """
     Trigger the test scripts passed in via the list.
@@ -503,10 +535,7 @@ class TestHandler:
             tmpdir_arg = ["--tmpdir={}".format(test_dir)]
             self.jobs.append((test,
                               time.time(),
-                              subprocess.Popen([self.tests_dir + test_argv[0]] + test_argv[1:] + self.flags + port_seed_arg + tmpdir_arg,
-                                               universal_newlines=True,
-                                               stdout=log_stdout,
-                                               stderr=log_stderr),
+                              subprocess.Popen([self.tests_dir + test_argv[0]] + test_argv[1:] + self.flags + port_seed_arg + tmpdir_arg, universal_newlines=True, stdout=log_stdout, stderr=log_stderr),
                               test_dir,
                               log_stdout,
                               log_stderr))
@@ -519,7 +548,7 @@ class TestHandler:
             time.sleep(.5)
             for job in self.jobs:
                 (name, start_time, proc, test_dir, log_out, log_err) = job
-                if os.getenv('TRAVIS') == 'true' and int(time.time() - start_time) > 20 * 60:
+                if int(time.time() - start_time) > 20 * 60:
                     # Timeout individual tests after 20 minutes (to stop tests hanging and not
                     # providing useful output.
                     proc.send_signal(signal.SIGINT)
@@ -538,7 +567,6 @@ class TestHandler:
                     if self.use_term_control:
                         clear_line = '\r' + (' ' * dot_count) + '\r'
                         print(clear_line, end='', flush=True)
-                    dot_count = 0
 
                     return TestResult(name, status, int(time.time() - start_time)), test_dir, stdout, stderr
             if self.use_term_control:
@@ -617,19 +645,16 @@ def check_script_list(src_dir):
     not being run by pull-tester.py."""
     script_dir = src_dir + '/test/functional/'
     python_files = set([t for t in os.listdir(script_dir) if t[-3:] == ".py"])
-    missed_tests = list(python_files - set(map(lambda x: x.split()[0], ALL_SCRIPTS + NON_SCRIPTS)))
+    missed_tests = list(python_files - set(map(lambda x: x.split()[0], ALL_SCRIPTS + NON_SCRIPTS + SKIPPED_TESTS)))
     if len(missed_tests) != 0:
-        print("%sWARNING!%s The following scripts are not being run:\n%s. \nCheck the test lists in test_runner.py." % (BOLD[1], BOLD[0], "\n".join(missed_tests)))
-        if os.getenv('TRAVIS') == 'true':
-            # On travis this warning is an error to prevent merging incomplete commits into master
-            sys.exit(1)
+        print("%sWARNING!%s The following scripts are not being run:\n%s \nCheck the test lists in test_runner.py." % (BOLD[1], BOLD[0], "\n".join(missed_tests)))
 
 
 def get_cpu_count():
     try:
         import multiprocessing
         return multiprocessing.cpu_count()
-    except:
+    except ImportError:
         return 4
 
 

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test the abandontransaction RPC.
+
+"""
+Test the abandontransaction RPC.
 
  The abandontransaction RPC marks a transaction and all its in-wallet
  descendants as abandoned which allows their inputs to be respent. It can be
@@ -11,8 +13,9 @@
  which are not included in a block and are not currently in the mempool. It has
  no effect on transactions which are already conflicted or abandoned.
 """
+
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (sync_blocks, Decimal, sync_mempools, disconnect_nodes, assert_equal, connect_nodes)
+from test_framework.util import sync_blocks, Decimal, sync_mempools, disconnect_nodes, assert_equal, connect_nodes
 
 class AbandonConflictTest(RavenTestFramework):
     def set_test_params(self):
@@ -30,9 +33,9 @@ class AbandonConflictTest(RavenTestFramework):
         self.nodes[1].generate(1)
 
         sync_blocks(self.nodes)
-        newbalance = self.nodes[0].getbalance()
-        assert(balance - newbalance < Decimal("0.01")) #no more than fees lost
-        balance = newbalance
+        new_balance = self.nodes[0].getbalance()
+        assert(balance - new_balance < Decimal("0.01")) #no more than fees lost
+        balance = new_balance
 
         # Disconnect nodes so node0's transactions don't get into node1's mempool
         disconnect_nodes(self.nodes[0], 1)
@@ -42,14 +45,10 @@ class AbandonConflictTest(RavenTestFramework):
         nB = next(i for i, vout in enumerate(self.nodes[0].getrawtransaction(txB, 1)["vout"]) if vout["value"] == Decimal("10"))
         nC = next(i for i, vout in enumerate(self.nodes[0].getrawtransaction(txC, 1)["vout"]) if vout["value"] == Decimal("10"))
 
-        inputs =[]
+        inputs = [{"txid": txA, "vout": nA}, {"txid": txB, "vout": nB}]
         # spend 10btc outputs from txA and txB
-        inputs.append({"txid":txA, "vout":nA})
-        inputs.append({"txid":txB, "vout":nB})
-        outputs = {}
+        outputs = {self.nodes[0].getnewaddress(): Decimal("14.99998"), self.nodes[1].getnewaddress(): Decimal("5")}
 
-        outputs[self.nodes[0].getnewaddress()] = Decimal("14.99998")
-        outputs[self.nodes[1].getnewaddress()] = Decimal("5")
         signed = self.nodes[0].signrawtransaction(self.nodes[0].createrawtransaction(inputs, outputs))
         txAB1 = self.nodes[0].sendrawtransaction(signed["hex"])
 
@@ -57,18 +56,15 @@ class AbandonConflictTest(RavenTestFramework):
         nAB = next(i for i, vout in enumerate(self.nodes[0].getrawtransaction(txAB1, 1)["vout"]) if vout["value"] == Decimal("14.99998"))
 
         #Create a child tx spending AB1 and C
-        inputs = []
-        inputs.append({"txid":txAB1, "vout":nAB})
-        inputs.append({"txid":txC, "vout":nC})
-        outputs = {}
-        outputs[self.nodes[0].getnewaddress()] = Decimal("24.9996")
+        inputs = [{"txid": txAB1, "vout": nAB}, {"txid": txC, "vout": nC}]
+        outputs = {self.nodes[0].getnewaddress(): Decimal("24.9996")}
         signed2 = self.nodes[0].signrawtransaction(self.nodes[0].createrawtransaction(inputs, outputs))
         txABC2 = self.nodes[0].sendrawtransaction(signed2["hex"])
 
         # In mempool txs from self should increase balance from change
-        newbalance = self.nodes[0].getbalance()
-        assert_equal(newbalance, balance - Decimal("30") + Decimal("24.9996"))
-        balance = newbalance
+        new_balance = self.nodes[0].getbalance()
+        assert_equal(new_balance, balance - Decimal("30") + Decimal("24.9996"))
+        balance = new_balance
 
         # Restart the node with a higher min relay fee so the parent tx is no longer in mempool
         # TODO: redo with eviction
@@ -81,57 +77,55 @@ class AbandonConflictTest(RavenTestFramework):
 
         # Not in mempool txs from self should only reduce balance
         # inputs are still spent, but change not received
-        newbalance = self.nodes[0].getbalance()
-        assert_equal(newbalance, balance - Decimal("24.9996"))
+        new_balance = self.nodes[0].getbalance()
+        assert_equal(new_balance, balance - Decimal("24.9996"))
         # Unconfirmed received funds that are not in mempool, also shouldn't show
         # up in unconfirmed balance
-        unconfbalance = self.nodes[0].getunconfirmedbalance() + self.nodes[0].getbalance()
-        assert_equal(unconfbalance, newbalance)
+        unconf_balance = self.nodes[0].getunconfirmedbalance() + self.nodes[0].getbalance()
+        assert_equal(unconf_balance, new_balance)
         # Also shouldn't show up in listunspent
         assert(not txABC2 in [utxo["txid"] for utxo in self.nodes[0].listunspent(0)])
-        balance = newbalance
+        balance = new_balance
 
         # Abandon original transaction and verify inputs are available again
         # including that the child tx was also abandoned
         self.nodes[0].abandontransaction(txAB1)
-        newbalance = self.nodes[0].getbalance()
-        assert_equal(newbalance, balance + Decimal("30"))
-        balance = newbalance
+        new_balance = self.nodes[0].getbalance()
+        assert_equal(new_balance, balance + Decimal("30"))
+        balance = new_balance
 
-        # Verify that even with a low min relay fee, the tx is not reaccepted from wallet on startup once abandoned
+        # Verify that even with a low min relay fee, the tx is not re-accepted from wallet on startup once abandoned
         self.stop_node(0)
         self.start_node(0, extra_args=["-minrelaytxfee=0.00001"])
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
         assert_equal(self.nodes[0].getbalance(), balance)
 
-        # But if its received again then it is unabandoned
+        # But if its received again then it is un-abandoned
         # And since now in mempool, the change is available
         # But its child tx remains abandoned
         self.nodes[0].sendrawtransaction(signed["hex"])
-        newbalance = self.nodes[0].getbalance()
-        assert_equal(newbalance, balance - Decimal("20") + Decimal("14.99998"))
-        balance = newbalance
+        new_balance = self.nodes[0].getbalance()
+        assert_equal(new_balance, balance - Decimal("20") + Decimal("14.99998"))
+        balance = new_balance
 
-        # Send child tx again so its unabandoned
+        # Send child tx again so its un-abandoned
         self.nodes[0].sendrawtransaction(signed2["hex"])
-        newbalance = self.nodes[0].getbalance()
-        assert_equal(newbalance, balance - Decimal("10") - Decimal("14.99998") + Decimal("24.9996"))
-        balance = newbalance
+        new_balance = self.nodes[0].getbalance()
+        assert_equal(new_balance, balance - Decimal("10") - Decimal("14.99998") + Decimal("24.9996"))
+        balance = new_balance
 
         # Remove using high relay fee again
         self.stop_node(0)
         self.start_node(0, extra_args=["-minrelaytxfee=0.0001"])
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
-        newbalance = self.nodes[0].getbalance()
-        assert_equal(newbalance, balance - Decimal("24.9996"))
-        balance = newbalance
+        new_balance = self.nodes[0].getbalance()
+        assert_equal(new_balance, balance - Decimal("24.9996"))
+        balance = new_balance
 
         # Create a double spend of AB1 by spending again from only A's 10 output
         # Mine double spend from node 1
-        inputs =[]
-        inputs.append({"txid":txA, "vout":nA})
-        outputs = {}
-        outputs[self.nodes[1].getnewaddress()] = Decimal("9.998")
+        inputs = [{"txid": txA, "vout": nA}]
+        outputs = {self.nodes[1].getnewaddress(): Decimal("9.998")}
         tx = self.nodes[0].createrawtransaction(inputs, outputs)
         signed = self.nodes[0].signrawtransaction(tx)
         self.nodes[1].sendrawtransaction(signed["hex"])
@@ -141,19 +135,19 @@ class AbandonConflictTest(RavenTestFramework):
         sync_blocks(self.nodes)
 
         # Verify that B and C's 10 RVN outputs are available for spending again because AB1 is now conflicted
-        newbalance = self.nodes[0].getbalance()
-        assert_equal(newbalance, balance + Decimal("20"))
-        balance = newbalance
+        new_balance = self.nodes[0].getbalance()
+        assert_equal(new_balance, balance + Decimal("20"))
+        balance = new_balance
 
         # There is currently a minor bug around this and so this test doesn't work.  See Issue #7315
         # Invalidate the block with the double spend and B's 10 RVN output should no longer be available
         # Don't think C's should either
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
-        newbalance = self.nodes[0].getbalance()
-        #assert_equal(newbalance, balance - Decimal("10"))
+        new_balance = self.nodes[0].getbalance()
+        #assert_equal(new_balance, balance - Decimal("10"))
         self.log.info("If balance has not declined after invalidateblock then out of mempool wallet tx which is no longer")
         self.log.info("conflicted has not resumed causing its inputs to be seen as spent.  See Issue #7315")
-        self.log.info(str(balance) + " -> " + str(newbalance) + " ?")
+        self.log.info(str(balance) + " -> " + str(new_balance) + " ?")
 
 if __name__ == '__main__':
     AbandonConflictTest().main()

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test the wallet backup features.
+
+"""
+Test the wallet backup features.
 
 Test case is:
 4 nodes. 1 2 and 3 send transactions between each other,
@@ -31,11 +33,11 @@ confirm 1/2/3/4 balances are same as before.
 Shutdown again, restore using importwallet,
 and confirm again balances are correct.
 """
+
 from random import randint
 import shutil
-
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_nodes, Decimal, sync_mempools, sync_blocks, os, assert_equal)
+from test_framework.util import connect_nodes, Decimal, sync_mempools, sync_blocks, os, assert_equal
 
 class WalletBackupTest(RavenTestFramework):
     def set_test_params(self):
@@ -53,7 +55,7 @@ class WalletBackupTest(RavenTestFramework):
         self.sync_all()
 
     def one_send(self, from_node, to_address):
-        if (randint(1,2) == 1):
+        if randint(1, 2) == 1:
             amount = Decimal(randint(1,10)) / Decimal(10)
             self.nodes[from_node].sendtoaddress(to_address, amount)
 

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -3,18 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the wallet."""
+
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (connect_nodes_bi, 
-                                assert_fee_amount, 
-                                assert_equal, 
-                                assert_raises_rpc_error, 
-                                Decimal, 
-                                count_bytes, 
-                                sync_mempools, 
-                                sync_blocks, 
-                                time, 
-                                assert_array_result)
+from test_framework.util import connect_nodes_bi, assert_fee_amount, assert_equal, assert_raises_rpc_error, Decimal, count_bytes, sync_mempools, sync_blocks, time, assert_array_result
 
 class WalletTest(RavenTestFramework):
     def set_test_params(self):
@@ -48,9 +41,9 @@ class WalletTest(RavenTestFramework):
 
         self.nodes[0].generate(1)
 
-        walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['immature_balance'], 5000)
-        assert_equal(walletinfo['balance'], 0)
+        wallet_info = self.nodes[0].getwalletinfo()
+        assert_equal(wallet_info['immature_balance'], 5000)
+        assert_equal(wallet_info['balance'], 0)
 
         self.sync_all([self.nodes[0:3]])
         self.nodes[1].generate(101)
@@ -101,8 +94,8 @@ class WalletTest(RavenTestFramework):
         # but 10 will go to node2 and the rest will go to node0
         balance = self.nodes[0].getbalance()
         assert_equal({txout1['value'], txout2['value']}, {10, balance})
-        walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['immature_balance'], 0)
+        wallet_info = self.nodes[0].getwalletinfo()
+        assert_equal(wallet_info['immature_balance'], 0)
 
         # Have node0 mine a block, thus it will collect its own fee.
         self.nodes[0].generate(1)
@@ -221,7 +214,7 @@ class WalletTest(RavenTestFramework):
 
         raw_tx = self.nodes[1].createrawtransaction(inputs, outputs)
         raw_tx = raw_tx.replace("c04fbbde19", "0000000000") #replace 1111.11 with 0.0 (int32)
-        dec_raw_tx = self.nodes[1].decoderawtransaction(raw_tx)
+        self.nodes[1].decoderawtransaction(raw_tx)
         signed_raw_tx = self.nodes[1].signrawtransaction(raw_tx)
         dec_raw_tx = self.nodes[1].decoderawtransaction(signed_raw_tx['hex'])
         zero_value_txid = dec_raw_tx['txid']
@@ -280,7 +273,7 @@ class WalletTest(RavenTestFramework):
         sync_blocks(self.nodes[0:3])
         node_2_bal += 2
 
-        #tx should be added to balance because after restarting the nodes tx should be broadcastet
+        #tx should be added to balance because after restarting the nodes tx should be broadcasted
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
 
         #send a tx with value in a string (PR#6380 +)
@@ -344,7 +337,7 @@ class WalletTest(RavenTestFramework):
         blocks = self.nodes[0].generate(2)
         self.sync_all([self.nodes[0:3]])
         balance_nodes = [self.nodes[i].getbalance() for i in range(3)]
-        block_count = self.nodes[0].getblockcount()
+        self.nodes[0].getblockcount()
 
         # Check modes:
         #   - True: unicode escaped as \u....
@@ -381,11 +374,11 @@ class WalletTest(RavenTestFramework):
 
         # Get all non-zero utxos together
         chain_addrs = [self.nodes[0].getnewaddress(), self.nodes[0].getnewaddress()]
-        singletxid = self.nodes[0].sendtoaddress(chain_addrs[0], self.nodes[0].getbalance(), "", "", True)
+        single_tx_id = self.nodes[0].sendtoaddress(chain_addrs[0], self.nodes[0].getbalance(), "", "", True)
         self.nodes[0].generate(1)
         node0_balance = self.nodes[0].getbalance()
         # Split into two chains
-        rawtx = self.nodes[0].createrawtransaction([{"txid":singletxid, "vout":0}], {chain_addrs[0]:node0_balance/2-Decimal('0.01'), chain_addrs[1]:node0_balance/2-Decimal('0.01')})
+        rawtx = self.nodes[0].createrawtransaction([{"txid":single_tx_id, "vout":0}], {chain_addrs[0]:node0_balance/2-Decimal('0.01'), chain_addrs[1]:node0_balance/2-Decimal('0.01')})
         signedtx = self.nodes[0].signrawtransaction(rawtx)
         self.nodes[0].sendrawtransaction(signedtx["hex"])
         self.nodes[0].generate(1)

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test the bumpfee RPC.
+
+"""
+Test the bumpfee RPC.
 
 Verifies that the bumpfee RPC creates replacement transactions successfully when
 its preconditions are met, and returns appropriate errors in other cases.
@@ -15,20 +17,12 @@ added in the future, they should try to follow the same convention and not
 make assumptions about execution order.
 """
 
+import io
 from feature_segwit import send_to_witness
 from test_framework.test_framework import RavenTestFramework
-from test_framework import blocktools
+from test_framework.blocktools import create_block, create_coinbase
 from test_framework.mininode import CTransaction
-from test_framework.util import (connect_nodes_bi, 
-                                assert_equal, 
-                                Decimal, 
-                                sync_mempools, 
-                                assert_raises_rpc_error, 
-                                assert_greater_than, 
-                                bytes_to_hex_str, 
-                                hex_str_to_bytes)
-
-import io
+from test_framework.util import connect_nodes_bi, assert_equal, Decimal, sync_mempools, assert_raises_rpc_error, assert_greater_than, bytes_to_hex_str, hex_str_to_bytes
 
 # Sequence number that is BIP 125 opt-in and BIP 68-compliant
 BIP125_SEQUENCE_NUMBER = 0xfffffffd
@@ -72,8 +66,8 @@ class BumpFeeTest(RavenTestFramework):
         dest_address = peer_node.getnewaddress()
         test_simple_bumpfee_succeeds(rbf_node, peer_node, dest_address)
         test_segwit_bumpfee_succeeds(rbf_node, dest_address)
-        test_nonrbf_bumpfee_fails(peer_node, dest_address)
-        test_notmine_bumpfee_fails(rbf_node, peer_node, dest_address)
+        test_non_rbf_bumpfee_fails(peer_node, dest_address)
+        test_not_mine_bumpfee_fails(rbf_node, peer_node, dest_address)
         test_bumpfee_with_descendant_fails(rbf_node, rbf_node_address, dest_address)
         test_small_output_fails(rbf_node, dest_address)
         test_dust_to_fee(rbf_node, dest_address)
@@ -87,25 +81,25 @@ class BumpFeeTest(RavenTestFramework):
 
 
 def test_simple_bumpfee_succeeds(rbf_node, peer_node, dest_address):
-    rbfid = spend_one_input(rbf_node, dest_address)
-    rbftx = rbf_node.gettransaction(rbfid)
+    rbf_id = spend_one_input(rbf_node, dest_address)
+    rbf_tx = rbf_node.gettransaction(rbf_id)
     sync_mempools((rbf_node, peer_node))
-    assert rbfid in rbf_node.getrawmempool() and rbfid in peer_node.getrawmempool()
-    bumped_tx = rbf_node.bumpfee(rbfid)
+    assert rbf_id in rbf_node.getrawmempool() and rbf_id in peer_node.getrawmempool()
+    bumped_tx = rbf_node.bumpfee(rbf_id)
     assert_equal(bumped_tx["errors"], [])
-    assert bumped_tx["fee"] - abs(rbftx["fee"]) > 0
+    assert bumped_tx["fee"] - abs(rbf_tx["fee"]) > 0
     # check that bumped_tx propagates, original tx was evicted and has a wallet conflict
     sync_mempools((rbf_node, peer_node))
     assert bumped_tx["txid"] in rbf_node.getrawmempool()
     assert bumped_tx["txid"] in peer_node.getrawmempool()
-    assert rbfid not in rbf_node.getrawmempool()
-    assert rbfid not in peer_node.getrawmempool()
-    oldwtx = rbf_node.gettransaction(rbfid)
-    assert len(oldwtx["walletconflicts"]) > 0
+    assert rbf_id not in rbf_node.getrawmempool()
+    assert rbf_id not in peer_node.getrawmempool()
+    old_w_tx = rbf_node.gettransaction(rbf_id)
+    assert len(old_w_tx["walletconflicts"]) > 0
     # check wallet transaction replaces and replaced_by values
-    bumpedwtx = rbf_node.gettransaction(bumped_tx["txid"])
-    assert_equal(oldwtx["replaced_by_txid"], bumped_tx["txid"])
-    assert_equal(bumpedwtx["replaces_txid"], rbfid)
+    bumped_w_tx = rbf_node.gettransaction(bumped_tx["txid"])
+    assert_equal(old_w_tx["replaced_by_txid"], bumped_tx["txid"])
+    assert_equal(bumped_w_tx["replaces_txid"], rbf_id)
 
 
 def test_segwit_bumpfee_succeeds(rbf_node, dest_address):
@@ -115,7 +109,7 @@ def test_segwit_bumpfee_succeeds(rbf_node, dest_address):
     segwit_in = next(u for u in rbf_node.listunspent() if u["amount"] == Decimal("0.001"))
     segwit_out = rbf_node.validateaddress(rbf_node.getnewaddress())
     rbf_node.addwitnessaddress(segwit_out["address"])
-    segwitid = send_to_witness(
+    segwit_id = send_to_witness(
         use_p2wsh=False,
         node=rbf_node,
         utxo=segwit_in,
@@ -124,30 +118,30 @@ def test_segwit_bumpfee_succeeds(rbf_node, dest_address):
         amount=Decimal("0.0009"),
         sign=True)
 
-    rbfraw = rbf_node.createrawtransaction([{
-        'txid': segwitid,
+    rbf_raw = rbf_node.createrawtransaction([{
+        'txid': segwit_id,
         'vout': 0,
         "sequence": BIP125_SEQUENCE_NUMBER
     }], {dest_address: Decimal("0.0005"),
          rbf_node.getrawchangeaddress(): Decimal("0.0003")})
-    rbfsigned = rbf_node.signrawtransaction(rbfraw)
-    rbfid = rbf_node.sendrawtransaction(rbfsigned["hex"])
-    assert rbfid in rbf_node.getrawmempool()
+    rbf_signed = rbf_node.signrawtransaction(rbf_raw)
+    rbf_id = rbf_node.sendrawtransaction(rbf_signed["hex"])
+    assert rbf_id in rbf_node.getrawmempool()
 
-    bumped_tx = rbf_node.bumpfee(rbfid)
+    bumped_tx = rbf_node.bumpfee(rbf_id)
     assert bumped_tx["txid"] in rbf_node.getrawmempool()
-    assert rbfid not in rbf_node.getrawmempool()
+    assert rbf_id not in rbf_node.getrawmempool()
 
 
-def test_nonrbf_bumpfee_fails(peer_node, dest_address):
+def test_non_rbf_bumpfee_fails(peer_node, dest_address):
     # cannot replace a non RBF transaction (from node which did not enable RBF)
-    not_rbfid = peer_node.sendtoaddress(dest_address, Decimal("0.00090000"))
-    assert_raises_rpc_error(-4, "not BIP 125 replaceable", peer_node.bumpfee, not_rbfid)
+    not_rbf_id = peer_node.sendtoaddress(dest_address, Decimal("0.00090000"))
+    assert_raises_rpc_error(-4, "not BIP 125 replaceable", peer_node.bumpfee, not_rbf_id)
 
 
-def test_notmine_bumpfee_fails(rbf_node, peer_node, dest_address):
+def test_not_mine_bumpfee_fails(rbf_node, peer_node, dest_address):
     # cannot bump fee unless the tx has only inputs that we own.
-    # here, the rbftx has a peer_node coin and then adds a rbf_node input
+    # here, the rbf_tx has a peer_node coin and then adds a rbf_node input
     # Note that this test depends upon the RPC code checking input ownership prior to change outputs
     # (since it can't use fundrawtransaction, it lacks a proper change output)
     utxos = [node.listunspent()[-1] for node in (rbf_node, peer_node)]
@@ -161,9 +155,9 @@ def test_notmine_bumpfee_fails(rbf_node, peer_node, dest_address):
     rawtx = rbf_node.createrawtransaction(inputs, {dest_address: output_val})
     signedtx = rbf_node.signrawtransaction(rawtx)
     signedtx = peer_node.signrawtransaction(signedtx["hex"])
-    rbfid = rbf_node.sendrawtransaction(signedtx["hex"])
+    rbf_id = rbf_node.sendrawtransaction(signedtx["hex"])
     assert_raises_rpc_error(-4, "Transaction contains inputs that don't belong to this wallet",
-                            rbf_node.bumpfee, rbfid)
+                            rbf_node.bumpfee, rbf_id)
 
 
 def test_bumpfee_with_descendant_fails(rbf_node, rbf_node_address, dest_address):
@@ -178,31 +172,31 @@ def test_bumpfee_with_descendant_fails(rbf_node, rbf_node_address, dest_address)
 
 def test_small_output_fails(rbf_node, dest_address):
     # cannot bump fee with a too-small output
-    rbfid = spend_one_input(rbf_node, dest_address)
-    rbf_node.bumpfee(rbfid, {"totalFee": 50000})
+    rbf_id = spend_one_input(rbf_node, dest_address)
+    rbf_node.bumpfee(rbf_id, {"totalFee": 50000})
 
-    rbfid = spend_one_input(rbf_node, dest_address)
-    assert_raises_rpc_error(-4, "Change output is too small", rbf_node.bumpfee, rbfid, {"totalFee": 50001})
+    rbf_id = spend_one_input(rbf_node, dest_address)
+    assert_raises_rpc_error(-4, "Change output is too small", rbf_node.bumpfee, rbf_id, {"totalFee": 50001})
 
 
 def test_dust_to_fee(rbf_node, dest_address):
     # check that if output is reduced to dust, it will be converted to fee
     # the bumped tx sets fee=49,900, but it converts to 50,000
-    rbfid = spend_one_input(rbf_node, dest_address)
-    fulltx = rbf_node.getrawtransaction(rbfid, 1)
-    bumped_tx = rbf_node.bumpfee(rbfid, {"totalFee": 49900})
+    rbf_id = spend_one_input(rbf_node, dest_address)
+    full_tx = rbf_node.getrawtransaction(rbf_id, 1)
+    bumped_tx = rbf_node.bumpfee(rbf_id, {"totalFee": 49900})
     full_bumped_tx = rbf_node.getrawtransaction(bumped_tx["txid"], 1)
     assert_equal(bumped_tx["fee"], Decimal("0.00050000"))
-    assert_equal(len(fulltx["vout"]), 2)
+    assert_equal(len(full_tx["vout"]), 2)
     assert_equal(len(full_bumped_tx["vout"]), 1)  # change output is eliminated
 
 
 def test_settxfee(rbf_node, dest_address):
     # check that bumpfee reacts correctly to the use of settxfee (paytxfee)
-    rbfid = spend_one_input(rbf_node, dest_address)
+    rbf_id = spend_one_input(rbf_node, dest_address)
     requested_feerate = Decimal("0.00025000")
     rbf_node.settxfee(requested_feerate)
-    bumped_tx = rbf_node.bumpfee(rbfid)
+    bumped_tx = rbf_node.bumpfee(rbf_id)
     actual_feerate = bumped_tx["fee"] * 1000 / rbf_node.getrawtransaction(bumped_tx["txid"], True)["size"]
     # Assert that the difference between the requested feerate and the actual
     # feerate of the bumped transaction is small.
@@ -212,69 +206,69 @@ def test_settxfee(rbf_node, dest_address):
 
 def test_rebumping(rbf_node, dest_address):
     # check that re-bumping the original tx fails, but bumping the bumper succeeds
-    rbfid = spend_one_input(rbf_node, dest_address)
-    bumped = rbf_node.bumpfee(rbfid, {"totalFee": 2000})
-    assert_raises_rpc_error(-4, "already bumped", rbf_node.bumpfee, rbfid, {"totalFee": 3000})
+    rbf_id = spend_one_input(rbf_node, dest_address)
+    bumped = rbf_node.bumpfee(rbf_id, {"totalFee": 2000})
+    assert_raises_rpc_error(-4, "already bumped", rbf_node.bumpfee, rbf_id, {"totalFee": 3000})
     rbf_node.bumpfee(bumped["txid"], {"totalFee": 3000})
 
 
 def test_rebumping_not_replaceable(rbf_node, dest_address):
     # check that re-bumping a non-replaceable bump tx fails
-    rbfid = spend_one_input(rbf_node, dest_address)
-    bumped = rbf_node.bumpfee(rbfid, {"totalFee": 10000, "replaceable": False})
+    rbf_id = spend_one_input(rbf_node, dest_address)
+    bumped = rbf_node.bumpfee(rbf_id, {"totalFee": 10000, "replaceable": False})
     assert_raises_rpc_error(-4, "Transaction is not BIP 125 replaceable", rbf_node.bumpfee, bumped["txid"],
                             {"totalFee": 20000})
 
 
 def test_unconfirmed_not_spendable(rbf_node, rbf_node_address):
     # check that unconfirmed outputs from bumped transactions are not spendable
-    rbfid = spend_one_input(rbf_node, rbf_node_address)
-    rbftx = rbf_node.gettransaction(rbfid)["hex"]
-    assert rbfid in rbf_node.getrawmempool()
-    bumpid = rbf_node.bumpfee(rbfid)["txid"]
-    assert bumpid in rbf_node.getrawmempool()
-    assert rbfid not in rbf_node.getrawmempool()
+    rbf_id = spend_one_input(rbf_node, rbf_node_address)
+    rbf_tx = rbf_node.gettransaction(rbf_id)["hex"]
+    assert rbf_id in rbf_node.getrawmempool()
+    bump_id = rbf_node.bumpfee(rbf_id)["txid"]
+    assert bump_id in rbf_node.getrawmempool()
+    assert rbf_id not in rbf_node.getrawmempool()
 
     # check that outputs from the bump transaction are not spendable
     # due to the replaces_txid check in CWallet::AvailableCoins
-    assert_equal([t for t in rbf_node.listunspent(minconf=0, include_unsafe=False) if t["txid"] == bumpid], [])
+    assert_equal([t for t in rbf_node.listunspent(minconf=0, include_unsafe=False) if t["txid"] == bump_id], [])
 
     # submit a block with the rbf tx to clear the bump tx out of the mempool,
     # then call abandon to make sure the wallet doesn't attempt to resubmit the
     # bump tx, then invalidate the block so the rbf tx will be put back in the
     # mempool. this makes it possible to check whether the rbf tx outputs are
     # spendable before the rbf tx is confirmed.
-    block = submit_block_with_tx(rbf_node, rbftx)
-    rbf_node.abandontransaction(bumpid)
+    block = submit_block_with_tx(rbf_node, rbf_tx)
+    rbf_node.abandontransaction(bump_id)
     rbf_node.invalidateblock(block.hash)
-    assert bumpid not in rbf_node.getrawmempool()
-    assert rbfid in rbf_node.getrawmempool()
+    assert bump_id not in rbf_node.getrawmempool()
+    assert rbf_id in rbf_node.getrawmempool()
 
     # check that outputs from the rbf tx are not spendable before the
     # transaction is confirmed, due to the replaced_by_txid check in
     # CWallet::AvailableCoins
-    assert_equal([t for t in rbf_node.listunspent(minconf=0, include_unsafe=False) if t["txid"] == rbfid], [])
+    assert_equal([t for t in rbf_node.listunspent(minconf=0, include_unsafe=False) if t["txid"] == rbf_id], [])
 
     # check that the main output from the rbf tx is spendable after confirmed
     rbf_node.generate(1)
     assert_equal(
         sum(1 for t in rbf_node.listunspent(minconf=0, include_unsafe=False)
-            if t["txid"] == rbfid and t["address"] == rbf_node_address and t["spendable"]), 1)
+            if t["txid"] == rbf_id and t["address"] == rbf_node_address and t["spendable"]), 1)
 
 
 def test_bumpfee_metadata(rbf_node, dest_address):
-    rbfid = rbf_node.sendtoaddress(dest_address, Decimal("0.00100000"), "comment value", "to value")
-    bumped_tx = rbf_node.bumpfee(rbfid)
+    rbf_id = rbf_node.sendtoaddress(dest_address, Decimal("0.00100000"), "comment value", "to value")
+    bumped_tx = rbf_node.bumpfee(rbf_id)
     bumped_wtx = rbf_node.gettransaction(bumped_tx["txid"])
     assert_equal(bumped_wtx["comment"], "comment value")
     assert_equal(bumped_wtx["to"], "to value")
 
 
 def test_locked_wallet_fails(rbf_node, dest_address):
-    rbfid = spend_one_input(rbf_node, dest_address)
+    rbf_id = spend_one_input(rbf_node, dest_address)
     rbf_node.walletlock()
     assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first.",
-                            rbf_node.bumpfee, rbfid)
+                            rbf_node.bumpfee, rbf_id)
 
 
 def spend_one_input(node, dest_address):
@@ -295,7 +289,7 @@ def submit_block_with_tx(node, tx):
     tip = node.getbestblockhash()
     height = node.getblockcount() + 1
     block_time = node.getblockheader(tip)["mediantime"] + 1
-    block = blocktools.create_block(int(tip, 16), blocktools.create_coinbase(height), block_time)
+    block = create_block(int(tip, 16), create_coinbase(height), block_time)
     block.vtx.append(ctx)
     block.rehash()
     block.hashMerkleRoot = block.calc_merkle_root()

--- a/test/functional/wallet_coinbase_category.py
+++ b/test/functional/wallet_coinbase_category.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2018 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Test coinbase transactions return the correct categories.
+Tests listtransactions, listsinceblock, and gettransaction.
+"""
+
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import assert_array_result
+
+class CoinbaseCategoryTest(RavenTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def assert_category(self, category, address, txid, skip):
+        assert_array_result(self.nodes[0].listtransactions(skip=skip),
+                            {"address": address},
+                            {"category": category})
+        assert_array_result(self.nodes[0].listsinceblock()["transactions"],
+                            {"address": address},
+                            {"category": category})
+        assert_array_result(self.nodes[0].gettransaction(txid)["details"],
+                            {"address": address},
+                            {"category": category})
+
+    def run_test(self):
+        # Generate one block to an address
+        address = self.nodes[0].getnewaddress()
+        self.nodes[0].generatetoaddress(1, address)
+        hash_data = self.nodes[0].getbestblockhash()
+        txid = self.nodes[0].getblock(hash_data)["tx"][0]
+
+        # Coinbase transaction is immature after 1 confirmation
+        self.assert_category("immature", address, txid, 0)
+
+        # Mine another 99 blocks on top
+        self.nodes[0].generate(99)
+        # Coinbase transaction is still immature after 100 confirmations
+        self.assert_category("immature", address, txid, 99)
+
+        # Mine one more block
+        self.nodes[0].generate(1)
+        # Coinbase transaction is now matured, so category is "generate"
+        self.assert_category("generate", address, txid, 100)
+
+        # Orphan block that paid to address
+        self.nodes[0].invalidateblock(hash_data)
+        # Coinbase transaction is now orphaned
+        self.assert_category("orphan", address, txid, 100)
+
+if __name__ == '__main__':
+    CoinbaseCategoryTest().main()

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2019 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import time
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.blocktools import REGTEST_GENISIS_BLOCK_TIME
+
+class CreateTxWalletTest(RavenTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def run_test(self):
+        self.log.info('Create some old blocks')
+        self.nodes[0].setmocktime(REGTEST_GENISIS_BLOCK_TIME)
+        self.nodes[0].generate(200)
+        self.nodes[0].setmocktime(0)
+
+        self.test_anti_fee_sniping()
+        self.test_tx_size_too_large()
+
+    def test_anti_fee_sniping(self):
+        self.log.info('Check that we have some (old) blocks and that anti-fee-sniping is disabled')
+        assert_equal(self.nodes[0].getblockchaininfo()['blocks'], 200)
+        tx = self.nodes[0].decoderawtransaction(self.nodes[0].gettransaction(self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1))['hex'])
+        attempts = 0
+        while tx['locktime'] < 200:
+            # for some reason sometimes we don't get the correct locktime on first attempt, retry...
+            tx = self.nodes[0].decoderawtransaction(self.nodes[0].gettransaction(self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1))['hex'])
+            if attempts == 20:
+                self.log.debug("Exceeded ~10 seconds waiting for tx locktime == 200.")
+                break
+            time.sleep(0.5)
+            attempts += 1
+        assert_equal(tx['locktime'], 200)
+
+        self.log.info('Check that anti-fee-sniping is enabled when we mine a recent block')
+        self.nodes[0].generate(1)
+        tx = self.nodes[0].decoderawtransaction(self.nodes[0].gettransaction(self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1))['hex'])
+        assert 0 < tx['locktime'] <= 201
+
+    def test_tx_size_too_large(self):
+        # More than 10kB of outputs, so that we hit -maxtxfee with a high feerate
+        outputs = {self.nodes[0].getnewaddress(): 0.000025 for _ in range(400)}
+        raw_tx = self.nodes[0].createrawtransaction(inputs=[], outputs=outputs)
+
+        self.log.info('Check maxtxfee in combination with -minrelaytxfee=0.01, -maxtxfee=0.1')
+        self.restart_node(0, extra_args=['-minrelaytxfee=0.01', '-maxtxfee=0.1'])
+        assert_raises_rpc_error(-6, "Transaction too large for fee policy", lambda: self.nodes[0].sendmany(fromaccount="", amounts=outputs),)
+        assert_raises_rpc_error(-4, "Transaction too large for fee policy", lambda: self.nodes[0].fundrawtransaction(hexstring=raw_tx),)
+
+        self.log.info('Check maxtxfee in combination with -mintxfee=0.01, -maxtxfee=0.1')
+        self.restart_node(0, extra_args=['-mintxfee=0.01', '-maxtxfee=0.1'])
+        assert_raises_rpc_error(-6, "Transaction too large for fee policy", lambda: self.nodes[0].sendmany(fromaccount="", amounts=outputs),)
+        assert_raises_rpc_error(-4, "Transaction too large for fee policy", lambda: self.nodes[0].fundrawtransaction(hexstring=raw_tx),)
+
+        self.log.info('Check maxtxfee in combination with -paytxfee=0.01, -maxtxfee=0.1')
+        self.restart_node(0, extra_args=['-paytxfee=0.01', '-maxtxfee=0.1'])
+        assert_raises_rpc_error(-6, "Transaction too large for fee policy", lambda: self.nodes[0].sendmany(fromaccount="", amounts=outputs),)
+        assert_raises_rpc_error(-4, "Transaction too large for fee policy", lambda: self.nodes[0].fundrawtransaction(hexstring=raw_tx),)
+
+
+        self.log.info('Check maxtxfee in combination with settxfee')
+        self.restart_node(0, extra_args=['-maxtxfee=0.1'])
+        self.nodes[0].settxfee(0.01)
+        assert_raises_rpc_error(-6, "Transaction too large for fee policy", lambda: self.nodes[0].sendmany(fromaccount="", amounts=outputs),)
+        assert_raises_rpc_error(-4, "Transaction too large for fee policy", lambda: self.nodes[0].fundrawtransaction(hexstring=raw_tx),)
+        self.nodes[0].settxfee(0)
+
+
+if __name__ == '__main__':
+    CreateTxWalletTest().main()

--- a/test/functional/wallet_disable.py
+++ b/test/functional/wallet_disable.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test a node with the -disablewallet option.
+
+"""
+Test a node with the -disablewallet option.
 
 - Test that validateaddress RPC works when running with -disablewallet
 - Test that it is not possible to mine to an invalid address.

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -3,13 +3,12 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the dumpwallet RPC."""
 
 import os
-
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, assert_raises_rpc_error)
-
+from test_framework.util import assert_equal, assert_raises_rpc_error
 
 def read_dump(file_name, addrs, hd_master_addr_old):
     """
@@ -86,8 +85,7 @@ class WalletDumpTest(RavenTestFramework):
         result = self.nodes[0].dumpwallet(tmpdir + "/node0/wallet.unencrypted.dump")
         assert_equal(result['filename'], os.path.abspath(tmpdir + "/node0/wallet.unencrypted.dump"))
 
-        found_addr, found_addr_chg, found_addr_rsv, hd_master_addr_unenc = \
-            read_dump(tmpdir + "/node0/wallet.unencrypted.dump", addrs, None)
+        found_addr, found_addr_chg, found_addr_rsv, hd_master_addr_unenc = read_dump(tmpdir + "/node0/wallet.unencrypted.dump", addrs, None)
         assert_equal(found_addr, test_addr_count)  # all keys must be in the dump
         assert_equal(found_addr_chg, 50)  # 50 blocks where mined
         assert_equal(found_addr_rsv, 90*2) # 90 keys plus 100% internal keys
@@ -100,8 +98,7 @@ class WalletDumpTest(RavenTestFramework):
         self.nodes[0].keypoolrefill()
         self.nodes[0].dumpwallet(tmpdir + "/node0/wallet.encrypted.dump")
 
-        found_addr, found_addr_chg, found_addr_rsv, _ = \
-            read_dump(tmpdir + "/node0/wallet.encrypted.dump", addrs, hd_master_addr_unenc)
+        found_addr, found_addr_chg, found_addr_rsv, _ = read_dump(tmpdir + "/node0/wallet.encrypted.dump", addrs, hd_master_addr_unenc)
         assert_equal(found_addr, test_addr_count)
         assert_equal(found_addr_chg, 90*2 + 50)  # old reserve keys are marked as change now
         assert_equal(found_addr_rsv, 90*2) 

--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -3,12 +3,12 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test Wallet encryption"""
 
 import time
-
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, assert_raises_rpc_error)
+from test_framework.util import assert_equal, assert_raises_rpc_error
 
 class WalletEncryptionTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test wallet group functionality."""
+
+from test_framework.test_framework import RavenTestFramework
+from test_framework.mininode import CTransaction, from_hex, to_hex
+from test_framework.util import assert_approx, assert_equal
+
+class WalletGroupTest(RavenTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+        self.rpc_timeout = 120
+
+
+    def run_test(self):
+        # Mine some coins
+        self.nodes[0].generate(110)
+
+        # Get some addresses from the two nodes
+        addr1 = [self.nodes[1].getnewaddress() for _ in range(3)]
+        addr2 = [self.nodes[2].getnewaddress() for _ in range(3)]
+        addrs = addr1 + addr2
+
+        # Send 1 + 0.5 coin to each address
+        [self.nodes[0].sendtoaddress(addr, 1.0) for addr in addrs]
+        [self.nodes[0].sendtoaddress(addr, 0.5) for addr in addrs]
+
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # For each node, send 0.2 coins back to 0;
+        # - node[1] should pick one 0.5 UTXO and leave the rest
+        # - node[2] should pick one (1.0 + 0.5) UTXO group corresponding to a
+        #   given address, and leave the rest
+        txid1 = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
+        tx1 = self.nodes[1].getrawtransaction(txid1, True)
+        # txid1 should have 1 input and 2 outputs
+        assert_equal(1, len(tx1["vin"]))
+        assert_equal(2, len(tx1["vout"]))
+        # one output should be 0.2, the other should be ~0.3
+        v = [vout["value"] for vout in tx1["vout"]]
+        v.sort()
+        assert_approx(v[0], 0.2)
+        assert_approx(v[1], 0.3, 0.01)
+
+        txid2 = self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
+        tx2 = self.nodes[2].getrawtransaction(txid2, True)
+        # txid2 should have 1 inputs and 2 outputs
+        assert_equal(1, len(tx2["vin"]))
+        assert_equal(2, len(tx2["vout"]))
+        # one output should be 0.2, the other should be ~0.3
+        v = [vout["value"] for vout in tx2["vout"]]
+        v.sort()
+        assert_approx(v[0], 0.2)
+        assert_approx(v[1], 0.3, 0.1)
+
+        # Empty out node2's wallet
+        self.nodes[2].sendtoaddress(address=self.nodes[0].getnewaddress(), amount=self.nodes[2].getbalance(), subtractfeefromamount=True)
+        self.sync_all()
+        self.nodes[0].generate(1)
+
+        # Fill node2's wallet with 10000 outputs corresponding to the same
+        # scriptPubKey
+        for i in range(5):
+            inputs = [{"txid":"0"*64, "vout":0}]
+            outputs = {addr2[0]: 0.05}
+            raw_tx = self.nodes[0].createrawtransaction(inputs, outputs)
+            tx = from_hex(CTransaction(), raw_tx)
+            tx.vin = []
+            tx.vout = [tx.vout[0]] * 2000
+            funded_tx = self.nodes[0].fundrawtransaction(to_hex(tx))
+            signed_tx = self.nodes[0].signrawtransaction(funded_tx['hex'])
+            self.nodes[0].sendrawtransaction(signed_tx['hex'])
+            self.nodes[0].generate(1)
+
+        self.sync_all()
+
+        # Check that we can create a transaction that only requires ~100 of our
+        # utxos, without pulling in all outputs and creating a transaction that
+        # is way too big.
+        assert self.nodes[2].sendtoaddress(address=addr2[0], amount=5)
+
+if __name__ == '__main__':
+    WalletGroupTest().main ()

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -3,12 +3,13 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test Hierarchical Deterministic wallet function."""
 
-from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, connect_nodes_bi)
 import shutil
 import os
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import assert_equal, connect_nodes_bi
 
 class WalletHDTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test wallet import RPCs.
+
+"""
+Test wallet import RPCs.
 
 Test rescan behavior of importaddress, importpubkey, importprivkey, and
 importmulti RPCs with different types of keys and rescan options.
@@ -20,18 +22,21 @@ importing nodes pick up the new transactions regardless of whether rescans
 happened previously.
 """
 
-from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_raises_rpc_error, connect_nodes, sync_blocks, assert_equal, set_node_times)
-
 import collections
 import enum
 import itertools
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import assert_raises_rpc_error, connect_nodes, sync_blocks, assert_equal, set_node_times
 
+# noinspection PyArgumentList
 Call = enum.Enum("Call", "single multi")
+# noinspection PyArgumentList
 Data = enum.Enum("Data", "address pub priv")
+# noinspection PyArgumentList
 Rescan = enum.Enum("Rescan", "no yes late_timestamp")
 
 
+# noinspection PyUnboundLocalVariable,PyUnresolvedReferences
 class Variant(collections.namedtuple("Variant", "call data rescan prune")):
     """Helper for importing one key and verifying scanned transactions."""
 

--- a/test/functional/wallet_import_with_label.py
+++ b/test/functional/wallet_import_with_label.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Test the behavior of RPC importprivkey on set and unset labels of
+addresses.
+It tests different cases in which an address is imported with importaddress
+with or without a label and then its private key is imported with importprivkey
+with and without a label.
+"""
+
+from test_framework.test_framework import RavenTestFramework
+from test_framework.wallet_util import test_address
+
+class ImportWithLabel(RavenTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        """Main test logic"""
+
+        self.log.info("Test importaddress with label and importprivkey without label.")
+        self.log.info("Import a watch-only address with a label.")
+        address = self.nodes[0].getnewaddress()
+        label = "Test Label"
+        self.nodes[1].importaddress(address, label)
+        test_address(self.nodes[1], address, iswatchonly=True, ismine=False, account=label)
+
+        self.log.info("Import the watch-only address's private key without a label and...")
+        self.log.info("the address should keep its label.")
+        priv_key = self.nodes[0].dumpprivkey(address)
+        self.nodes[1].importprivkey(priv_key)
+        #test_address(self.nodes[1], address, account=label)
+
+        self.log.info("Test importaddress without label and importprivkey with label.")
+        self.log.info("Import a watch-only address without a label.")
+        address2 = self.nodes[0].getnewaddress()
+        self.nodes[1].importaddress(address2)
+        test_address(self.nodes[1], address2, iswatchonly=True, ismine=False, account="")
+
+        self.log.info( "Import the watch-only address's private key with a label and...")
+        self.log.info("the address should have its label updated.")
+        priv_key2 = self.nodes[0].dumpprivkey(address2)
+        label2 = "Test Label 2"
+        self.nodes[1].importprivkey(priv_key2, label2)
+        test_address(self.nodes[1], address2, account=label2)
+
+        self.log.info("Test importaddress with label and importprivkey with label.")
+        self.log.info("Import a watch-only address with a label.")
+        address3 = self.nodes[0].getnewaddress()
+        label3_addr = "Test Label 3 for importaddress"
+        self.nodes[1].importaddress(address3, label3_addr)
+        test_address(self.nodes[1], address3, iswatchonly=True, ismine=False, account=label3_addr)
+
+        self.log.info("Import the watch-only address's private key with a label and...")
+        self.log.info("the address should have its label updated.")
+        priv_key3 = self.nodes[0].dumpprivkey(address3)
+        label3_priv = "Test Label 3 for importprivkey"
+        self.nodes[1].importprivkey(priv_key3, label3_priv)
+        test_address(self.nodes[1], address3, account=label3_priv)
+
+        self.log.info("Test importprivkey won't label new dests with the same label...")
+        self.log.info("as others labeled dests for the same key.")
+        self.log.info("Import a watch-only address with a label.")
+        address4 = self.nodes[0].getnewaddress("")
+        label4_addr = "Test Label 4 for importaddress"
+        self.nodes[1].importaddress(address4, label4_addr)
+        test_address(self.nodes[1], address4, iswatchonly=True, ismine=False, account=label4_addr)
+
+        self.log.info("Import the watch-only address's private key without a label and...")
+        self.log.info("New destinations for the key should have an empty label.")
+        self.log.info("New destinations for the key should have an empty label.")
+        priv_key4 = self.nodes[0].dumpprivkey(address4)
+        self.nodes[1].importprivkey(priv_key4)
+        embedded_addr = self.nodes[1].validateaddress(address4)['address']
+        test_address(self.nodes[1], embedded_addr, account="")
+
+        self.stop_nodes()
+
+
+if __name__ == "__main__":
+    ImportWithLabel().main()

--- a/test/functional/wallet_importmulti.py
+++ b/test/functional/wallet_importmulti.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the importmulti RPC."""
+
 from test_framework.test_framework import RavenTestFramework
 from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error
 
@@ -246,9 +248,9 @@ class ImportMultiTest (RavenTestFramework):
         assert_equal(address_assert['isscript'], True)
         assert_equal(address_assert['iswatchonly'], True)
         assert_equal(address_assert['timestamp'], timestamp)
-        p2shunspent = self.nodes[1].listunspent(0,999999, [multi_sig_script['address']])[0]
-        assert_equal(p2shunspent['spendable'], False)
-        assert_equal(p2shunspent['solvable'], False)
+        p2sh_unspent = self.nodes[1].listunspent(0,999999, [multi_sig_script['address']])[0]
+        assert_equal(p2sh_unspent['spendable'], False)
+        assert_equal(p2sh_unspent['solvable'], False)
 
 
         # P2SH + Redeem script
@@ -257,7 +259,7 @@ class ImportMultiTest (RavenTestFramework):
         sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
         self.nodes[1].generate(100)
-        transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
+        self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
 
@@ -273,9 +275,9 @@ class ImportMultiTest (RavenTestFramework):
         address_assert = self.nodes[1].validateaddress(multi_sig_script['address'])
         assert_equal(address_assert['timestamp'], timestamp)
 
-        p2shunspent = self.nodes[1].listunspent(0,999999, [multi_sig_script['address']])[0]
-        assert_equal(p2shunspent['spendable'], False)
-        assert_equal(p2shunspent['solvable'], True)
+        p2sh_unspent = self.nodes[1].listunspent(0,999999, [multi_sig_script['address']])[0]
+        assert_equal(p2sh_unspent['spendable'], False)
+        assert_equal(p2sh_unspent['solvable'], True)
 
 
         # P2SH + Redeem script + Private Keys + !Watchonly
@@ -284,7 +286,7 @@ class ImportMultiTest (RavenTestFramework):
         sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
         self.nodes[1].generate(100)
-        transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
+        self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
 
@@ -301,9 +303,9 @@ class ImportMultiTest (RavenTestFramework):
         address_assert = self.nodes[1].validateaddress(multi_sig_script['address'])
         assert_equal(address_assert['timestamp'], timestamp)
 
-        p2shunspent = self.nodes[1].listunspent(0,999999, [multi_sig_script['address']])[0]
-        assert_equal(p2shunspent['spendable'], False)
-        assert_equal(p2shunspent['solvable'], True)
+        p2sh_unspent = self.nodes[1].listunspent(0,999999, [multi_sig_script['address']])[0]
+        assert_equal(p2sh_unspent['spendable'], False)
+        assert_equal(p2sh_unspent['solvable'], True)
 
         # P2SH + Redeem script + Private Keys + Watchonly
         sig_address_1 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
@@ -311,7 +313,7 @@ class ImportMultiTest (RavenTestFramework):
         sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
         self.nodes[1].generate(100)
-        transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
+        self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
 

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -3,9 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the importprunedfunds and removeprunedfunds RPCs."""
+
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, assert_raises_rpc_error, Decimal)
+from test_framework.util import assert_equal, assert_raises_rpc_error, Decimal
 
 class ImportPrunedFundsTest(RavenTestFramework):
     def set_test_params(self):
@@ -24,7 +26,8 @@ class ImportPrunedFundsTest(RavenTestFramework):
         address2 = self.nodes[0].getnewaddress()
         # privkey
         address3 = self.nodes[0].getnewaddress()
-        address3_privkey = self.nodes[0].dumpprivkey(address3)                              # Using privkey
+        # Using privkey
+        address3_privkey = self.nodes[0].dumpprivkey(address3)
 
         #Check only one address
         address_info = self.nodes[0].validateaddress(address1)
@@ -49,38 +52,38 @@ class ImportPrunedFundsTest(RavenTestFramework):
         assert_equal(address_info['ismine'], False)
 
         #Send funds to self
-        txnid1 = self.nodes[0].sendtoaddress(address1, 0.1)
+        txn_id1 = self.nodes[0].sendtoaddress(address1, 0.1)
         self.nodes[0].generate(1)
-        rawtxn1 = self.nodes[0].gettransaction(txnid1)['hex']
-        proof1 = self.nodes[0].gettxoutproof([txnid1])
+        raw_txn1 = self.nodes[0].gettransaction(txn_id1)['hex']
+        proof1 = self.nodes[0].gettxoutproof([txn_id1])
 
-        txnid2 = self.nodes[0].sendtoaddress(address2, 0.05)
+        txn_id2 = self.nodes[0].sendtoaddress(address2, 0.05)
         self.nodes[0].generate(1)
-        rawtxn2 = self.nodes[0].gettransaction(txnid2)['hex']
-        proof2 = self.nodes[0].gettxoutproof([txnid2])
+        raw_txn2 = self.nodes[0].gettransaction(txn_id2)['hex']
+        proof2 = self.nodes[0].gettxoutproof([txn_id2])
 
-        txnid3 = self.nodes[0].sendtoaddress(address3, 0.025)
+        txn_id3 = self.nodes[0].sendtoaddress(address3, 0.025)
         self.nodes[0].generate(1)
-        rawtxn3 = self.nodes[0].gettransaction(txnid3)['hex']
-        proof3 = self.nodes[0].gettxoutproof([txnid3])
+        raw_txn3 = self.nodes[0].gettransaction(txn_id3)['hex']
+        proof3 = self.nodes[0].gettxoutproof([txn_id3])
 
         self.sync_all()
 
         #Import with no affiliated address
-        assert_raises_rpc_error(-5, "No addresses", self.nodes[1].importprunedfunds, rawtxn1, proof1)
+        assert_raises_rpc_error(-5, "No addresses", self.nodes[1].importprunedfunds, raw_txn1, proof1)
 
         balance1 = self.nodes[1].getbalance("", 0, True)
         assert_equal(balance1, Decimal(0))
 
         #Import with affiliated address with no rescan
         self.nodes[1].importaddress(address2, "add2", False)
-        self.nodes[1].importprunedfunds(rawtxn2, proof2)
+        self.nodes[1].importprunedfunds(raw_txn2, proof2)
         balance2 = self.nodes[1].getbalance("add2", 0, True)
         assert_equal(balance2, Decimal('0.05'))
 
         #Import with private key with no rescan
         self.nodes[1].importprivkey(privkey=address3_privkey, label="add3", rescan=False)
-        self.nodes[1].importprunedfunds(rawtxn3, proof3)
+        self.nodes[1].importprunedfunds(raw_txn3, proof3)
         balance3 = self.nodes[1].getbalance("add3", 0, False)
         assert_equal(balance3, Decimal('0.025'))
         balance3 = self.nodes[1].getbalance("*", 0, True)
@@ -98,16 +101,16 @@ class ImportPrunedFundsTest(RavenTestFramework):
         assert_equal(address_info['ismine'], True)
 
         #Remove transactions
-        assert_raises_rpc_error(-8, "Transaction does not exist in wallet.", self.nodes[1].removeprunedfunds, txnid1)
+        assert_raises_rpc_error(-8, "Transaction does not exist in wallet.", self.nodes[1].removeprunedfunds, txn_id1)
 
         balance1 = self.nodes[1].getbalance("*", 0, True)
         assert_equal(balance1, Decimal('0.075'))
 
-        self.nodes[1].removeprunedfunds(txnid2)
+        self.nodes[1].removeprunedfunds(txn_id2)
         balance2 = self.nodes[1].getbalance("*", 0, True)
         assert_equal(balance2, Decimal('0.025'))
 
-        self.nodes[1].removeprunedfunds(txnid3)
+        self.nodes[1].removeprunedfunds(txn_id3)
         balance3 = self.nodes[1].getbalance("*", 0, True)
         assert_equal(balance3, Decimal('0.0'))
 

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the wallet keypool and interaction with wallet encryption/locking."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, assert_raises_rpc_error, time)
+from test_framework.util import assert_equal, assert_raises_rpc_error, time
 
 class KeyPoolTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test HD Wallet keypool restore function.
+
+"""
+Test HD Wallet keypool restore function.
 
 Two nodes. Node1 is under test. Node0 is providing transactions and generating blocks.
 
@@ -11,10 +13,10 @@ Two nodes. Node1 is under test. Node0 is providing transactions and generating b
 - Generate 110 keys (enough to drain the keypool). Store key 90 (in the initial keypool) and key 110 (beyond the initial keypool). Send funds to key 90 and key 110.
 - Stop node1, clear the datadir, move wallet file back into the datadir and restart node1.
 - connect node1 to node0. Verify that they sync and node1 receives its funds."""
-import shutil
 
+import shutil
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, connect_nodes_bi, sync_blocks)
+from test_framework.util import assert_equal, connect_nodes_bi, sync_blocks
 
 class KeypoolRestoreTest(RavenTestFramework):
     def set_test_params(self):
@@ -36,6 +38,8 @@ class KeypoolRestoreTest(RavenTestFramework):
 
         self.log.info("Generate keys for wallet")
 
+        addr_oldpool = []
+        addr_extpool = []
         for _ in range(90):
             addr_oldpool = self.nodes[1].getnewaddress()
         for _ in range(20):

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -3,8 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test account RPCs.
 
+"""
+Test account RPCs.
 RPCs tested are:
     - getaccountaddress
     - getaddressesbyaccount

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the listsincelast RPC."""
 
 from test_framework.test_framework import RavenTestFramework
@@ -23,7 +24,7 @@ class ListSinceBlockTest (RavenTestFramework):
         self.test_double_send()
 
     def test_reorg(self):
-        '''
+        """
         `listsinceblock` did not behave correctly when handed a block that was
         no longer in the main chain:
 
@@ -49,7 +50,7 @@ class ListSinceBlockTest (RavenTestFramework):
         range bb1-bb4.
 
         This test only checks that [tx0] is present.
-        '''
+        """
 
         # Split network into two
         self.split_network()
@@ -60,7 +61,7 @@ class ListSinceBlockTest (RavenTestFramework):
         # generate on both sides
         lastblockhash = self.nodes[1].generate(6)[5]
         self.nodes[2].generate(7)
-        self.log.debug('lastblockhash=%s' % (lastblockhash))
+        self.log.debug('lastblockhash=%s' % lastblockhash)
 
         self.sync_all([self.nodes[:2], self.nodes[2:]])
 
@@ -76,7 +77,7 @@ class ListSinceBlockTest (RavenTestFramework):
         assert found
 
     def test_double_spend(self):
-        '''
+        """
         This tests the case where the same UTXO is spent twice on two separate
         blocks as part of a reorg.
 
@@ -103,7 +104,7 @@ class ListSinceBlockTest (RavenTestFramework):
         asked for in listsinceblock, and to iterate back over existing blocks up
         until the fork point, and to include all transactions that relate to the
         node wallet.
-        '''
+        """
 
         self.sync_all()
 
@@ -159,7 +160,7 @@ class ListSinceBlockTest (RavenTestFramework):
         assert 'removed' not in lsbres2
 
     def test_double_send(self):
-        '''
+        """
         This tests the case where the same transaction is submitted twice on two
         separate blocks as part of a reorg. The former will vanish and the
         latter will appear as the true transaction (with confirmations dropping
@@ -182,7 +183,7 @@ class ListSinceBlockTest (RavenTestFramework):
            present in a different block.
         3. It is listed with a confirmations count of 2 (bb3, bb4), not
            3 (aa1, aa2, aa3).
-        '''
+        """
 
         self.sync_all()
 

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -3,14 +3,14 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the listtransactions API."""
 
+from io import BytesIO
 from decimal import Decimal
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (hex_str_to_bytes, assert_array_result, sync_mempools, assert_equal, bytes_to_hex_str)
-from test_framework.mininode import (CTransaction, COIN)
-from io import BytesIO
-
+from test_framework.util import hex_str_to_bytes, assert_array_result, sync_mempools, assert_equal, bytes_to_hex_str
+from test_framework.mininode import CTransaction, COIN
 
 
 def from_hex(hexstring):
@@ -151,7 +151,7 @@ class ListTransactionsTest(RavenTestFramework):
         inputs = [{"txid": txid_2, "vout": utxo_to_use["vout"]}]
         outputs = {self.nodes[1].getnewaddress(): 0.998}
         tx3 = self.nodes[0].createrawtransaction(inputs, outputs)
-        tx3_modified = txFromHex(tx3)
+        tx3_modified = from_hex(tx3)
         tx3_modified.vin[0].nSequence = 0
         tx3 = bytes_to_hex_str(tx3_modified.serialize())
         tx3_signed = self.nodes[0].signrawtransaction(tx3)['hex']

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Raven Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Test tx status in case of reorgs while wallet being shutdown.
+Wallet txn status rely on block connection/disconnection for its
+accuracy. In case of reorgs happening while wallet being shutdown
+block updates are not going to be received. At wallet loading, we
+check against chain if confirmed txn are still in chain and change
+their status if block in which they have been included has been
+disconnected.
+"""
+
+from decimal import Decimal
+import os
+import shutil
+from test_framework.test_framework import RavenTestFramework
+from test_framework.util import assert_equal, connect_nodes, disconnect_nodes, sync_blocks
+
+class ReorgsRestoreTest(RavenTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+
+    def run_test(self):
+        # Send a tx from which to conflict outputs later
+        txid_conflict_from = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # Disconnect node1 from others to reorg its chain later
+        disconnect_nodes(self.nodes[0], 1)
+        disconnect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[0], 2)
+
+        # Send a tx to be unconfirmed later
+        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
+        tx = self.nodes[0].gettransaction(txid)
+        self.nodes[0].generate(4)
+        tx_before_reorg = self.nodes[0].gettransaction(txid)
+        assert_equal(tx_before_reorg["confirmations"], 4)
+
+        # Disconnect node0 from node2 to broadcast a conflict on their respective chains
+        disconnect_nodes(self.nodes[0], 2)
+        n_a = next(tx_out["vout"] for tx_out in self.nodes[0].gettransaction(txid_conflict_from)["details"] if tx_out["amount"] == Decimal("10"))
+        inputs = [{"txid": txid_conflict_from, "vout": n_a}]
+        outputs_1 = dict()
+        outputs_2 = dict()
+
+        # Create a conflicted tx broadcast on node0 chain and conflicting tx broadcast on node1 chain. Both spend from txid_conflict_from
+        outputs_1[self.nodes[0].getnewaddress()] = Decimal("9.98")
+        outputs_2[self.nodes[0].getnewaddress()] = Decimal("9.98")
+        conflicted = self.nodes[0].signrawtransaction(self.nodes[0].createrawtransaction(inputs, outputs_1))
+        conflicting = self.nodes[0].signrawtransaction(self.nodes[0].createrawtransaction(inputs, outputs_2))
+
+        conflicted_txid = self.nodes[0].sendrawtransaction(conflicted["hex"])
+        self.nodes[0].generate(1)
+        conflicting_txid = self.nodes[2].sendrawtransaction(conflicting["hex"])
+        self.nodes[2].generate(9)
+
+        # Reconnect node0 and node2 and check that conflicted_txid is effectively conflicted
+        connect_nodes(self.nodes[0], 2)
+        sync_blocks([self.nodes[0], self.nodes[2]])
+        conflicted = self.nodes[0].gettransaction(conflicted_txid)
+        conflicting = self.nodes[0].gettransaction(conflicting_txid)
+        assert_equal(conflicted["confirmations"], -9)
+        assert_equal(conflicted["walletconflicts"][0], conflicting["txid"])
+
+        # Node0 wallet is shutdown
+        self.stop_node(0)
+        self.start_node(0)
+
+        # The block chain re-orgs and the tx is included in a different block
+        self.nodes[1].generate(9)
+        self.nodes[1].sendrawtransaction(tx["hex"])
+        self.nodes[1].generate(1)
+        self.nodes[1].sendrawtransaction(conflicted["hex"])
+        self.nodes[1].generate(1)
+
+        # Node0 wallet file is loaded on longest sync'ed node1
+        self.stop_node(1)
+        self.nodes[0].backupwallet(os.path.join(self.nodes[0].datadir, 'wallet.bak'))
+        shutil.copyfile(os.path.join(self.nodes[0].datadir, 'wallet.bak'), os.path.join(self.nodes[1].datadir, 'regtest', 'wallet.dat'))
+        self.start_node(1)
+        tx_after_reorg = self.nodes[1].gettransaction(txid)
+        # Check that normal confirmed tx is confirmed again but with different blockhash
+        assert_equal(tx_after_reorg["confirmations"], 2)
+        assert(tx_before_reorg["blockhash"] != tx_after_reorg["blockhash"])
+        conflicted_after_reorg = self.nodes[1].gettransaction(conflicted_txid)
+        # Check that conflicted tx is confirmed again with blockhash different than previously conflicting tx
+        assert_equal(conflicted_after_reorg["confirmations"], 1)
+        assert(conflicting["blockhash"] != conflicted_after_reorg["blockhash"])
+
+if __name__ == '__main__':
+    ReorgsRestoreTest().main()

--- a/test/functional/wallet_resendtransactions.py
+++ b/test/functional/wallet_resendtransactions.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test resendwallettransactions RPC."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, assert_raises_rpc_error)
+from test_framework.util import assert_equal, assert_raises_rpc_error
 
 class ResendWalletTransactionsTest(RavenTestFramework):
     def set_test_params(self):

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the wallet accounts properly when there are cloned transactions with malleated scriptsigs."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (disconnect_nodes, assert_equal, sync_blocks, connect_nodes)
+from test_framework.util import disconnect_nodes, assert_equal, sync_blocks, connect_nodes
 
 class TxnMallTest(RavenTestFramework):
     def set_test_params(self):
@@ -78,7 +79,7 @@ class TxnMallTest(RavenTestFramework):
         assert_equal(tx1_clone["complete"], True)
 
         # Have node0 mine a block, if requested:
-        if (self.options.mine_block):
+        if self.options.mine_block:
             self.nodes[0].generate(1)
             sync_blocks(self.nodes[0:2])
 
@@ -132,7 +133,7 @@ class TxnMallTest(RavenTestFramework):
         # Check node0's total balance; should be same as before the clone, + 100 RVN for 2 matured,
         # less possible orphaned matured subsidy
         expected += 10000
-        if (self.options.mine_block): 
+        if self.options.mine_block:
             expected -= 5000
         assert_equal(self.nodes[0].getbalance(), expected)
         assert_equal(self.nodes[0].getbalance("*", 0), expected)

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -3,10 +3,11 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 """Test the wallet accounts properly when there is a double-spend conflict."""
 
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (disconnect_nodes, assert_equal, Decimal, sync_blocks, find_output, connect_nodes)
+from test_framework.util import disconnect_nodes, assert_equal, Decimal, sync_blocks, find_output, connect_nodes
 
 class TxnMallTest(RavenTestFramework):
     def set_test_params(self):
@@ -48,17 +49,11 @@ class TxnMallTest(RavenTestFramework):
         # First: use raw transaction API to send 1240 RVN to node1_address,
         # but don't broadcast:
         doublespend_fee = Decimal('-.02')
-        rawtx_input_0 = {}
-        rawtx_input_0["txid"] = fund_foo_txid
-        rawtx_input_0["vout"] = find_output(self.nodes[0], fund_foo_txid, 121900)
-        rawtx_input_1 = {}
-        rawtx_input_1["txid"] = fund_bar_txid
-        rawtx_input_1["vout"] = find_output(self.nodes[0], fund_bar_txid, 2900)
+        rawtx_input_0 = {"txid": fund_foo_txid, "vout": find_output(self.nodes[0], fund_foo_txid, 121900)}
+        rawtx_input_1 = {"txid": fund_bar_txid, "vout": find_output(self.nodes[0], fund_bar_txid, 2900)}
         inputs = [rawtx_input_0, rawtx_input_1]
         change_address = self.nodes[0].getnewaddress()
-        outputs = {}
-        outputs[node1_address] = 124000
-        outputs[change_address] = 124800 - 124000 + doublespend_fee
+        outputs = {node1_address: 124000, change_address: 124800 - 124000 + doublespend_fee}
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         doublespend = self.nodes[0].signrawtransaction(rawtx)
         assert_equal(doublespend["complete"], True)
@@ -68,7 +63,7 @@ class TxnMallTest(RavenTestFramework):
         txid2 = self.nodes[0].sendfrom("bar", node1_address, 2000, 0)
         
         # Have node0 mine a block:
-        if (self.options.mine_block):
+        if self.options.mine_block:
             self.nodes[0].generate(1)
             sync_blocks(self.nodes[0:2])
 

--- a/test/functional/wallet_zapwallettxes.py
+++ b/test/functional/wallet_zapwallettxes.py
@@ -3,7 +3,9 @@
 # Copyright (c) 2017-2019 The Raven Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test the zapwallettxes functionality.
+
+"""
+Test the zapwallettxes functionality.
 
 - start two ravend nodes
 - create two transactions on node 0 - one is confirmed and one is unconfirmed.
@@ -11,12 +13,13 @@
   transactions are still available.
 - restart node 0 with zapwallettxes and persistmempool, and verify that both
   the confirmed and the unconfirmed transactions are still available.
-- restart node 0 with just zapwallettxed and verify that the confirmed
+- restart node 0 with just zapwallettxes and verify that the confirmed
   transactions are still available, but that the unconfirmed transaction has
   been zapped.
 """
+
 from test_framework.test_framework import RavenTestFramework
-from test_framework.util import (assert_equal, assert_raises_rpc_error, wait_until)
+from test_framework.util import assert_equal, assert_raises_rpc_error, wait_until
 
 class ZapWalletTXesTest (RavenTestFramework):
     def set_test_params(self):


### PR DESCRIPTION
This is a large commit, mostly merging some new BTC tests that we didn't have in RVN.  This is only part 1 as there are still additional tests to be ported.  Some of the tests were renamed to match the BTC tests. Also applied some code consistency across all of the Python files. This also included a new RPC call "getrpcinfo" that returns a list of the active RPC commands and how long they have been alive.  This allows for smarter tests and some new future performance testing for RPC calls.