### PR TITLE
consensus: exception for special cases p2sh-assets.

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -654,13 +654,17 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, CValidationState& state, c
     for (const auto& txout : tx.vout) {
         i++;
         bool fIsAsset = false;
+        bool fIsSpecial = false;
         int nType = 0;
         int nScriptType = 0;
         bool fIsOwner = false;
         if (txout.scriptPubKey.IsAssetScript(nType, nScriptType, fIsOwner))
             fIsAsset = true;
 
-        if (fIsAsset && nScriptType == TX_SCRIPTHASH) {
+        if(!AreP2SHAssetsAllowed() && txout.scriptPubKey.IsPreP2SHAssetScript())
+            fIsSpecial = true;
+
+        if (fIsAsset && nScriptType == TX_SCRIPTHASH && !fIsSpecial) {
             if (!AreP2SHAssetsAllowed())
                 return state.DoS(0, false, REJECT_INVALID, "bad-txns-p2sh-assets-not-active");
         }

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -256,8 +256,6 @@ bool CScript::IsPreP2SHAssetScript() const
     if( (*this)[0] == OP_HASH160
         && (*this)[1] == 0x14
         && (*this)[22] == OP_EQUAL
-        && (*this)[23] == OP_0
-        && (*this)[24] == OP_0
         && (*this)[25] == OP_RVN_ASSET
     )
         return true;

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -250,6 +250,21 @@ bool CScript::IsAssetScript(int& nType, int& nScriptType, bool& isOwner) const
     return IsAssetScript(nType, nScriptType, isOwner, start);
 }
 
+bool CScript::IsPreP2SHAssetScript() const
+{
+    // check for special cases, only active pre-p2sh-asset activation.
+    if( (*this)[0] == OP_HASH160
+        && (*this)[1] == 0x14
+        && (*this)[22] == OP_EQUAL
+        && (*this)[23] == OP_0
+        && (*this)[24] == OP_0
+        && (*this)[25] == OP_RVN_ASSET
+    )
+        return true;
+    else
+        return false;
+}
+
 bool CScript::IsAssetScript(int& nType, int& nScriptType, bool& fIsOwner, int& nStartingIndex) const
 {
     if (this->size() > 31) {

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -669,6 +669,7 @@ public:
     bool IsAssetScript(int& nType, int& nScriptType, bool& fIsOwner) const;
     bool IsAssetScript(int& nTXType, int& nScriptType, bool& fIsOwner, int& nStartingIndex) const;
     bool IsP2SHAssetScript() const;
+    bool IsPreP2SHAssetScript() const;
     bool IsNewAsset() const;
     bool IsOwnerAsset() const;
     bool IsReissueAsset() const;


### PR DESCRIPTION
    Make exceptions for pre-p2sh-asset transactions that match previous checks.