### PR TITLE
Update sendfromaddress Bitcoin Format to Valid Ravencoin Address Exam…

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -738,10 +738,10 @@ UniValue getaddressmempool(const JSONRPCRequest& request)
             "  }\n"
             "]\n"
             "\nExamples:\n"
-            + HelpExampleCli("getaddressmempool", "'{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}'")
-            + HelpExampleRpc("getaddressmempool", "{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}")
-            + HelpExampleCli("getaddressmempool", "'{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}', true")
-            + HelpExampleRpc("getaddressmempool", "{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}, true")
+            + HelpExampleCli("getaddressmempool", "'{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}'")
+            + HelpExampleRpc("getaddressmempool", "{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}")
+            + HelpExampleCli("getaddressmempool", "'{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}', true")
+            + HelpExampleRpc("getaddressmempool", "{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}, true")
         );
 
     std::vector<std::pair<uint160, int> > addresses;
@@ -829,10 +829,10 @@ UniValue getaddressutxos(const JSONRPCRequest& request)
             "  }\n"
             "]\n"
             "\nExamples:\n"
-            + HelpExampleCli("getaddressutxos", "'{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}'")
-            + HelpExampleRpc("getaddressutxos", "{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}")
-            + HelpExampleCli("getaddressutxos", "'{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"],\"assetName\":\"MY_ASSET\"}'")
-            + HelpExampleRpc("getaddressutxos", "{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"],\"assetName\":\"MY_ASSET\"}")
+            + HelpExampleCli("getaddressutxos", "'{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}'")
+            + HelpExampleRpc("getaddressutxos", "{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}")
+            + HelpExampleCli("getaddressutxos", "'{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"],\"assetName\":\"MY_ASSET\"}'")
+            + HelpExampleRpc("getaddressutxos", "{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"],\"assetName\":\"MY_ASSET\"}")
             );
 
     bool includeChainInfo = false;
@@ -942,10 +942,10 @@ UniValue getaddressdeltas(const JSONRPCRequest& request)
             "  }\n"
             "]\n"
             "\nExamples:\n"
-            + HelpExampleCli("getaddressdeltas", "'{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}'")
-            + HelpExampleRpc("getaddressdeltas", "{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}")
-            + HelpExampleCli("getaddressdeltas", "'{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"],\"assetName\":\"MY_ASSET\"}'")
-            + HelpExampleRpc("getaddressdeltas", "{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"],\"assetName\":\"MY_ASSET\"}")
+            + HelpExampleCli("getaddressdeltas", "'{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}'")
+            + HelpExampleRpc("getaddressdeltas", "{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}")
+            + HelpExampleCli("getaddressdeltas", "'{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"],\"assetName\":\"MY_ASSET\"}'")
+            + HelpExampleRpc("getaddressdeltas", "{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"],\"assetName\":\"MY_ASSET\"}")
         );
 
 
@@ -1080,10 +1080,10 @@ UniValue getaddressbalance(const JSONRPCRequest& request)
             "  },...\n"
             "\n]"
             "\nExamples:\n"
-            + HelpExampleCli("getaddressbalance", "'{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}'")
-            + HelpExampleCli("getaddressbalance", "'{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}', true")
-            + HelpExampleRpc("getaddressbalance", "{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}")
-            + HelpExampleRpc("getaddressbalance", "{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}, true")
+            + HelpExampleCli("getaddressbalance", "'{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}'")
+            + HelpExampleCli("getaddressbalance", "'{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}', true")
+            + HelpExampleRpc("getaddressbalance", "{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}")
+            + HelpExampleRpc("getaddressbalance", "{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}, true")
         );
 
     std::vector<std::pair<uint160, int> > addresses;
@@ -1189,10 +1189,10 @@ UniValue getaddresstxids(const JSONRPCRequest& request)
             "  ,...\n"
             "]\n"
             "\nExamples:\n"
-            + HelpExampleCli("getaddresstxids", "'{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}'")
-            + HelpExampleRpc("getaddresstxids", "{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}")
-            + HelpExampleCli("getaddresstxids", "'{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}', true")
-            + HelpExampleRpc("getaddresstxids", "{\"addresses\": [\"12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX\"]}, true")
+            + HelpExampleCli("getaddresstxids", "'{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}'")
+            + HelpExampleRpc("getaddresstxids", "{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}")
+            + HelpExampleCli("getaddresstxids", "'{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}', true")
+            + HelpExampleRpc("getaddresstxids", "{\"addresses\": [\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"]}, true")
         );
 
     std::vector<std::pair<uint160, int> > addresses;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -199,8 +199,8 @@ UniValue validateaddress(const JSONRPCRequest& request)
             "  \"hdmasterkeyid\" : \"<hash160>\" (string, optional) The Hash160 of the HD master pubkey\n"
             "}\n"
             "\nExamples:\n"
