### PR TITLE
Update develop with enforced value fixes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -153,7 +153,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE].nOverrideMinerConfirmationWindow = 2016;
         consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].bit = 9;
         consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nStartTime = 1593453600; // UTC: Mon Jun 29 2020 18:00:00
-        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nTimeout = 1624989600; // UTC: Mon Jun 29 2020 18:00:00
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nTimeout = 1624989600; // UTC: Mon Jun 29 2021 18:00:00
         consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideRuleChangeActivationThreshold = 1411; // Approx 70% of 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideMinerConfirmationWindow = 2016;
 
@@ -309,8 +309,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE].nOverrideMinerConfirmationWindow = 2016;
         consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].bit = 9;
         consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nStartTime = 1593453600; // UTC: Mon Jun 29 2020 18:00:00
-        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nTimeout = 1624989600; // UTC: Mon Jun 29 2020 18:00:00
-        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideRuleChangeActivationThreshold = 1209; // Approx 60% of 2016
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nTimeout = 1624989600; // UTC: Mon Jun 29 2021 18:00:00
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideRuleChangeActivationThreshold = 1411; // Approx 70% of 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideMinerConfirmationWindow = 2016;
 
         // The best chain should have at least this much work.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -307,6 +307,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE].nTimeout = 1618509600; // UTC: Thu Apr 15 2021 18:00:00
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE].nOverrideRuleChangeActivationThreshold = 1310;
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE].nOverrideMinerConfirmationWindow = 2016;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].bit = 9;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nStartTime = 1593453600; // UTC: Mon Jun 29 2020 18:00:00
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nTimeout = 1624989600; // UTC: Mon Jun 29 2020 18:00:00
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideRuleChangeActivationThreshold = 1209; // Approx 60% of 2016
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideMinerConfirmationWindow = 2016;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000000000168050db560b4");
@@ -517,6 +522,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE].nTimeout = 999999999999ULL;
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE].nOverrideRuleChangeActivationThreshold = 208;
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE].nOverrideMinerConfirmationWindow = 288;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].bit = 9;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nStartTime = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nTimeout = 999999999999ULL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideRuleChangeActivationThreshold = 108;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideMinerConfirmationWindow = 144;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -154,7 +154,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].bit = 9;
         consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nStartTime = 1593453600; // UTC: Mon Jun 29 2020 18:00:00
         consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nTimeout = 1624989600; // UTC: Mon Jun 29 2020 18:00:00
-        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideRuleChangeActivationThreshold = 1209; // Approx 60% of 2016
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideRuleChangeActivationThreshold = 1411; // Approx 70% of 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideMinerConfirmationWindow = 2016;
 
         // The best chain should have at least this much work

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -151,6 +151,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE].nTimeout = 1620324000; // UTC: Thu May 06 2021 18:00:00
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE].nOverrideRuleChangeActivationThreshold = 1714; // Approx 85% of 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE].nOverrideMinerConfirmationWindow = 2016;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].bit = 9;
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nStartTime = 1593453600; // UTC: Mon Jun 29 2020 18:00:00
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nTimeout = 1624989600; // UTC: Mon Jun 29 2020 18:00:00
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideRuleChangeActivationThreshold = 1209; // Approx 60% of 2016
+        consensus.vDeployments[Consensus::DEPLOYMENT_ENFORCE_VALUE].nOverrideMinerConfirmationWindow = 2016;
 
         // The best chain should have at least this much work
         consensus.nMinimumChainWork = uint256S("000000000000000000000000000000000000000000000020d4ac871fb7009b63"); // Block 1186833

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -37,6 +37,7 @@ static const size_t MIN_SERIALIZABLE_TRANSACTION_WEIGHT = WITNESS_SCALE_FACTOR *
 UNUSED_VAR static bool fAssetsIsActive = false;
 UNUSED_VAR static bool fRip5IsActive = false;
 UNUSED_VAR static bool fTransferScriptIsActive = false;
+UNUSED_VAR static bool fEnforcedValuesIsActive = false;
 
 unsigned int GetMaxBlockWeight();
 unsigned int GetMaxBlockSerializedSize();

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -19,6 +19,7 @@ enum DeploymentPos
     DEPLOYMENT_ASSETS, // Deployment of RIP2
     DEPLOYMENT_MSG_REST_ASSETS, // Delpoyment of RIP5 and Restricted assets
     DEPLOYMENT_TRANSFER_SCRIPT_SIZE,
