### PR TITLE
net: Do not force dns seeds by default.

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -83,7 +83,7 @@ static const uint64_t MAX_UPLOAD_TIMEFRAME = 60 * 60 * 24;
 /** Default for blocks only*/
 static const bool DEFAULT_BLOCKSONLY = false;
 
-static const bool DEFAULT_FORCEDNSSEED = true;
+static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 


### PR DESCRIPTION
It does not make sense to force dns seeds by default.