-            + HelpExampleCli("validateaddress", "\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"")
-            + HelpExampleRpc("validateaddress", "\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"")
+            + HelpExampleCli("validateaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"")
+            + HelpExampleRpc("validateaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"")
         );
 
 #ifdef ENABLE_WALLET

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -451,10 +451,10 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
             "\nResult:\n"
             "\"txid\"                  (string) The transaction id.\n"
             "\nExamples:\n"
-            + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1")
-            + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"donation\" \"seans outpost\"")
-            + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"\" \"\" true")
-            + HelpExampleRpc("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\"")
+            + HelpExampleCli("sendtoaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" 0.1")
+            + HelpExampleCli("sendtoaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" 0.1 \"donation\" \"seans outpost\"")
+            + HelpExampleCli("sendtoaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" 0.1 \"\" \"\" true")
+            + HelpExampleRpc("sendtoaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\", 0.1, \"donation\", \"seans outpost\"")
         );
 
     ObserveSafeMode();
@@ -536,10 +536,10 @@ UniValue sendfromaddress(const JSONRPCRequest& request)
             "\nResult:\n"
             "\"txid\"                  (string) The transaction id.\n"
             "\nExamples:\n"
-            + HelpExampleCli("sendfromaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1")
-            + HelpExampleCli("sendfromaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"donation\" \"seans outpost\"")
-            + HelpExampleCli("sendfromaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"\" \"\" true")
-            + HelpExampleRpc("sendfromaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\"")
+            + HelpExampleCli("sendfromaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" \"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" 0.1")
+            + HelpExampleCli("sendfromaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" \"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" 0.1 \"donation\" \"seans outpost\"")
+            + HelpExampleCli("sendfromaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" \"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" 0.1 \"\" \"\" true")
+            + HelpExampleRpc("sendfromaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" \"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\", 0.1, \"donation\", \"seans outpost\"")
         );
 
     ObserveSafeMode();
@@ -1031,11 +1031,11 @@ UniValue sendfrom(const JSONRPCRequest& request)
             "\"txid\"                 (string) The transaction id.\n"
             "\nExamples:\n"
             "\nSend 0.01 " + CURRENCY_UNIT + " from the default account to the address, must have at least 1 confirmation\n"
-            + HelpExampleCli("sendfrom", "\"\" \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.01") +
+            + HelpExampleCli("sendfrom", "\"\" \"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" 0.01") +
             "\nSend 0.01 from the tabby account to the given address, funds must have at least 6 confirmations\n"
-            + HelpExampleCli("sendfrom", "\"tabby\" \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.01 6 \"donation\" \"seans outpost\"") +
+            + HelpExampleCli("sendfrom", "\"tabby\" \"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" 0.01 6 \"donation\" \"seans outpost\"") +
             "\nAs a json rpc call\n"
-            + HelpExampleRpc("sendfrom", "\"tabby\", \"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.01, 6, \"donation\", \"seans outpost\"")
+            + HelpExampleRpc("sendfrom", "\"tabby\", \"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\", 0.01, 6, \"donation\", \"seans outpost\"")
         );
 
     ObserveSafeMode();
@@ -2454,7 +2454,7 @@ UniValue walletlock(const JSONRPCRequest& request)
             "\nSet the passphrase for 2 minutes to perform a transaction\n"
             + HelpExampleCli("walletpassphrase", "\"my pass phrase\" 120") +
             "\nPerform a send (requires passphrase set)\n"
-            + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 1.0") +
+            + HelpExampleCli("sendtoaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" 1.0") +
             "\nClear the passphrase since we are done before 2 minutes is up\n"
             + HelpExampleCli("walletlock", "") +
             "\nAs json rpc call\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -274,8 +274,8 @@ UniValue setaccount(const JSONRPCRequest& request)
             "1. \"address\"         (string, required) The raven address to be associated with an account.\n"
             "2. \"account\"         (string, required) The account to assign the address to.\n"
             "\nExamples:\n"
-            + HelpExampleCli("setaccount", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"tabby\"")
-            + HelpExampleRpc("setaccount", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", \"tabby\"")
+            + HelpExampleCli("setaccount", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" \"tabby\"")
+            + HelpExampleRpc("setaccount", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\", \"tabby\"")
         );
 
     LOCK2(cs_main, pwallet->cs_wallet);
@@ -323,8 +323,8 @@ UniValue getaccount(const JSONRPCRequest& request)
             "\nResult:\n"
             "\"accountname\"        (string) the account address\n"
             "\nExamples:\n"
-            + HelpExampleCli("getaccount", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\"")
-            + HelpExampleRpc("getaccount", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\"")
+            + HelpExampleCli("getaccount", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"")
+            + HelpExampleRpc("getaccount", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"")
         );
 
     LOCK2(cs_main, pwallet->cs_wallet);
@@ -697,11 +697,11 @@ UniValue signmessage(const JSONRPCRequest& request)
             "\nUnlock the wallet for 30 seconds\n"
             + HelpExampleCli("walletpassphrase", "\"mypassphrase\" 30") +
             "\nCreate the signature\n"
