### PR TITLE
Display correct unit in Qt wallet transaction history

### DIFF
--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -259,6 +259,14 @@ QColor PlatformStyle::SingleColor() const
     return singleColor;
 }
 
+QColor PlatformStyle::AssetTxColor() const
+{
+    if (darkModeEnabled)
+        return COLOR_LIGHT_BLUE;
+
+    return COLOR_DARK_BLUE;
+}
+
 
 const PlatformStyle *PlatformStyle::instantiate(const QString &platformId)
 {

--- a/src/qt/platformstyle.h
+++ b/src/qt/platformstyle.h
@@ -37,6 +37,7 @@ public:
     QColor DarkBlueColor() const;
     QColor LightOrangeColor() const;
     QColor DarkOrangeColor() const;
+    QColor AssetTxColor() const;
 
 
     /** Colorize an image (given filename) with the icon color */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -263,11 +263,11 @@ TransactionTableModel::~TransactionTableModel()
 }
 
 /** Updates the column title to "Amount (DisplayUnit)" and emits headerDataChanged() signal for table headers to react. */
-void TransactionTableModel::updateAmountColumnTitle()
-{
-    columns[Amount] = RavenUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit());
-    Q_EMIT headerDataChanged(Qt::Horizontal,Amount,Amount);
-}
+//void TransactionTableModel::updateAmountColumnTitle()
+//{
+//    columns[Amount] = RavenUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit());
+//    Q_EMIT headerDataChanged(Qt::Horizontal,Amount,Amount);
+//}
 
 void TransactionTableModel::updateTransaction(const QString &hash, int status, bool showTransaction)
 {
@@ -592,7 +592,10 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         case Amount:
             return formatTxAmount(rec, true, RavenUnits::separatorAlways);
         case AssetName:
-            return QString::fromStdString(rec->assetName);
+            if (rec->assetName != "RVN")
+               return QString::fromStdString(rec->assetName);
+            else
+               return QString(RavenUnits::name(walletModel->getOptionsModel()->getDisplayUnit()));
         }
         break;
     case Qt::EditRole:
@@ -637,6 +640,11 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         if(index.column() == ToAddress)
         {
             return addressColor(rec);
+        }
+        if(index.column() == AssetName)
+        {
+            if (rec->assetName != "RVN")
+               return platformStyle->AssetTxColor();
         }
         break;
     case TypeRole:
@@ -697,7 +705,10 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
     case AssetNameRole:
         {
             QString assetName;
-            assetName.append(QString::fromStdString(rec->assetName));
+            if (rec->assetName != "RVN")
+               assetName.append(QString::fromStdString(rec->assetName));
+            else
+               assetName.append(QString(RavenUnits::name(walletModel->getOptionsModel()->getDisplayUnit())));
             return assetName;
         }
     case StatusRole:
@@ -755,7 +766,7 @@ QModelIndex TransactionTableModel::index(int row, int column, const QModelIndex 
 void TransactionTableModel::updateDisplayUnit()
 {
     // emit dataChanged to update Amount column with the current unit
-    updateAmountColumnTitle();
+    //updateAmountColumnTitle();
     Q_EMIT dataChanged(index(0, Amount), index(priv->size()-1, Amount));
 }
 

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -114,7 +114,7 @@ public Q_SLOTS:
     void updateConfirmations();
     void updateDisplayUnit();
     /** Updates the column title to "Amount (DisplayUnit)" and emits headerDataChanged() signal for table headers to react. */
-    void updateAmountColumnTitle();
+    //void updateAmountColumnTitle();
     /* Needed to update fProcessingQueuedTransactions through a QueuedConnection */
     void setProcessingQueuedTransactions(bool value) { fProcessingQueuedTransactions = value; }
 


### PR DESCRIPTION
The Qt wallet transaction history uses 'RVN' for all RVN transactions even if a different display unit is chosen in the options. This has occasionally been a cause of confusion for some users.

These changes:
* Use the correct unit (e.g. RVN, mRVN or μRVN) in the transaction history 'Asset' column and recent transactions
* Removes display unit from the 'Amount' column (as asset amounts are not in RVN)
* Further reduces potential for confusion by displaying asset names in a different colour (I chose raven blue)

![shot_191206_162717](https://user-images.githubusercontent.com/14331016/70340522-d7798a00-1848-11ea-8261-373d718a6d0e.png)





