### PR TITLE
[Qt] Use version nums from configure

### DIFF
--- a/src/qt/ravengui.cpp
+++ b/src/qt/ravengui.cpp
@@ -865,40 +865,40 @@ void RavenGUI::createToolBars()
                            bool fNewSoftwareFound = false;
                            bool fStopSearch = false;
                            if (list.size() >= 4) {
-                               if (MAIN_SOFTWARE_VERSION < list[1].toInt()) {
+                               if (CLIENT_VERSION_MAJOR < list[1].toInt()) {
                                    fNewSoftwareFound = true;
                                } else {
-                                   if (MAIN_SOFTWARE_VERSION > list[1].toInt()) {
+                                   if (CLIENT_VERSION_MAJOR > list[1].toInt()) {
                                        fStopSearch = true;
                                    }
                                }
 
                                if (!fStopSearch) {
-                                   if (SECOND_SOFTWARE_VERSION < list[2].toInt()) {
+                                   if (CLIENT_VERSION_MINOR < list[2].toInt()) {
                                        fNewSoftwareFound = true;
                                    } else {
-                                       if (SECOND_SOFTWARE_VERSION > list[2].toInt()) {
+                                       if (CLIENT_VERSION_MINOR > list[2].toInt()) {
                                            fStopSearch = true;
                                        }
                                    }
                                }
 
                                if (!fStopSearch) {
-                                   if (THIRD_SOFTWARE_VERSION < list[3].toInt()) {
+                                   if (CLIENT_VERSION_REVISION < list[3].toInt()) {
                                        fNewSoftwareFound = true;
                                    }
                                }
                            }
 
                            if (fNewSoftwareFound) {
-                               labelVersionUpdate->setToolTip(QString::fromStdString(strprintf("Currently running: %s\nLatest version: %s", SOFTWARE_VERSION,
+                               labelVersionUpdate->setToolTip(QString::fromStdString(strprintf("Currently running: %s\nLatest version: %s", FormatFullVersion(),
                                                                                                latestVersion)));
                                labelVersionUpdate->show();
 
                                // Only display the message on startup to the user around 1/2 of the time
                                if (GetRandInt(2) == 1) {
                                    bool fRet = uiInterface.ThreadSafeQuestion(
-                                           strprintf("\nCurrently running: %s\nLatest version: %s", SOFTWARE_VERSION,
+                                           strprintf("\nCurrently running: %s\nLatest version: %s", FormatFullVersion(),
                                                      latestVersion) + "\n\nWould you like to visit the releases page?",
                                            "",
                                            "New Wallet Version Found",

--- a/src/version.h
+++ b/src/version.h
@@ -10,14 +10,6 @@
  * network protocol versioning
  */
 
-// Update these four values on every release cycle
-// These values should match the values in configure.ac
-// Used for checking the Ravencoin releases on github
-static const std::string SOFTWARE_VERSION = "v4.2.0";
-static const int MAIN_SOFTWARE_VERSION = 4;
-static const int SECOND_SOFTWARE_VERSION = 2;
-static const int THIRD_SOFTWARE_VERSION = 0;
-
 static const int PROTOCOL_VERSION = 70028;
 
 //! initial proto version, to be increased after version/verack negotiation


### PR DESCRIPTION
This PR remove the requirement to update version messages on each new version in version.h constants and rather pull the version numbers from the configure values.