### PR TITLE
GUI: Reissue asset spinboxes. Disable if unit is max.

### DIFF
--- a/src/qt/reissueassetdialog.cpp
+++ b/src/qt/reissueassetdialog.cpp
@@ -723,9 +723,13 @@ void ReissueAssetDialog::onAssetSelected(int index)
         ss.precision(asset->units);
         ss << std::fixed << value.get_real();
 
-        ui->unitSpinBox->setValue(asset->units);
         ui->unitSpinBox->setMinimum(asset->units);
+        ui->unitSpinBox->setValue(asset->units);
 
+        if (asset->units == MAX_ASSET_UNITS) {
+            ui->unitSpinBox->setDisabled(true);
+        }
+        
         ui->quantitySpinBox->setMaximum(21000000000 - value.get_real());
 
         ui->currentAssetData->clear();


### PR DESCRIPTION
    Disable units spinbox if max units is already set.

    Set minvalue for spinbox after setting value, to allow
    updates when the number of units in the selected asset is
    lower than the number of units in the previous.

Related to issue #1045 