### PR TITLE
[WIP, do not merge] http: Release work queue after event base finish (btc#19033)

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -110,7 +110,7 @@ public:
     bool Enqueue(WorkItem* item)
     {
         std::unique_lock<std::mutex> lock(cs);
-        if (queue.size() >= maxDepth) {
+        if (!running || queue.size() >= maxDepth) {
             return false;
         }
         queue.emplace_back(std::unique_ptr<WorkItem>(item));
@@ -127,7 +127,7 @@ public:
                 std::unique_lock<std::mutex> lock(cs);
                 while (running && queue.empty())
                     cond.wait(lock);
-                if (!running)
+                if (!running && queue.empty())
                     break;
                 i = std::move(queue.front());
                 queue.pop_front();
@@ -504,6 +504,10 @@ void StopHTTPServer()
     if (eventBase) {
         event_base_free(eventBase);
         eventBase = nullptr;
+    }
+    if (workQueue) {
+        delete workQueue;
+        workQueue = nullptr;
     }
     LogPrint(BCLog::HTTP, "Stopped HTTP server\n");
 }


### PR DESCRIPTION
[WIP] - wait for upstream to merge.

backport of bitcoin#19033.

This fixes a race between http_request_cb and StopHTTPServer where
the work queue is used after release. - promag @ bitcoin.