### PR TITLE
Fixing broken restricted asset test and loop argument

### DIFF
--- a/test/functional/feature_restricted_assets.py
+++ b/test/functional/feature_restricted_assets.py
@@ -515,20 +515,19 @@ class RestrictedAssetsTest(RavenTestFramework):
         assert_raises_rpc_error(None, "Invalid Raven change address", n0.freezerestrictedasset, asset_name, "garbagechangeaddress")
 
         n0.freezerestrictedasset(asset_name, rvn_change_address)  # Can only freeze once!
+        assert_raises_rpc_error(-26, "Freezing transaction already in mempool", n0.freezerestrictedasset, asset_name, rvn_change_address)
         n0.generate(1)
-
         assert_raises_rpc_error(None, "global-freeze-when-already-frozen", n0.freezerestrictedasset, asset_name, rvn_change_address)
 
         # post-freeze validation
         assert_contains(asset_name, n0.listglobalrestrictions())
         assert n0.checkglobalrestriction(asset_name)
         assert_raises_rpc_error(-8, "restricted asset has been globally frozen", n0.transferfromaddress, asset_name, address, 1000, n1.getnewaddress())
-
         assert_raises_rpc_error(None, "Invalid Raven change address", n0.unfreezerestrictedasset, asset_name, "garbagechangeaddress")
 
         n0.unfreezerestrictedasset(asset_name, rvn_change_address)  # Can only un-freeze once!
+        assert_raises_rpc_error(-26, "Unfreezing transaction already in mempool", n0.unfreezerestrictedasset, asset_name, rvn_change_address)
         n0.generate(1)
-
         assert_raises_rpc_error(None, "global-unfreeze-when-not-frozen", n0.unfreezerestrictedasset, asset_name, rvn_change_address)
 
         # post-unfreeze validation

--- a/test/functional/feature_restricted_assets.py
+++ b/test/functional/feature_restricted_assets.py
@@ -514,8 +514,7 @@ class RestrictedAssetsTest(RavenTestFramework):
 
         assert_raises_rpc_error(None, "Invalid Raven change address", n0.freezerestrictedasset, asset_name, "garbagechangeaddress")
 
-        n0.freezerestrictedasset(asset_name, rvn_change_address)
-        n0.freezerestrictedasset(asset_name, rvn_change_address)  # redundant freezing ok if consistent
+        n0.freezerestrictedasset(asset_name, rvn_change_address)  # Can only freeze once!
         n0.generate(1)
 
         assert_raises_rpc_error(None, "global-freeze-when-already-frozen", n0.freezerestrictedasset, asset_name, rvn_change_address)
@@ -527,8 +526,7 @@ class RestrictedAssetsTest(RavenTestFramework):
 
         assert_raises_rpc_error(None, "Invalid Raven change address", n0.unfreezerestrictedasset, asset_name, "garbagechangeaddress")
 
-        n0.unfreezerestrictedasset(asset_name, rvn_change_address)
-        n0.unfreezerestrictedasset(asset_name, rvn_change_address)  # redundant unfreezing ok if consistent
+        n0.unfreezerestrictedasset(asset_name, rvn_change_address)  # Can only un-freeze once!
         n0.generate(1)
 
         assert_raises_rpc_error(None, "global-unfreeze-when-not-frozen", n0.unfreezerestrictedasset, asset_name, rvn_change_address)


### PR DESCRIPTION
Fixing restricted asset test - it was previously valid to freeze and unfreeze multiple times in one. As of PR #704 this is no longer the case.  Now the tests freezes once, and expects assertion on the second attempt.
Also found a problem in the test runner --loop argument. If a test during an early loop fails, it will fail every loop afterwards - This is because the directory structure is not deleted when a test fails (to allow looking at logs etc). The options were to override the directory (would lose any debug info), or to create a new directory - this is what it now does.  The test now simply appends a  "random" integer to the end of the pathname. This will allow for tests to continue to run with or without error as desired.