### PR TITLE
build: update Expat 2.4.1 change source to github.

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,8 +1,8 @@
 package=expat
-$(package)_version=2.3.0
-$(package)_download_path=https://downloads.sourceforge.net/project/expat/expat/$($(package)_version)
+$(package)_version=2.4.1
+$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$($(package)_version))/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=f122a20eada303f904d5e0513326c5b821248f2d4d2afbf5c6f1339e511c0586
+$(package)_sha256_hash=2f9b6a580b94577b150a7d5617ad4643a4301a6616ff459307df3e225bcfbf40
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-static

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -14,7 +14,7 @@ These are the dependencies currently used by Raven Core. You can find instructio
 | Clang | [11.0.1](http://llvm.org/releases/download.html) |  (C++11 support) |  |  |  |
 | D-Bus | [1.10.18](https://cgit.freedesktop.org/dbus/dbus/tree/NEWS?h=dbus-1.10) |  | No | Yes |  |
 | ds_store    | 1.3.0  | | | | |
-| Expat | [2.3.0](https://libexpat.github.io/) |  | Yes | Yes |  |
+| Expat | [2.4.1](https://libexpat.github.io/) |  | Yes | Yes |  |
 | fontconfig | [2.12.1](https://www.freedesktop.org/software/fontconfig/release/) |  | No | Yes |  |
 | FreeType | [2.7.1](http://download.savannah.gnu.org/releases/freetype) |  | No |  |  |
 | GCC |  | [4.7+](https://gcc.gnu.org/) |  |  |  |


### PR DESCRIPTION
    Expat renamed files on sourceforge because of CVE-2013-0340/CWE-776.
    This switches to v.2.4.1.
    Source changed from sourceforge to github.