### PR TITLE
fixing the feature_uacomment.py test

### DIFF
--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -25,7 +25,7 @@ class UacommentTest(RavenTestFramework):
 
         self.log.info("test -uacomment max length")
         self.stop_node(0)
-        expected = "Total length of network version string (288) exceeds maximum length (256). Reduce the number or size of uacomments."
+        expected = "Total length of network version string (286) exceeds maximum length (256). Reduce the number or size of uacomments."
         self.assert_start_raises_init_error(0, ["-uacomment=" + 'a' * 256], expected)
 
         self.log.info("test -uacomment unsafe characters")


### PR DESCRIPTION
Simple fix, change the expected string to match what is now returned 286 vs 288,