### PR TITLE
fixing boost 1.73 compile errors

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -65,7 +65,9 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/bind.hpp>
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/thread.hpp>
 #include <openssl/crypto.h>

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -28,7 +28,8 @@
 
 // Fixing Boost 1.73 compile errors
 #include <boost/bind/bind.hpp>
-using namespace boost::placeholders;class CBlockIndex;
+using namespace boost::placeholders;
+class CBlockIndex;
 
 static int64_t nLastHeaderTipUpdateNotification = 0;
 static int64_t nLastBlockTipUpdateNotification = 0;

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -26,7 +26,9 @@
 #include <QDebug>
 #include <QTimer>
 
-class CBlockIndex;
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;class CBlockIndex;
 
 static int64_t nLastHeaderTipUpdateNotification = 0;
 static int64_t nLastBlockTipUpdateNotification = 0;

--- a/src/qt/myrestrictedassettablemodel.cpp
+++ b/src/qt/myrestrictedassettablemodel.cpp
@@ -27,6 +27,10 @@
 #include <QIcon>
 #include <QList>
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
         Qt::AlignLeft|Qt::AlignVCenter, /* date */

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -29,6 +29,7 @@
 
 #include <QDebug>
 #include <QTimer>
+#include <QPainterPath>
 #include <QGraphicsDropShadowEffect>
 #include <QScrollBar>
 

--- a/src/qt/ravengui.cpp
+++ b/src/qt/ravengui.cpp
@@ -69,6 +69,10 @@
 #include <QToolBar>
 #include <QVBoxLayout>
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 #include <QTextDocument>
 #include <QUrl>

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -31,6 +31,10 @@
 #define QTversionPreFiveEleven
 #endif
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) :
     QWidget(0, f), curAlignment(0)
 {

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -7,6 +7,7 @@
 #include "clientmodel.h"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -27,6 +27,10 @@
 #include <QIcon>
 #include <QList>
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
         Qt::AlignLeft|Qt::AlignVCenter, /* status */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -39,6 +39,9 @@
 #include <QSet>
 #include <QTimer>
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
 
 WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, OptionsModel *_optionsModel, QObject *parent) :
     QObject(parent), wallet(_wallet), optionsModel(_optionsModel), addressTableModel(0),

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -19,7 +19,9 @@
 #include <mutex>
 #include <univalue.h>
 
-#include <boost/bind.hpp>
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
 #include <boost/signals2/signal.hpp>
 #include <boost/algorithm/string/case_conv.hpp> // for to_upper()
 #include <boost/algorithm/string/classification.hpp>

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -9,7 +9,9 @@
 #include "reverselock.h"
 
 #include <assert.h>
-#include <boost/bind.hpp>
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
 #include <utility>
 
 CScheduler::CScheduler() : nThreadsServicingQueue(0), stopRequested(false), stopWhenEmpty(false)

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -8,7 +8,9 @@
 
 #include "test/test_raven.h"
 
-#include <boost/bind.hpp>
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
 #include <boost/thread.hpp>
 #include <boost/test/unit_test.hpp>
 

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -16,7 +16,9 @@
 #include <set>
 #include <stdlib.h>
 
-#include <boost/bind.hpp>
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
 #include <boost/signals2/signal.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -60,6 +60,10 @@
 #include "assets/snapshotrequestdb.h"
 #include "assets/assetsnapshotdb.h"
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 #if defined(NDEBUG)
 # error "Raven cannot be compiled without assertions."
 #endif

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,10 @@
 
 #include <boost/signals2/signal.hpp>
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;
     boost::signals2::signal<void (const CTransactionRef &)> TransactionAddedToMempool;


### PR DESCRIPTION
Splitting a few changes up to simplify commits.  Part one is to resolve compile errors using boost v1.73.  Part two is resolving compile issues for QT 5.15. Part three has new test enhancements and coverage.