### PR TITLE
Fix handling of nonstandard txns and "-acceptnonstdtxn"

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1191,9 +1191,11 @@ bool AppInitParameterInteraction()
         dustRelayFee = CFeeRate(n);
     }
 
-    fRequireStandard = !gArgs.GetBoolArg("-acceptnonstdtxn", !chainparams.RequireStandard());
+    fRequireStandard = !gArgs.GetBoolArg("-acceptnonstdtxn", false);
     if (chainparams.RequireStandard() && !fRequireStandard)
         return InitError(strprintf("acceptnonstdtxn is not currently supported for %s chain", chainparams.NetworkIDString()));
+    // This defaults all chains to requiring standard transactions; testnet and regtest can use "-acceptnonstdtxn" to over-ride, but mainnet cannot
+    // Note that as previously coded, the "-acceptnonstdtxn" switch was broken. Bitcoin fixed this differently in their PR#15891
     nBytesPerSigOp = gArgs.GetArg("-bytespersigop", nBytesPerSigOp);
 
 #ifdef ENABLE_WALLET


### PR DESCRIPTION
Currently, the chains reject nonstandard transactions according to=> mainnet:true, testnet:false, regtest:false
The "-acceptnonstdtxn" CLI switch option is broken and has no effect.

After this simple code change, all chains default to rejecting nonstandard transactions, while allowing the "-acceptnonstdtxn" switch to change that behavior on testnet and regtest (but not mainnet).

Note that bitcoin has also fixed the "-acceptnonstdtxn" switch in their PR#15891, but in a more complicated way and with different results.