### PR TITLE
p2p: add fixed seeds if less than 5 addresses available after 60 sec.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1779,7 +1779,7 @@ void CConnman::ThreadOpenConnections()
             return;
 
         // Add seed nodes if DNS seeds are all down (an infrastructure attack?).
-        if (addrman.size() == 0 && (GetTime() - nStart > 60)) {
+        if (addrman.size() < 5 && (GetTime() - nStart > 60)) {
             static bool done = false;
 
             if (!done) {


### PR DESCRIPTION
p2p: add fixed seeds if less than 5 addresses available after 60 sec.