### PR TITLE
Set and reset better maximum values on quantity spinboxes for asset c…

### DIFF
--- a/src/qt/createassetdialog.cpp
+++ b/src/qt/createassetdialog.cpp
@@ -1340,32 +1340,39 @@ void CreateAssetDialog::updateMinFeeLabel()
 
 void CreateAssetDialog::setUniqueSelected()
 {
-    ui->reissuableBox->setChecked(false);
     ui->quantitySpinBox->setValue(1);
-    ui->unitBox->setValue(0);
-    ui->reissuableBox->setDisabled(true);
-    ui->unitBox->setDisabled(true);
     ui->quantitySpinBox->setDisabled(true);
+
+    ui->unitBox->setValue(0);
+    ui->unitBox->setDisabled(true);
+
+    ui->reissuableBox->setChecked(false);
+    ui->reissuableBox->setDisabled(true);
 }
 
 void CreateAssetDialog::setQualifierSelected()
 {
-    ui->reissuableBox->setChecked(false);
     ui->quantitySpinBox->setValue(1);
     ui->quantitySpinBox->setMaximum(10);
+    ui->quantitySpinBox->setDisabled(false);
+    
     ui->unitBox->setValue(0);
-    ui->reissuableBox->setDisabled(true);
     ui->unitBox->setDisabled(true);
+
+    ui->reissuableBox->setChecked(false);
+    ui->reissuableBox->setDisabled(true);
 }
 
 void CreateAssetDialog::clearSelected()
 {
-    ui->reissuableBox->setDisabled(false);
-    ui->unitBox->setDisabled(false);
-    ui->quantitySpinBox->setDisabled(false);
-    ui->reissuableBox->setChecked(true);
-    ui->unitBox->setValue(0);
     ui->quantitySpinBox->setMaximum(21000000000);
+    ui->quantitySpinBox->setDisabled(false);
+
+    ui->unitBox->setValue(0);
+    ui->unitBox->setDisabled(false);
+    
+    ui->reissuableBox->setChecked(true);
+    ui->reissuableBox->setDisabled(false);
 }
 
 void CreateAssetDialog::updateAssetList()
@@ -1433,6 +1440,7 @@ void CreateAssetDialog::clear()
     ui->assetFullName->clear();
     ui->unitBox->setDisabled(false);
     ui->quantitySpinBox->setDisabled(false);
+    ui->quantitySpinBox->setMaximum(21000000000);
     ui->nameText->setEnabled(true);
 
     ui->reissuableBox->setDisabled(false);
@@ -1492,7 +1500,6 @@ void CreateAssetDialog::restrictedAssetNotSelected()
     ui->nameText->clear();
     ui->nameText->setEnabled(true);
     ui->assetFullName->show();
-    ui->quantitySpinBox->setMaximum(21000000000);
 
     ui->labelVerifierString->hide();
     ui->lineEditVerifierString->hide();

--- a/src/qt/createassetdialog.cpp
+++ b/src/qt/createassetdialog.cpp
@@ -1365,6 +1365,7 @@ void CreateAssetDialog::clearSelected()
     ui->quantitySpinBox->setDisabled(false);
     ui->reissuableBox->setChecked(true);
     ui->unitBox->setValue(0);
+    ui->quantitySpinBox->setMaximum(1000000000);
 }
 
 void CreateAssetDialog::updateAssetList()
@@ -1491,6 +1492,7 @@ void CreateAssetDialog::restrictedAssetNotSelected()
     ui->nameText->clear();
     ui->nameText->setEnabled(true);
     ui->assetFullName->show();
+    ui->quantitySpinBox->setMaximum(1000000000);
 
     ui->labelVerifierString->hide();
     ui->lineEditVerifierString->hide();

--- a/src/qt/createassetdialog.cpp
+++ b/src/qt/createassetdialog.cpp
@@ -1365,7 +1365,7 @@ void CreateAssetDialog::clearSelected()
     ui->quantitySpinBox->setDisabled(false);
     ui->reissuableBox->setChecked(true);
     ui->unitBox->setValue(0);
-    ui->quantitySpinBox->setMaximum(1000000000);
+    ui->quantitySpinBox->setMaximum(21000000000);
 }
 
 void CreateAssetDialog::updateAssetList()
@@ -1492,7 +1492,7 @@ void CreateAssetDialog::restrictedAssetNotSelected()
     ui->nameText->clear();
     ui->nameText->setEnabled(true);
     ui->assetFullName->show();
-    ui->quantitySpinBox->setMaximum(1000000000);
+    ui->quantitySpinBox->setMaximum(21000000000);
 
     ui->labelVerifierString->hide();
     ui->lineEditVerifierString->hide();


### PR DESCRIPTION
If the maxvalues are usable, I think this will fix issue #871 and #830 

The fixed issue can be recreated like this:
Select Qualifier Asset
Select Main Asset
Try to set Quantity more than 10.