-            + HelpExampleCli("signmessage", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"my message\"") +
+            + HelpExampleCli("signmessage", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" \"my message\"") +
             "\nVerify the signature\n"
-            + HelpExampleCli("verifymessage", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" \"signature\" \"my message\"") +
+            + HelpExampleCli("verifymessage", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" \"signature\" \"my message\"") +
             "\nAs json rpc\n"
-            + HelpExampleRpc("signmessage", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", \"my message\"")
+            + HelpExampleRpc("signmessage", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\", \"my message\"")
         );
 
     LOCK2(cs_main, pwallet->cs_wallet);
@@ -755,13 +755,13 @@ UniValue getreceivedbyaddress(const JSONRPCRequest& request)
             "amount   (numeric) The total amount in " + CURRENCY_UNIT + " received at this address.\n"
             "\nExamples:\n"
             "\nThe amount from transactions with at least 1 confirmation\n"
-            + HelpExampleCli("getreceivedbyaddress", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\"") +
+            + HelpExampleCli("getreceivedbyaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\"") +
             "\nThe amount including unconfirmed transactions, zero confirmations\n"
-            + HelpExampleCli("getreceivedbyaddress", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" 0") +
+            + HelpExampleCli("getreceivedbyaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" 0") +
             "\nThe amount with at least 6 confirmations\n"
-            + HelpExampleCli("getreceivedbyaddress", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\" 6") +
+            + HelpExampleCli("getreceivedbyaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\" 6") +
             "\nAs a json rpc call\n"
-            + HelpExampleRpc("getreceivedbyaddress", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", 6")
+            + HelpExampleRpc("getreceivedbyaddress", "\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\", 6")
        );
 
     ObserveSafeMode();
@@ -1114,13 +1114,13 @@ UniValue sendmany(const JSONRPCRequest& request)
             "                                    the number of addresses.\n"
             "\nExamples:\n"
             "\nSend two amounts to two different addresses:\n"
-            + HelpExampleCli("sendmany", "\"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\"") +
+            + HelpExampleCli("sendmany", "\"\" \"{\\\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\"") +
             "\nSend two amounts to two different addresses setting the confirmation and comment:\n"
-            + HelpExampleCli("sendmany", "\"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 6 \"testing\"") +
+            + HelpExampleCli("sendmany", "\"\" \"{\\\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 6 \"testing\"") +
             "\nSend two amounts to two different addresses, subtract fee from amount:\n"
-            + HelpExampleCli("sendmany", "\"\" \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 1 \"\" \"[\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\",\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\"]\"") +
+            + HelpExampleCli("sendmany", "\"\" \"{\\\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\" 1 \"\" \"[\\\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\\\",\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\"]\"") +
             "\nAs a json rpc call\n"
-            + HelpExampleRpc("sendmany", "\"\", \"{\\\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\", 6, \"testing\"")
+            + HelpExampleRpc("sendmany", "\"\", \"{\\\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\\\":0.01,\\\"1353tsE8YMTA4EuV7dgUXGjNFf9KpVvKHz\\\":0.02}\", 6, \"testing\"")
         );
 
     ObserveSafeMode();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2891,8 +2891,8 @@ UniValue listunspent(const JSONRPCRequest& request)
 
             "\nExamples\n"
             + HelpExampleCli("listunspent", "")
-            + HelpExampleCli("listunspent", "6 9999999 \"[\\\"1PGFqEzfmQch1gKD3ra4k18PNj3tTUUSqg\\\",\\\"1LtvqCaApEdUGFkpKMM4MstjcaL4dKg8SP\\\"]\"")
-            + HelpExampleRpc("listunspent", "6, 9999999 \"[\\\"1PGFqEzfmQch1gKD3ra4k18PNj3tTUUSqg\\\",\\\"1LtvqCaApEdUGFkpKMM4MstjcaL4dKg8SP\\\"]\"")
+            + HelpExampleCli("listunspent", "6 9999999 \"[\\\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\\\",\\\"1LtvqCaApEdUGFkpKMM4MstjcaL4dKg8SP\\\"]\"")
+            + HelpExampleRpc("listunspent", "6, 9999999 \"[\\\"RKAWWWw3nCXLugJfb58JPkf1iBgkbsF2dx\\\",\\\"1LtvqCaApEdUGFkpKMM4MstjcaL4dKg8SP\\\"]\"")
             + HelpExampleCli("listunspent", "6 9999999 '[]' true '{ \"minimumAmount\": 0.005 }'")
             + HelpExampleRpc("listunspent", "6, 9999999, [] , true, { \"minimumAmount\": 0.005 } ")
         );


### PR DESCRIPTION
I noticed that some of the help src file still have the old Bitcoin CLI examples. 

I've put in a new valid Ravencoin address more accurately reflecting a valid Ravencoin address format. I.e. an address string starting with 'R' instead of '1'. 
