### PR TITLE
mney - correct seed policy readme

### DIFF
--- a/.github/scripts/05-binary-checks.sh
+++ b/.github/scripts/05-binary-checks.sh
@@ -3,7 +3,7 @@
 OS=${1}
 GITHUB_WORKSPACE=${2}
 
-export BOOST_TEST_LOG_LEVEL=error
+export BOOST_TEST_LOG_LEVEL=all
 
 if [[ ${OS} == "windows" ]]; then
     echo "----------------------------------------"

--- a/.github/scripts/05-binary-checks.sh
+++ b/.github/scripts/05-binary-checks.sh
@@ -3,7 +3,7 @@
 OS=${1}
 GITHUB_WORKSPACE=${2}
 
-export BOOST_TEST_LOG_LEVEL=all
+export BOOST_TEST_LOG_LEVEL=error
 
 if [[ ${OS} == "windows" ]]; then
     echo "----------------------------------------"

--- a/doc/dnsseed-policy.md
+++ b/doc/dnsseed-policy.md
@@ -44,7 +44,7 @@ related to the DNS seed operation.
 If these expectations cannot be satisfied the operator should
 discontinue providing services and contact the active Raven
 Core development team as well as posting on
-[raven-dev](https://lists.linuxfoundation.org/mailman/listinfo/raven-dev).
+[raven-dev](mailto:feedback@ravencoin.org).
 
 Behavior outside of these expectations may be reasonable in some
 situations but should be discussed in public in advance.


### PR DESCRIPTION
The readme for the DNS policy had two links that were/are invalid. Pointed the link for the seeder source to the ravenProject/ravencoin-seeder and the contact to our feedback@ravencoin.org since we don't have a mailman list on the server specified.