### PR TITLE
GUI: custom ipfs viewer url

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="tabMain">
       <attribute name="title">
@@ -628,6 +628,34 @@
           <widget class="QLineEdit" name="thirdPartyTxUrls">
            <property name="toolTip">
             <string>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4_Display" stretch="0,0,0">
+         <item>
+          <widget class="QLabel" name="ipfsUrlLabel">
+           <property name="toolTip">
+            <string>Third party URL for IPFS-viewer. %s in the URL is replaced by IPFS hash.</string>
+           </property>
+           <property name="text">
+            <string>IPFS Viewer URL</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="ipfsUrl">
+           <property name="toolTip">
+            <string>Third party URL for IPFS-viewer. %s in the URL is replaced by IPFS hash.</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="ipfsUrlReset">
+           <property name="text">
+            <string>Reset</string>
            </property>
           </widget>
          </item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -109,6 +109,7 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     }
 #if QT_VERSION >= 0x040700
     ui->thirdPartyTxUrls->setPlaceholderText("https://example.com/tx/%s");
+    ui->ipfsUrl->setPlaceholderText("https://ipfs.io/ipfs/%s");
 #endif
 
     ui->unit->setModel(new RavenUnits(this));
@@ -168,6 +169,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
     /* Display */
     connect(ui->lang, SIGNAL(valueChanged()), this, SLOT(showRestartWarning()));
     connect(ui->thirdPartyTxUrls, SIGNAL(textChanged(const QString &)), this, SLOT(showRestartWarning()));
+    connect(ui->ipfsUrl, SIGNAL(textChanged(const QString &)), this, SLOT(showRestartWarning()));
     connect(ui->darkModeCheckBox, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
 }
 
@@ -207,6 +209,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->lang, OptionsModel::Language);
     mapper->addMapping(ui->unit, OptionsModel::DisplayUnit);
     mapper->addMapping(ui->thirdPartyTxUrls, OptionsModel::ThirdPartyTxUrls);
+    mapper->addMapping(ui->ipfsUrl, OptionsModel::IpfsUrl);
 }
 
 void OptionsDialog::setOkButtonState(bool fState)
@@ -230,6 +233,12 @@ void OptionsDialog::on_resetButton_clicked()
         model->Reset();
         QApplication::quit();
     }
+}
+
+void OptionsDialog::on_ipfsUrlReset_clicked()
+{
+    /* reset third-party IPFS viewer URL to default setting. */
+    ui->ipfsUrl->setText("https://ipfs.io/ipfs/%s");
 }
 
 void OptionsDialog::on_openRavenConfButton_clicked()

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -48,6 +48,7 @@ private Q_SLOTS:
     /* set OK button state (enabled / disabled) */
     void setOkButtonState(bool fState);
     void on_resetButton_clicked();
+    void on_ipfsUrlReset_clicked();
     void on_openRavenConfButton_clicked();
     void on_okButton_clicked();
     void on_cancelButton_clicked();

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -79,6 +79,10 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("strThirdPartyTxUrls", "");
     strThirdPartyTxUrls = settings.value("strThirdPartyTxUrls", "").toString();
 
+    if (!settings.contains("strIpfsUrl"))
+        settings.setValue("strIpfsUrl", "https://ipfs.io/ipfs/%s");
+    strIpfsUrl = settings.value("strIpfsUrl", "").toString();
+
     if (!settings.contains("fCoinControlFeatures"))
         settings.setValue("fCoinControlFeatures", false);
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
@@ -269,6 +273,8 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             return nDisplayUnit;
         case ThirdPartyTxUrls:
             return strThirdPartyTxUrls;
+        case IpfsUrl:
+            return strIpfsUrl;
         case Language:
             return settings.value("language");
         case CoinControlFeatures:
