### PR TITLE
Fix script size check by gu3

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -205,6 +205,11 @@ bool IsAssetNameASubQualifier(const std::string& name)
 
 bool IsAssetNameValid(const std::string& name, AssetType& assetType, std::string& error)
 {
+    // Do a max length check first to stop the possibility of a stack exhaustion.
+    // We check for a value that is larger than the max asset name
+    if (name.length() > 40)
+        return false;
+
     assetType = AssetType::INVALID;
     if (std::regex_match(name, UNIQUE_INDICATOR))
     {
@@ -900,6 +905,14 @@ bool AssetNullVerifierDataFromScript(const CScript& scriptPubKey, CNullAssetTxVe
 //! Call VerifyNewAsset if this function returns true
 bool CTransaction::IsNewAsset() const
 {
+    // New Asset transaction will always have at least three outputs.
+    // 1. Owner Token output
+    // 2. Issue Asset output
+    // 3. RVN Burn Fee
+    if (vout.size() < 3) {
+        return false;
+    }
+
     // Check for the assets data CTxOut. This will always be the last output in the transaction
     if (!CheckIssueDataTx(vout[vout.size() - 1]))
         return false;
@@ -5290,10 +5303,6 @@ bool CheckNewAsset(const CNewAsset& asset, std::string& strError)
             strError = _("Invalid parameter: reissuable must be 0");
             return false;
         }
-    }
-
-    if (assetType == AssetType::RESTRICTED) {
-        // TODO add more restricted asset checks
     }
 
     if (IsAssetNameAnOwner(std::string(asset.strName))) {

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -329,6 +329,9 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
     }
 
     for (auto name: setNullGlobalAssetChanges) {
+        if (name.size() == 0)
+            return state.DoS(100, false, REJECT_INVALID,"bad-txns-tx-contains-global-asset-null-tx-with-null-asset-name");
+
         std::string rootName = name.substr(1,  name.size()); // $TOKEN into TOKEN
         if (!setAssetTransferNames.count(rootName + OWNER_TAG)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-tx-contains-global-asset-null-tx-without-asset-transfer");

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -244,7 +244,7 @@ bool CScript::IsAssetScript(int& nType, bool& isOwner) const
 
 bool CScript::IsAssetScript(int& nType, bool& fIsOwner, int& nStartingIndex) const
 {
-    if (this->size() > 30) {
+    if (this->size() > 31) {
         if ((*this)[25] == OP_RVN_ASSET) { // OP_RVN_ASSET is always in the 25 index of the script if it exists
             int index = -1;
             if ((*this)[27] == RVN_R) { // Check to see if RVN starts at 27 ( this->size() < 105)


### PR DESCRIPTION
If a script is above a certain size, the RVN characters are placed in different indexes in the script. This change makes sure that all scripts that might be asset scripts meet the size constraints for finding all required asset special characters. 