### PR TITLE
Only do full kawpow hash when checking POW

### DIFF
--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -163,7 +163,8 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
             break;
     }
 
-    LogPrint(BCLog::CMPCTBLOCK, "Initialized PartiallyDownloadedBlock for block %s using a cmpctblock of size %lu\n", cmpctblock.header.GetHash().ToString(), GetSerializeSize(cmpctblock, SER_NETWORK, PROTOCOL_VERSION));
+    LogPrint(BCLog::CMPCTBLOCK, "Initialized PartiallyDownloadedBlock for block %s using a cmpctblock of size %lu\n",
+             cmpctblock.header.GetHash().ToString(), GetSerializeSize(cmpctblock, SER_NETWORK, PROTOCOL_VERSION));
 
     return READ_STATUS_OK;
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -403,6 +403,7 @@ public:
             {
                     { 225, uint256S("0x000003465e3e0167322eb8269ce91246bbc211e293bc5fbf6f0a0d12c1ccb363")},
                     {223408, uint256S("0x000000012a0c09dd6456ab19018cc458648dec762b04f4ddf8ef8108eae69db9")},
+                    {232980, uint256S("0x000000007b16ae547fce76c3308dbeec2090cde75de74ab5dfcd6f60d13f089b")},
             }
         };
 

--- a/src/crypto/ethash/include/ethash/progpow.hpp
+++ b/src/crypto/ethash/include/ethash/progpow.hpp
@@ -35,6 +35,9 @@ result hash(const epoch_context_full& context, int block_number, const hash256& 
 bool verify(const epoch_context& context, int block_number, const hash256& header_hash,
     const hash256& mix_hash, uint64_t nonce, const hash256& boundary) noexcept;
 
+hash256 hash_no_verify(const int& block_number, const hash256& header_hash,
+    const hash256& mix_hash, const uint64_t& nonce) noexcept;
+
 search_result search_light(const epoch_context& context, int block_number,
     const hash256& header_hash, const hash256& boundary, uint64_t start_nonce,
     size_t iterations) noexcept;

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -277,4 +277,18 @@ uint256 KAWPOWHash(const CBlockHeader& blockHeader, uint256& mix_hash)
 }
 
 
+uint256 KAWPOWHash_OnlyMix(const CBlockHeader& blockHeader)
+{
+    // Build the header_hash
+    uint256 nHeaderHash = blockHeader.GetKAWPOWHeaderHash();
+    const auto header_hash = to_hash256(nHeaderHash.GetHex());
+
+    // ProgPow hash
+    const auto result = progpow::hash_no_verify(blockHeader.nHeight, header_hash, to_hash256(blockHeader.mix_hash.GetHex()), blockHeader.nNonce64);
+
+    return uint256S(to_hex(result));
+}
+
+
+
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -606,6 +606,7 @@ inline uint256 HashX16RV2(const T1 pbegin, const T1 pend, const uint256 PrevBloc
 }
 
 uint256 KAWPOWHash(const CBlockHeader& blockHeader, uint256& mix_hash);
+uint256 KAWPOWHash_OnlyMix(const CBlockHeader& blockHeader);
 
 
 #endif // RAVEN_HASH_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -634,7 +634,7 @@ void static RavenMiner(const CChainParams& chainparams)
                 uint256 mix_hash;
                 while (true)
                 {
-                    hash = pblock->GetHash(mix_hash);
+                    hash = pblock->GetHashFull(mix_hash);
                     if (UintToArith256(hash) <= hashTarget)
                     {
                         pblock->mix_hash = mix_hash;

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -50,12 +50,11 @@ uint256 CBlockHeader::GetHash() const
 
         return HashX16R(BEGIN(nVersion), END(nNonce), hashPrevBlock);
     } else {
-        uint256 mix_hash;
-        return KAWPOWHash(*this, mix_hash);
+        return KAWPOWHash_OnlyMix(*this);
     }
 }
 
-uint256 CBlockHeader::GetHash(uint256& mix_hash) const
+uint256 CBlockHeader::GetHashFull(uint256& mix_hash) const
 {
     if (nTime < nKAWPOWActivationTime) {
         uint32_t nTimeToUse = MAINNET_X16RV2ACTIVATIONTIME;
@@ -73,6 +72,7 @@ uint256 CBlockHeader::GetHash(uint256& mix_hash) const
         return KAWPOWHash(*this, mix_hash);
     }
 }