+    DEPLOYMENT_ENFORCE_VALUE,
     // DEPLOYMENT_CSV, // Deployment of BIP68, BIP112, and BIP113.
 //    DEPLOYMENT_SEGWIT, // Deployment of BIP141, BIP143, and BIP147.
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -166,7 +166,7 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
     return nSigOps;
 }
 
-bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fCheckDuplicateInputs)
+bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fCheckDuplicateInputs, bool fMempoolCheck, bool fBlockCheck)
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty())
@@ -308,7 +308,27 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
                 // Specific check and error message to go with to make sure the amount is 0
                 if (txout.nValue != 0)
                     return state.DoS(100, false, REJECT_INVALID, "bad-txns-asset-issued-amount-isn't-zero");
+            }  else if (nType == TX_REISSUE_ASSET) {
+                // Specific check and error message to go with to make sure the amount is 0
+                if (AreEnforcedValuesDeployed()) {
+                    // We only want to not accept these txes when checking them from CheckBlock.
+                    // We don't want to change the behavior when reading transactions from the database
+                    // when AreEnforcedValuesDeployed return true
+                    if (fBlockCheck) {
+                        if (txout.nValue != 0) {
+                            return state.DoS(100, false, REJECT_INVALID, "bad-txns-asset-reissued-amount-isn't-zero");
+                        }
+                    }
+                }
+
+                if (fMempoolCheck) {
+                    // Don't accept to the mempool no matter what on these types of transactions
+                    if (txout.nValue != 0) {
+                        return state.DoS(100, false, REJECT_INVALID, "bad-txns-asset-reissued-amount-isn't-zero");
+                    }
+                }
             }
+
         }
     }
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -308,7 +308,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
                 // Specific check and error message to go with to make sure the amount is 0
                 if (txout.nValue != 0)
                     return state.DoS(100, false, REJECT_INVALID, "bad-txns-asset-issued-amount-isn't-zero");
-            }  else if (nType == TX_REISSUE_ASSET) {
+            } else if (nType == TX_REISSUE_ASSET) {
                 // Specific check and error message to go with to make sure the amount is 0
                 if (AreEnforcedValuesDeployed()) {
                     // We only want to not accept these txes when checking them from CheckBlock.
@@ -327,8 +327,9 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
                         return state.DoS(0, false, REJECT_INVALID, "bad-mempool-txns-asset-reissued-amount-isn't-zero");
                     }
                 }
+            } else {
+                return state.DoS(0, false, REJECT_INVALID, "bad-asset-type-not-any-of-the-main-three");
             }
-
         }
     }
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -316,7 +316,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
                     // when AreEnforcedValuesDeployed return true
                     if (fBlockCheck) {
                         if (txout.nValue != 0) {
-                            return state.DoS(100, false, REJECT_INVALID, "bad-txns-asset-reissued-amount-isn't-zero");
+                            return state.DoS(0, false, REJECT_INVALID, "bad-txns-asset-reissued-amount-isn't-zero");
                         }
                     }
                 }
