### PR TITLE
GUI: Transfer assets and send view fixes (PR #927)

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -62,6 +62,9 @@ static const bool DEFAULT_SPLASHSCREEN = true;
 #define COLOR_TOOLBAR_NOT_SELECTED_TEXT QColor("#a5b7f3")
 /* Toolbar selected text color */
 #define COLOR_TOOLBAR_SELECTED_TEXT COLOR_WHITE
+/* Send entries background color */
+#define COLOR_SENDENTRIES_BACKGROUND QColor("#fbfbfe")
+
 
 /** DARK MODE */
 /* Widget background color, dark mode */
@@ -84,6 +87,8 @@ static const bool DEFAULT_SPLASHSCREEN = true;
 #define COLOR_TOOLBAR_NOT_SELECTED_TEXT_DARK_MODE QColor("#6c80c5")
 /* Toolbar selected text color */
 #define COLOR_TOOLBAR_SELECTED_TEXT_DARK_MODE QColor("#c5ccdf")
+/* Send entries background color dark mode */
+#define COLOR_SENDENTRIES_BACKGROUND_DARK QColor("#1c2535")
 
 
 /* Ravencoin label color as a string */

--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -212,9 +212,11 @@ QColor PlatformStyle::WidgetBackGroundColor() const
 QColor PlatformStyle::SendEntriesBackGroundColor() const
 {
     if (darkModeEnabled)
-        return QColor(21,20,17);
+     // return QColor(21,20,17);
+        return COLOR_SENDENTRIES_BACKGROUND_DARK;
 
-    return QColor("#faf9f6");
+//  return QColor("#faf9f6");
+    return COLOR_SENDENTRIES_BACKGROUND;
 }
 
 QColor PlatformStyle::ShadowColor() const

--- a/src/qt/sendassetsentry.cpp
+++ b/src/qt/sendassetsentry.cpp
@@ -374,9 +374,10 @@ void SendAssetsEntry::onAssetSelected(int index)
     // If the name
     if (index == 0) {
         ui->assetAmountLabel->clear();
-        if(!ui->administratorCheckbox->isChecked())
-            ui->payAssetAmount->setDisabled(false);
+//        if(!ui->administratorCheckbox->isChecked())
+//            ui->payAssetAmount->setDisabled(false);
         ui->payAssetAmount->clear();
+        ui->payAssetAmount->setDisabled(true);
         return;
     }
 
@@ -385,6 +386,12 @@ void SendAssetsEntry::onAssetSelected(int index)
     if (IsAssetNameAnOwner(name.toStdString())) {
         fIsOwnerAsset = true;
         name = name.split("!").first();
+    }
+
+    // Check to see if the asset selected is an messenger asset
+    bool fIsMessengerAsset = false;
+    if (IsAssetNameAnMsgChannel(name.toStdString())) {
+        fIsMessengerAsset = true;
     }
 
     LOCK(cs_main);
@@ -442,10 +449,18 @@ void SendAssetsEntry::onAssetSelected(int index)
     ui->messageLabel->hide();
     ui->messageTextLabel->hide();
 
-    // If it is an ownership asset lock the amount
+    // If it is not an ownership asset unlock the amount
     if (!fIsOwnerAsset) {
         ui->payAssetAmount->setUnit(asset.units);
+        ui->payAssetAmount->setSingleStep(1);
         ui->payAssetAmount->setDisabled(false);
+        ui->payAssetAmount->setValue(0);
+    }
+    // If it is messanger channel set amount to 1 and keep locked.
+    if (fIsMessengerAsset) {
+        ui->payAssetAmount->setUnit(asset.units);
+        ui->payAssetAmount->setDisabled(true);
+        ui->payAssetAmount->setValue(1);
     }
 }
 
@@ -534,8 +549,8 @@ void SendAssetsEntry::switchAdministratorList(bool fSwitchStatus)
 
             stringModel->setStringList(list);
             ui->assetSelectionBox->lineEdit()->setPlaceholderText(tr("Select an asset to transfer"));
-            ui->payAssetAmount->clear();
-            ui->payAssetAmount->setUnit(MAX_UNIT);
+//            ui->payAssetAmount->clear();
+//            ui->payAssetAmount->setUnit(MAX_UNIT);
             ui->assetAmountLabel->clear();
             ui->assetSelectionBox->setFocus();
         } else {


### PR DESCRIPTION
GUI: Transfer Assets view - Amount-field.
 - Set units from asset-units.
 - Set always default to 0 when switching asset.
 - Clicking arrows in the amount-field has better stepvalues.

GUI: Send and Transfer Assets
 - Make a define for the hardcoded background color in send entries.
 - Change the background color to match the rest.