+
 
 
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -36,6 +36,7 @@ extern BlockNetwork bNetwork;
 class CBlockHeader
 {
 public:
+
     // header
     int32_t nVersion;
     uint256 hashPrevBlock;
@@ -95,7 +96,7 @@ public:
     uint256 GetX16RHash() const;
     uint256 GetX16RV2Hash() const;
 
-    uint256 GetHash(uint256& mix_hash) const;
+    uint256 GetHashFull(uint256& mix_hash) const;
     uint256 GetKAWPOWHeaderHash() const;
     std::string ToString() const;
 
@@ -119,6 +120,7 @@ public:
 
     // memory only
     mutable bool fChecked;
+
 
     CBlock()
     {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -251,6 +251,9 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.push_back(Pair("headerhash", block.GetKAWPOWHeaderHash().GetHex()));
+    result.push_back(Pair("mixhash", block.mix_hash.GetHex()));
+    result.push_back(Pair("nonce64", (uint64_t)block.nNonce64));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -137,7 +137,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
         }
         uint256 mix_hash;
-        while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(mix_hash), pblock->nBits,
+        while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHashFull(mix_hash), pblock->nBits,
                                                                                       GetParams().GetConsensus())) {
             if (pblock->nTime < nKAWPOWActivationTime) {
                 ++pblock->nNonce;
@@ -877,7 +877,8 @@ static UniValue pprpcsb(const JSONRPCRequest& request) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block does not start with a coinbase");
     }
 
-    if (!CheckProofOfWork(blockptr->GetHash(), blockptr->nBits, GetParams().GetConsensus()))
+    uint256 retMixHash;
+    if (!CheckProofOfWork(blockptr->GetHashFull(retMixHash), blockptr->nBits, GetParams().GetConsensus()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block does not solve the boundary");
 
 

--- a/src/test/test_raven.cpp
+++ b/src/test/test_raven.cpp
@@ -143,7 +143,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction> 
     IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
 
     uint256 mix_hash;
-    while (!CheckProofOfWork(block.GetHash(mix_hash), block.nBits, chainparams.GetConsensus())) { ++block.nNonce64; ++block.nNonce;};
+    while (!CheckProofOfWork(block.GetHashFull(mix_hash), block.nBits, chainparams.GetConsensus())) { ++block.nNonce64; ++block.nNonce;};
     block.mix_hash = mix_hash;
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3926,7 +3926,7 @@ static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state,
     // If we are checking a KAWPOW block below a know checkpoint height. We can validate the proof of work using the mix_hash
     if (fCheckPOW && block.nTime >= nKAWPOWActivationTime) {
         CBlockIndex* pcheckpoint = Checkpoints::GetLastCheckpoint(GetParams().Checkpoints());
-        if (fCheckPOW && block.nHeight <= (uint32_t)pcheckpoint->nHeight) {
+        if (fCheckPOW && pcheckpoint && block.nHeight <= (uint32_t)pcheckpoint->nHeight) {
            if (!CheckProofOfWork(block.GetHash(), block.nBits, consensusParams)) {
                return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed with mix_hash only check");
            }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3923,13 +3923,25 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
 
 static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
+    // If we are checking a KAWPOW block below a know checkpoint height. We can validate the proof of work using the mix_hash
+    if (fCheckPOW && block.nTime >= nKAWPOWActivationTime) {
+        CBlockIndex* pcheckpoint = Checkpoints::GetLastCheckpoint(GetParams().Checkpoints());
+        if (fCheckPOW && block.nHeight <= (uint32_t)pcheckpoint->nHeight) {
+           if (!CheckProofOfWork(block.GetHash(), block.nBits, consensusParams)) {
+               return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed with mix_hash only check");
+           }
+
+           return true;
+        }
+    }
+
     uint256 mix_hash;
     // Check proof of work matches claimed amount
-    if (fCheckPOW && !CheckProofOfWork(block.GetHash(mix_hash), block.nBits, consensusParams)) {
+    if (fCheckPOW && !CheckProofOfWork(block.GetHashFull(mix_hash), block.nBits, consensusParams)) {
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
     }
 
-    if (block.nTime >= nKAWPOWActivationTime) {
+    if (fCheckPOW && block.nTime >= nKAWPOWActivationTime) {
         if (mix_hash != block.mix_hash) {
             return state.DoS(50, false, REJECT_INVALID, "invalid-mix-hash", false, "mix_hash validity failed");
         }
@@ -3948,7 +3960,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     // Check that the header is valid (particularly PoW).  This is mostly
     // redundant with the call in AcceptBlockHeader.
     if (!CheckBlockHeader(block, state, consensusParams, fCheckPOW))
-        return false;
+        return error("%s: Consensus::CheckBlockHeader: %s", __func__, FormatStateMessage(state));
 
     // Check the merkle root.
     if (fCheckMerkleRoot) {


### PR DESCRIPTION
Because we use block.GetHash() everywhere in the code to obtain the block hash. We are currently triggering it to do a full kawpow hash. Which when done on the same block multiple times can really slow down the syncing process. 

This commit changes to only do the full KawPow hash when checking the ProofofWork. If the proof of work is correct then we know we have a valid block. 

Everywhere else the GetHash is called for `logging`, `qt gui updates` we want to use the light mix_hash varient which doesn't take much time to compute at all. 