### PR TITLE
Build: Switch to building on ubuntu 18.04 bionic

### DIFF
--- a/.github/scripts/00-install-deps.sh
+++ b/.github/scripts/00-install-deps.sh
@@ -37,6 +37,7 @@ if [[ ${OS} == "windows" ]]; then
 
     update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix 
 
+
 elif [[ ${OS} == "osx" ]]; then
     apt -y install \
     autoconf \
@@ -58,7 +59,6 @@ elif [[ ${OS} == "osx" ]]; then
     libz-dev \
     p7zip-full \
     pkg-config \
-    python-is-python3 \
     python3 \
     python3-dev \
     python3-setuptools \
@@ -80,17 +80,16 @@ elif [[ ${OS} == "linux" || ${OS} == "linux-disable-wallet" ]]; then
     ca-certificates \
     curl \
     g++-aarch64-linux-gnu \
-    g++-9-aarch64-linux-gnu \
-    g++-9-multilib \
-    gcc-9-aarch64-linux-gnu \
-    gcc-9-multilib \
+    g++-8-aarch64-linux-gnu \
+    g++-8-multilib \
+    gcc-8-aarch64-linux-gnu \
+    gcc-8-multilib \
     git \
     gnupg \
     libtool \
     nsis \
     pbuilder \
     pkg-config \
-    python-is-python3 \
     python3 \
     rename \
     ubuntu-dev-tools \
@@ -108,20 +107,21 @@ elif [[ ${OS} == "arm32v7" || ${OS} == "arm32v7-disable-wallet" ]]; then
     ca-certificates \
     curl \
     g++-aarch64-linux-gnu \
-    g++-9-aarch64-linux-gnu \
-    gcc-9-aarch64-linux-gnu \
+    g++-8-aarch64-linux-gnu \
+    gcc-8-aarch64-linux-gnu \
     g++-arm-linux-gnueabihf \
-    g++-9-arm-linux-gnueabihf \
-    gcc-9-arm-linux-gnueabihf \
-    g++-9-multilib \
-    gcc-9-multilib \
+    g++-8-arm-linux-gnueabihf \
+    gcc-8-arm-linux-gnueabihf \
+    g++-8-multilib \
+    gcc-8-multilib \
     git \
     libtool \
     pkg-config \
-    python-is-python3 \
     python3 \
     bison
 else
     echo "you must pass the OS to build for"
     exit 1
 fi
+    update-alternatives --install /usr/bin/python python /usr/bin/python2 1
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 2

--- a/.github/workflows/build-raven.yml
+++ b/.github/workflows/build-raven.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
        OS: [ 'windows', 'linux', 'linux-disable-wallet', 'arm32v7', 'arm32v7-disable-wallet' ]


### PR DESCRIPTION
This addresses the issue with incompatible GLIBC versions.
Binaries built on ubuntu 20.04 does not run on 18.04 out of the box.

Building linux binaries on ubuntu 18.04 makes binaries that work on ubuntu versions 18.04, 20.04 to 21.04.
And probably most other modern distros.

This change also reduces our exposure to this issue:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189

Refs:
bitcoin#20005
bitcoin#21454

Any feedback is of course welcome.