### PR TITLE
Depends: Remove depends we don't need.

### DIFF
--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -4,7 +4,7 @@ native_packages := native_ccache native_b2
 qt_native_packages = native_protobuf
 qt_packages = qrencode protobuf
 
-qt_x86_64_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans libxkbcommon
+qt_x86_64_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libxkbcommon
 qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
 qt_arm_linux_packages:=$(qt_x86_64_linux_packages)
 


### PR DESCRIPTION
    - libX11
    - xextproto
    - libXext
    - xtrans

I have not found any reason to keep them around.
Please check for regressions.