### PR TITLE
Adding master branch PRs to run build as part of process

### DIFF
--- a/.github/workflows/build-raven.yml
+++ b/.github/workflows/build-raven.yml
@@ -1,4 +1,4 @@
-name: Build Raven
+name: Build Raxven
 
 on:
   push:
@@ -6,6 +6,7 @@ on:
       - release*
   pull_request:
     branches:
+      - master
       - develop
       - release*
     paths-ignore:

--- a/.github/workflows/build-raven.yml
+++ b/.github/workflows/build-raven.yml
@@ -1,4 +1,4 @@
-name: Build Raxven
+name: Build Raven
 
 on:
   push:


### PR DESCRIPTION
Previously only develop and release branches were setup to auto-build on a PR. Now this includes master.