@@ -324,7 +324,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
                 if (fMempoolCheck) {
                     // Don't accept to the mempool no matter what on these types of transactions
                     if (txout.nValue != 0) {
-                        return state.DoS(100, false, REJECT_INVALID, "bad-mempool-txns-asset-reissued-amount-isn't-zero");
+                        return state.DoS(0, false, REJECT_INVALID, "bad-mempool-txns-asset-reissued-amount-isn't-zero");
                     }
                 }
             }

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -324,7 +324,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
                 if (fMempoolCheck) {
                     // Don't accept to the mempool no matter what on these types of transactions
                     if (txout.nValue != 0) {
-                        return state.DoS(100, false, REJECT_INVALID, "bad-txns-asset-reissued-amount-isn't-zero");
+                        return state.DoS(100, false, REJECT_INVALID, "bad-mempool-txns-asset-reissued-amount-isn't-zero");
                     }
                 }
             }

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -26,7 +26,7 @@ class CNullAssetTxData;
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true, bool fMempoolCheck = false, bool fBlockCheck = false);
 
 namespace Consensus {
 /**

--- a/src/qt/ravengui.cpp
+++ b/src/qt/ravengui.cpp
@@ -865,40 +865,40 @@ void RavenGUI::createToolBars()
                            bool fNewSoftwareFound = false;
                            bool fStopSearch = false;
                            if (list.size() >= 4) {
-                               if (MAIN_SOFTWARE_VERSION < list[1].toInt()) {
+                               if (CLIENT_VERSION_MAJOR < list[1].toInt()) {
                                    fNewSoftwareFound = true;
                                } else {
-                                   if (MAIN_SOFTWARE_VERSION > list[1].toInt()) {
+                                   if (CLIENT_VERSION_MAJOR > list[1].toInt()) {
                                        fStopSearch = true;
                                    }
                                }
 
                                if (!fStopSearch) {
-                                   if (SECOND_SOFTWARE_VERSION < list[2].toInt()) {
+                                   if (CLIENT_VERSION_MINOR < list[2].toInt()) {
                                        fNewSoftwareFound = true;
                                    } else {
-                                       if (SECOND_SOFTWARE_VERSION > list[2].toInt()) {
+                                       if (CLIENT_VERSION_MINOR > list[2].toInt()) {
                                            fStopSearch = true;
                                        }
                                    }
                                }
 
                                if (!fStopSearch) {
-                                   if (THIRD_SOFTWARE_VERSION < list[3].toInt()) {
+                                   if (CLIENT_VERSION_REVISION < list[3].toInt()) {
                                        fNewSoftwareFound = true;
                                    }
                                }
                            }
 
                            if (fNewSoftwareFound) {
-                               labelVersionUpdate->setToolTip(QString::fromStdString(strprintf("Currently running: %s\nLatest version: %s", SOFTWARE_VERSION,
+                               labelVersionUpdate->setToolTip(QString::fromStdString(strprintf("Currently running: %s\nLatest version: %s", FormatFullVersion(),
                                                                                                latestVersion)));
                                labelVersionUpdate->show();
 
                                // Only display the message on startup to the user around 1/2 of the time
                                if (GetRandInt(2) == 1) {
                                    bool fRet = uiInterface.ThreadSafeQuestion(
-                                           strprintf("\nCurrently running: %s\nLatest version: %s", SOFTWARE_VERSION,
+                                           strprintf("\nCurrently running: %s\nLatest version: %s", FormatFullVersion(),
                                                      latestVersion) + "\n\nWould you like to visit the releases page?",
                                            "",
                                            "New Wallet Version Found",

--- a/src/qt/ravengui.cpp
+++ b/src/qt/ravengui.cpp
@@ -862,29 +862,32 @@ void RavenGUI::createToolBars()
 
                            // List the found values
                            QStringList list = rx.capturedTexts();
+                           static const int CLIENT_VERSION_MAJOR_INDEX = 1;
+                           static const int CLIENT_VERSION_MINOR_INDEX = 2;
+                           static const int CLIENT_VERSION_REVISION_INDEX = 3;
                            bool fNewSoftwareFound = false;
                            bool fStopSearch = false;
                            if (list.size() >= 4) {
-                               if (CLIENT_VERSION_MAJOR < list[1].toInt()) {
+                               if (CLIENT_VERSION_MAJOR < list[CLIENT_VERSION_MAJOR_INDEX].toInt()) {
                                    fNewSoftwareFound = true;
                                } else {
-                                   if (CLIENT_VERSION_MAJOR > list[1].toInt()) {
+                                   if (CLIENT_VERSION_MAJOR > list[CLIENT_VERSION_MAJOR_INDEX].toInt()) {
                                        fStopSearch = true;
                                    }
                                }
 
                                if (!fStopSearch) {
-                                   if (CLIENT_VERSION_MINOR < list[2].toInt()) {
+                                   if (CLIENT_VERSION_MINOR < list[CLIENT_VERSION_MINOR_INDEX].toInt()) {
                                        fNewSoftwareFound = true;
                                    } else {
-                                       if (CLIENT_VERSION_MINOR > list[2].toInt()) {
+                                       if (CLIENT_VERSION_MINOR > list[CLIENT_VERSION_MINOR_INDEX].toInt()) {
                                            fStopSearch = true;
                                        }
                                    }
                                }
 
                                if (!fStopSearch) {
-                                   if (CLIENT_VERSION_REVISION < list[3].toInt()) {
+                                   if (CLIENT_VERSION_REVISION < list[CLIENT_VERSION_REVISION_INDEX].toInt()) {
                                        fNewSoftwareFound = true;
                                    }
                                }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1433,6 +1433,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BIP9SoftForkDescPushBack(bip9_softforks, "assets", consensusParams, Consensus::DEPLOYMENT_ASSETS);
     BIP9SoftForkDescPushBack(bip9_softforks, "messaging_restricted", consensusParams, Consensus::DEPLOYMENT_MSG_REST_ASSETS);
     BIP9SoftForkDescPushBack(bip9_softforks, "transfer_script", consensusParams, Consensus::DEPLOYMENT_TRANSFER_SCRIPT_SIZE);
+    BIP9SoftForkDescPushBack(bip9_softforks, "enforce", consensusParams, Consensus::DEPLOYMENT_ENFORCE_VALUE);
     obj.push_back(Pair("softforks",             softforks));
     obj.push_back(Pair("bip9_softforks", bip9_softforks));
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -263,6 +263,36 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     return result;
 }
 
+UniValue decodeblockToJSON(const CBlock& block)
+{
+    UniValue result(UniValue::VOBJ);
+    result.push_back(Pair("hash", block.GetHash().GetHex()));
+
+    result.push_back(Pair("strippedsize", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS)));
+    result.push_back(Pair("size", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION)));
+    result.push_back(Pair("weight", (int)::GetBlockWeight(block)));
+    result.push_back(Pair("height", (int)block.nHeight));
+    result.push_back(Pair("version", block.nVersion));
+    result.push_back(Pair("versionHex", strprintf("%08x", block.nVersion)));
+    result.push_back(Pair("merkleroot", block.hashMerkleRoot.GetHex()));
+    UniValue txs(UniValue::VARR);
+    for(const auto& tx : block.vtx)
+    {
+        UniValue objTx(UniValue::VOBJ);
+        TxToUniv(*tx, uint256(), objTx, true, RPCSerializationFlags());
+        txs.push_back(objTx);
+    }
+    result.push_back(Pair("tx", txs));
+    result.push_back(Pair("time", block.GetBlockTime()));
+    result.push_back(Pair("nonce", (uint64_t)block.nNonce));
+    result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
+    result.push_back(Pair("headerhash", block.GetKAWPOWHeaderHash().GetHex()));
+    result.push_back(Pair("mixhash", block.mix_hash.GetHex()));
+    result.push_back(Pair("nonce64", (uint64_t)block.nNonce64));
+
+    return result;
+}
+
 UniValue getblockcount(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
@@ -989,6 +1019,45 @@ UniValue getblock(const JSONRPCRequest& request)
 
     return blockToJSON(block, pblockindex, verbosity >= 2);
 }
+
+UniValue decodeblock(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 1)
+        throw std::runtime_error(
+                "decodeblock \"blockhex\"\n"
+                "\nArguments:\n"
+                "1. \"blockhex\"          (string, required) The block hex\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"hash\" : \"hash\",     (string) the block hash (same as provided)\n"
+                "  \"size\" : n,            (numeric) The block size\n"
+                "  \"strippedsize\" : n,    (numeric) The block size excluding witness data\n"
+                "  \"weight\" : n           (numeric) The block weight as defined in BIP 141\n"
+                "  \"height\" : n,          (numeric) The block height or index\n"
+                "  \"version\" : n,         (numeric) The block version\n"
+                "  \"versionHex\" : \"00000000\", (string) The block version formatted in hexadecimal\n"
+                "  \"merkleroot\" : \"xxxx\", (string) The merkle root\n"
+                "  \"tx\" : [               (array of string) The transaction ids\n"
+                "     \"transactionid\"     (string) The transaction id\n"
+                "     ,...\n"
+                "  ],\n"
+                "  \"time\" : ttt,          (numeric) The block time in seconds since epoch (Jan 1 1970 GMT)\n"
+                "  \"nonce\" : n,           (numeric) The nonce\n"
+                "  \"bits\" : \"1d00ffff\", (string) The bits\n"
+                "}\n"
+                "\nExamples:\n"
+                + HelpExampleCli("decodeblock", "\"xxxx\"")
+                + HelpExampleRpc("decodeblock", "\"xxxx\"")
+        );
+
+    std::string strHex = request.params[0].get_str();
+    CBlock block;
+    DecodeHexBlk(block, strHex);
+
+    return decodeblockToJSON(block);
+}
+
+
 
 struct CCoinsStats
 {
@@ -1833,6 +1902,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "getbestblockhash",       &getbestblockhash,       {} },
     { "blockchain",         "getblockcount",          &getblockcount,          {} },
     { "blockchain",         "getblock",               &getblock,               {"blockhash","verbosity|verbose"} },
+    { "blockchain",         "decodeblock",            &decodeblock,               {"blockhex",} },
     { "blockchain",         "getblockdeltas",         &getblockdeltas,         {} },
     { "blockchain",         "getblockhashes",         &getblockhashes,         {} },
     { "blockchain",         "getblockhash",           &getblockhash,           {"height"} },

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1902,7 +1902,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "getbestblockhash",       &getbestblockhash,       {} },
     { "blockchain",         "getblockcount",          &getblockcount,          {} },
     { "blockchain",         "getblock",               &getblock,               {"blockhash","verbosity|verbose"} },
-    { "blockchain",         "decodeblock",            &decodeblock,               {"blockhex",} },
+    { "blockchain",         "decodeblock",            &decodeblock,               {"blockhex"} },
     { "blockchain",         "getblockdeltas",         &getblockdeltas,         {} },
     { "blockchain",         "getblockhashes",         &getblockhashes,         {} },
     { "blockchain",         "getblockhash",           &getblockhash,           {"height"} },

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -30,6 +30,7 @@ void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);
 
 /** Block description to JSON */
 UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false);
