### PR TITLE
CLI/Options: Add helpmessage for -assetindex

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -478,6 +478,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-sysperms", _("Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)"));
 #endif
     strUsage += HelpMessageOpt("-txindex", strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"), DEFAULT_TXINDEX));
+    strUsage += HelpMessageOpt("-assetindex", _("Keep an index of assets, used by the requestsnapshot rpc call. Requires a -reindex."));
 
     strUsage += HelpMessageOpt("-addressindex", strprintf(_("Maintain a full address index, used to query for the balance, txids and unspent outputs for addresses (default: %u)"), DEFAULT_ADDRESSINDEX));
     strUsage += HelpMessageOpt("-timestampindex", strprintf(_("Maintain a timestamp index for block hashes, used to query blocks hashes by a range of timestamps (default: %u)"), DEFAULT_TIMESTAMPINDEX));
@@ -1608,7 +1609,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                         LogPrintf(
                                 "Database failed to load last Reissued Mempool State. Will have to start from empty state");
 
-                    LogPrintf("Loaded Assets from database without error\nCache of assets size: %d\n",
+                    LogPrintf("Successfully loaded assets from database.\nCache of assets size: %d\n",
                               passetsCache->Size());
 
                     // Check for changed -disablemessaging state


### PR DESCRIPTION
CLI/Options: Add helpmessage for -assetindex (PR #925)
Changed logging to not say error when there is no error.