@@ -399,6 +405,13 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (strThirdPartyTxUrls != value.toString()) {
                 strThirdPartyTxUrls = value.toString();
                 settings.setValue("strThirdPartyTxUrls", strThirdPartyTxUrls);
+                setRestartRequired(true);
+            }
+            break;
+        case IpfsUrl:
+            if (strIpfsUrl != value.toString()) {
+                strIpfsUrl = value.toString();
+                settings.setValue("strIpfsUrl", strIpfsUrl);
                 setRestartRequired(true);
             }
             break;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -41,6 +41,7 @@ public:
         ProxyPortTor,           // int
         DisplayUnit,            // RavenUnits::Unit
         ThirdPartyTxUrls,       // QString
+        IpfsUrl,                // QString
         Language,               // QString
         CoinControlFeatures,    // bool
         ThreadsScriptVerif,     // int
@@ -67,6 +68,7 @@ public:
     bool getMinimizeOnClose() const { return fMinimizeOnClose; }
     int getDisplayUnit() const { return nDisplayUnit; }
     QString getThirdPartyTxUrls() const { return strThirdPartyTxUrls; }
+    QString getIpfsUrl() const { return strIpfsUrl; }
     bool getProxySettings(QNetworkProxy& proxy) const;
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
     bool getCustomFeeFeatures() const { return fCustomFeeFeatures; }
@@ -85,6 +87,7 @@ private:
     QString language;
     int nDisplayUnit;
     QString strThirdPartyTxUrls;
+    QString strIpfsUrl;
     bool fCoinControlFeatures;
     /** RVN START*/
     bool fCustomFeeFeatures;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -475,6 +475,7 @@ void OverviewPage::handleAssetRightClicked(const QModelIndex &index)
         // Grab the data elements from the index that we need to disable and enable menu items
         QString name = index.data(AssetTableModel::AssetNameRole).toString();
         QString ipfshash = index.data(AssetTableModel::AssetIPFSHashRole).toString();
+        QString ipfsbrowser = walletModel->getOptionsModel()->getIpfsUrl();
 
         if (IsAssetNameAnOwner(name.toStdString())) {
             name = name.left(name.size() - 1);
@@ -484,7 +485,7 @@ void OverviewPage::handleAssetRightClicked(const QModelIndex &index)
         }
 
         // If the ipfs hash isn't there or doesn't start with Qm, disable the action item
-        if (ipfshash.count() > 0 && ipfshash.indexOf("Qm") == 0) {
+        if (ipfshash.count() > 0 && ipfshash.indexOf("Qm") == 0 && ipfsbrowser.indexOf("http") == 0 ) {
             openURL->setDisabled(false);
         } else {
             openURL->setDisabled(true);
@@ -522,7 +523,7 @@ void OverviewPage::handleAssetRightClicked(const QModelIndex &index)
             else if (action->objectName() == "Copy Amount")
                 GUIUtil::setClipboard(index.data(AssetTableModel::FormattedAmountRole).toString());
             else if (action->objectName() == "Browse") {
-                QDesktopServices::openUrl(QUrl::fromUserInput("https://ipfs.io/ipfs/" + ipfshash));
+                QDesktopServices::openUrl(QUrl::fromUserInput(ipfsbrowser.replace("%s", ipfshash)));
             }
         }
     }
@@ -696,9 +697,10 @@ void OverviewPage::openIPFSForAsset(const QModelIndex &index)
 {
     // Get the ipfs hash of the asset clicked
     QString ipfshash = index.data(AssetTableModel::AssetIPFSHashRole).toString();
+    QString ipfsbrowser = walletModel->getOptionsModel()->getIpfsUrl();
 
     // If the ipfs hash isn't there or doesn't start with Qm, disable the action item
-    if (ipfshash.count() > 0 && ipfshash.indexOf("Qm") == 0) {
-        QDesktopServices::openUrl(QUrl::fromUserInput("https://ipfs.io/ipfs/" + ipfshash));
+    if (ipfshash.count() > 0 && ipfshash.indexOf("Qm") == 0 && ipfsbrowser.indexOf("http") == 0) {
+        QDesktopServices::openUrl(QUrl::fromUserInput(ipfsbrowser.replace("%s", ipfshash)));
     }
 }


### PR DESCRIPTION
Add the ability to set ipfs-url in options.  Closes #897
Defaults to https://ipfs.io/ipfs/

Naming of the labels, tooltips and such probably need some work.