+UniValue decodeblockToJSON(const CBlock& block);
 
 /** Mempool information to JSON */
 UniValue mempoolInfoToJSON();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5715,7 +5715,7 @@ bool AreEnforcedValuesDeployed()
         return true;
 
     const ThresholdState thresholdState = VersionBitsTipState(GetParams().GetConsensus(), Consensus::DEPLOYMENT_ENFORCE_VALUE);
-    if (thresholdState == THRESHOLD_ACTIVE)
+    if (thresholdState == THRESHOLD_ACTIVE || thresholdState == THRESHOLD_LOCKED_IN)
         fEnforcedValuesIsActive = true;
 
     return fEnforcedValuesIsActive;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -67,6 +67,13 @@
 #define MICRO 0.000001
 #define MILLI 0.001
 
+#define CHECK_DUPLICATE_TRANSACTION_TRUE true
+#define CHECK_DUPLICATE_TRANSACTION_FALSE false
+#define CHECK_MEMPOOL_TRANSACTION_TRUE true
+#define CHECK_MEMPOOL_TRANSACTION_FALSE false
+#define CHECK_BLOCK_TRANSACTION_TRUE true
+#define CHECK_BLOCK_TRANSACTION_FALSE false
+
 /**
  * Global state
  */
@@ -3999,16 +4006,16 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-multiple", false, "more than one coinbase");
 
     // Check transactions
