### PR TITLE
Fixing the QT exernal depends link

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,6 +1,6 @@
 PACKAGE=qt
 $(package)_version=5.7.1
-$(package)_download_path=https://download.qt.io/archive/qt/5.7/$($(package)_version)/submodules
+$(package)_download_path=https://download.qt.io/new_archive/qt/5.7/$($(package)_version)/submodules
 $(package)_suffix=opensource-src-$($(package)_version).tar.gz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=95f83e532d23b3ddbde7973f380ecae1bac13230340557276f75f2e37984e410

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -381,6 +381,10 @@ def run_tests(test_list, src_dir, build_dir, exeext, tmpdir, use_term_control, j
 
     tests_dir = src_dir + '/test/functional/'
 
+    # limit number of jobs to 13
+    if jobs > 13:
+        jobs = 13
+        print("Jobs limited to 13 threads max.")
     print("Using: ", jobs, " threads")
 
     flags = ["--srcdir={}/src".format(build_dir)] + args


### PR DESCRIPTION
Looks like QT moved the 5.7.1 downloads from archive to new_archive, breaking the builds.  This should resolve that.