### PR TITLE
Introduce a Shuffle for FastRandomContext and use it in wallet

### DIFF
--- a/src/random.h
+++ b/src/random.h
@@ -124,6 +124,29 @@ public:
     bool randbool() { return randbits(1); }
 };
 
+/** More efficient than using std::shuffle on a FastRandomContext.
+ *
+ * This is more efficient as std::shuffle will consume entropy in groups of
+ * 64 bits at the time and throw away most.
+ *
+ * This also works around a bug in libstdc++ std::shuffle that may cause
+ * type::operator=(type&&) to be invoked on itself, which the library's
+ * debug mode detects and panics on. This is a known issue, see
+ * https://stackoverflow.com/questions/22915325/avoiding-self-assignment-in-stdshuffle
+ */
+template<typename I, typename R>
+void Shuffle(I first, I last, R&& rng)
+{
+    while (first != last) {
+        size_t j = rng.randrange(last - first);
+        if (j) {
+            using std::swap;
+            swap(*first, *(first + j));
+        }
+        ++first;
+    }
+}
+
 /* Number of random bytes returned by GetOSRand.
  * When changing this constant make sure to change all call sites, and make
  * sure that the underlying OS APIs for all platforms support the number.

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -65,4 +65,34 @@ BOOST_FIXTURE_TEST_SUITE(random_tests, BasicTestingSetup)
         }
     }
 
+    /** Test that Shuffle reaches every permutation with equal probability. */
+    BOOST_AUTO_TEST_CASE(shuffle_stat_test)
+    {
+        FastRandomContext ctx(true);
+        uint32_t counts[5 * 5 * 5 * 5 * 5] = {0};
+        for (int i = 0; i < 12000; ++i) {
+            int data[5] = {0, 1, 2, 3, 4};
+            Shuffle(std::begin(data), std::end(data), ctx);
+            int pos = data[0] + data[1] * 5 + data[2] * 25 + data[3] * 125 + data[4] * 625;
+            ++counts[pos];
+        }
+        unsigned int sum = 0;
+        double chi_score = 0.0;
+        for (int i = 0; i < 5 * 5 * 5 * 5 * 5; ++i) {
+            int i1 = i % 5, i2 = (i / 5) % 5, i3 = (i / 25) % 5, i4 = (i / 125) % 5, i5 = i / 625;
+            uint32_t count = counts[i];
+            if (i1 == i2 || i1 == i3 || i1 == i4 || i1 == i5 || i2 == i3 || i2 == i4 || i2 == i5 || i3 == i4 || i3 == i5 || i4 == i5) {
+                BOOST_CHECK(count == 0);
+        } else {
+            chi_score += ((count - 100.0) * (count - 100.0)) / 100.0;
+            BOOST_CHECK(count > 50);
+            BOOST_CHECK(count < 150);
+            sum += count;
+        }
+    }
+    BOOST_CHECK(chi_score > 58.1411); // 99.9999% confidence interval
+    BOOST_CHECK(chi_score < 210.275);
+    BOOST_CHECK_EQUAL(sum, 12000);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -38,6 +38,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
+#include <random>
 #include <tinyformat.h>
 
 #include "assets/assets.h"
@@ -2751,7 +2752,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
     std::vector<CInputCoin> vValue;
     CAmount nTotalLower = 0;
 
-    random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
+    Shuffle(vCoins.begin(), vCoins.end(), FastRandomContext());
 
     for (const COutput &output : vCoins)
     {
@@ -2954,7 +2955,7 @@ bool CWallet::SelectAssetsMinConf(const CAmount& nTargetValue, const int nConfMi
     std::map<COutPoint, CAmount> mapValueAmount;
     CAmount nTotalLower = 0;
 
-    random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
+    Shuffle(vCoins.begin(), vCoins.end(), FastRandomContext());
     #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     for (const COutput &output : vCoins)
     {


### PR DESCRIPTION
Backport part of bitcoin#14624

bitcoin#3db746beb407f7cdd9cd6a605a195bef1254b4c0

random_shuffle is depratected in c++17.
Fixes compile errors on freebsd and osx.