-    bool fCheckBlock = true;
-    bool fCheckDuplicates = true;
-    bool fCheckMempool = false;
+    bool fCheckBlock = CHECK_BLOCK_TRANSACTION_TRUE;
+    bool fCheckDuplicates = CHECK_DUPLICATE_TRANSACTION_TRUE;
+    bool fCheckMempool = CHECK_MEMPOOL_TRANSACTION_FALSE;
     for (const auto& tx : block.vtx) {
         // We only want to check the blocks when they are added to our chain
         // We want to make sure when nodes shutdown and restart that they still
         // verify the blocks in the database correctly even if Enforce Value BIP is active
-        fCheckBlock = true;
+        fCheckBlock = CHECK_BLOCK_TRANSACTION_TRUE;
         if (fDBCheck){
-            fCheckBlock = false;
+            fCheckBlock = CHECK_BLOCK_TRANSACTION_FALSE;
         }
 
         if (!CheckTransaction(*tx, state, fCheckDuplicates, fCheckMempool, fCheckBlock))

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5703,6 +5703,12 @@ double GuessVerificationProgress(const ChainTxData& data, CBlockIndex *pindex) {
 }
 
 /** RVN START */
+
+// Only used by test framework
+void SetEnforcedValues(bool value) {
+    fEnforcedValuesIsActive = value;
+}
+
 bool AreEnforcedValuesDeployed()
 {
     if (fEnforcedValuesIsActive)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -515,7 +515,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
     AssertLockHeld(cs_main);
     if (pfMissingInputs)
         *pfMissingInputs = false;
-    if (!CheckTransaction(tx, state))
+    if (!CheckTransaction(tx, state, true, true))
         return false; // state filled in by CheckTransaction
 
     // Coinbase is only valid in a block, not as a loose transaction
@@ -3997,7 +3997,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Check transactions
     for (const auto& tx : block.vtx)
-        if (!CheckTransaction(*tx, state))
+        if (!CheckTransaction(*tx, state, true, false, true))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s %s", tx->GetHash().ToString(), state.GetDebugMessage(), state.GetRejectReason()));
 
@@ -5703,7 +5703,20 @@ double GuessVerificationProgress(const ChainTxData& data, CBlockIndex *pindex) {
 }
 
 /** RVN START */
-bool AreAssetsDeployed() {
+bool AreEnforcedValuesDeployed()
+{
+    if (fEnforcedValuesIsActive)
+        return true;
+
+    const ThresholdState thresholdState = VersionBitsTipState(GetParams().GetConsensus(), Consensus::DEPLOYMENT_ENFORCE_VALUE);
+    if (thresholdState == THRESHOLD_ACTIVE)
+        fEnforcedValuesIsActive = true;
+
+    return fEnforcedValuesIsActive;
+}
+
+bool AreAssetsDeployed()
+{
 
     if (fAssetsIsActive)
         return true;

--- a/src/validation.h
+++ b/src/validation.h
@@ -597,6 +597,9 @@ bool AreRestrictedAssetsDeployed();
 
 bool AreEnforcedValuesDeployed();
 
+// Only used by test framework
+void SetEnforcedValues(bool value);
+
 bool IsRip5Active();
 
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -595,6 +595,8 @@ bool AreMessagesDeployed();
 
 bool AreRestrictedAssetsDeployed();
 
+bool AreEnforcedValuesDeployed();
+
 bool IsRip5Active();
 
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -451,7 +451,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
-bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
+bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fDBCheck = false);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block, with cs_main held) */
 bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true);

--- a/src/version.h
+++ b/src/version.h
@@ -6,17 +6,18 @@
 #ifndef RAVEN_VERSION_H
 #define RAVEN_VERSION_H
 
+#include <tinyformat.h>
 /**
  * network protocol versioning
  */
 
-// Update these four values on every release cycle
+// Update these three values on every release cycle
 // These values should match the values in configure.ac
 // Used for checking the Ravencoin releases on github
-static const std::string SOFTWARE_VERSION = "v4.2.0";
 static const int MAIN_SOFTWARE_VERSION = 4;
 static const int SECOND_SOFTWARE_VERSION = 2;
 static const int THIRD_SOFTWARE_VERSION = 0;
+static const std::string SOFTWARE_VERSION = strprintf("v%d.%d.%d", MAIN_SOFTWARE_VERSION, SECOND_SOFTWARE_VERSION, THIRD_SOFTWARE_VERSION);
 
 static const int PROTOCOL_VERSION = 70028;
 

--- a/src/version.h
+++ b/src/version.h
@@ -6,18 +6,9 @@
 #ifndef RAVEN_VERSION_H
 #define RAVEN_VERSION_H
 
-#include <tinyformat.h>
 /**
  * network protocol versioning
  */
-
-// Update these three values on every release cycle
-// These values should match the values in configure.ac
-// Used for checking the Ravencoin releases on github
-static const int MAIN_SOFTWARE_VERSION = 4;
-static const int SECOND_SOFTWARE_VERSION = 2;
-static const int THIRD_SOFTWARE_VERSION = 0;
-static const std::string SOFTWARE_VERSION = strprintf("v%d.%d.%d", MAIN_SOFTWARE_VERSION, SECOND_SOFTWARE_VERSION, THIRD_SOFTWARE_VERSION);
 
 static const int PROTOCOL_VERSION = 70028;
 

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -26,6 +26,10 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
     {
             /*.name =*/ "transfer_script",
             /*.gbt_force =*/ true,
+    },
+    {
+            /*.name =*/ "enforce_value",
+            /*.gbt_force =*/ true,
     }
 };
 


### PR DESCRIPTION
- Added Bip Logic for the new ENFORCE_VALUE BIP which will enforce reissue assets to have a value of 0 in the txout.nValue - 62c30f9, 905952c, 787d4c0, 9c8fbc0, 8141607, c455cfc, 185a052, 09578af   
- Added new rpccall `decodeblock` - ae65a29
- Updated GUI version checking to use configure.ac variable -  8c1fb71, 627a6f0, 405e1ee


Code Added by developers:
@akshaynexus - 8c1fb71 
@blondfrogs - 62c30f9, 905952c, 787d4c0, 9c8fbc0, 8141607, c455cfc, 185a052, 09578af, 627a6f0, 405e1ee, ae65a29, e889065

Closes #795 