### PR TITLE
(Doc) Updated unix library list

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -78,7 +78,7 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-    sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3 libdb++
+    sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3 libdb++-dev
 
 Options when installing required Boost library files:
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -48,6 +48,7 @@ These dependencies are required:
  libssl      | Crypto           | Random Number Generation, Elliptic Curve Cryptography
  libboost    | Utility          | Library for threading, data structures, etc
  libevent    | Networking       | OS independent asynchronous networking
+ libdb++     | Utility          | Contains headers and static libraries for the Berkeley DB library
 
 Optional dependencies:
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -78,7 +78,7 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-    sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3
+    sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3 libdb++
 
 Options when installing required Boost library files:
 


### PR DESCRIPTION
In the docs  libdb++ isn't listed, although libdb4.8 is and is listed as optional. But ravencoin will not compile without the libdb++ library (even without running the wallet)

You will get the following error:
In file included from ./wallet/walletdb.h:12,
                 from ./wallet/wallet.h:20,
                 from consensus/tx_verify.cpp:18:
./wallet/db.h:22:10: fatal error: db_cxx.h: No such file or directory
   22 | #include <db_cxx.h>
      |          ^~~~~~~~~~
compilation terminated.