### PR TITLE
Fix memo's not attaching to GUI asset transfers

### DIFF
--- a/src/qt/assetsdialog.cpp
+++ b/src/qt/assetsdialog.cpp
@@ -366,7 +366,7 @@ void AssetsDialog::on_sendButton_clicked()
     std::vector< std::pair<CAssetTransfer, std::string> >vTransfers;
 
     for (auto recipient : recipients) {
-        vTransfers.emplace_back(std::make_pair(CAssetTransfer(recipient.assetName.toStdString(), recipient.amount), recipient.address.toStdString()));
+        vTransfers.emplace_back(std::make_pair(CAssetTransfer(recipient.assetName.toStdString(), recipient.amount, DecodeAssetData(recipient.message.toStdString()), 0), recipient.address.toStdString()));
     }
 
     // Always use a CCoinControl instance, use the AssetControlDialog instance if CoinControl has been enabled

--- a/src/qt/sendassetsentry.cpp
+++ b/src/qt/sendassetsentry.cpp
@@ -303,7 +303,7 @@ SendAssetsRecipient SendAssetsEntry::getValue()
     recipient.address = ui->payTo->text();
     recipient.label = ui->addAsLabel->text();
     recipient.amount = ui->payAssetAmount->value();
-    recipient.message = ui->messageTextLabel->text();
+    recipient.message = ui->memoBox->text();
 
     return recipient;
 }


### PR DESCRIPTION
- Found bug where the wrong message box text was being grabbed. 
- Added message to the asset transfer