### PR TITLE
GUI: Adjust blue and orange to match the logo.

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -47,11 +47,11 @@ static const bool DEFAULT_SPLASHSCREEN = true;
 /* Background color, very light gray */
 #define COLOR_BACKGROUND_LIGHT QColor("#fbfbfe")
 /* Ravencoin dark orange */
-#define COLOR_DARK_ORANGE QColor("#f05339")
+#define COLOR_DARK_ORANGE QColor("#f05239")
 /* Ravencoin light orange */
 #define COLOR_LIGHT_ORANGE QColor("#f79433")
 /* Ravencoin dark blue */
-#define COLOR_DARK_BLUE QColor("#475eaa")
+#define COLOR_DARK_BLUE QColor("#384192")
 /* Ravencoin light blue */
 #define COLOR_LIGHT_BLUE QColor("#5874cf")
 /* Ravencoin asset text */


### PR DESCRIPTION
    Match blue and orange to the Ravencoin logo.
    Closes issue #952

Co-authored-by: Michael Fussco <michael.r.fusco@gmail.com>

New colors on the left.
![image](https://user-images.githubusercontent.com/26197922/116008237-bbc87c80-a613-11eb-95c5-a4174518d2ce.png)
