### PR TITLE
gui: set window minimum size to usable default

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -40,7 +40,7 @@
         <number>34</number>
        </property>
        <property name="sizeConstraint">
-        <enum>QLayout::SetMaximumSize</enum>
+        <enum>QLayout::SetMinAndMaxSize</enum>
        </property>
        <property name="leftMargin">
         <number>40</number>
@@ -69,6 +69,12 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>450</width>
+             <height>243</height>
+            </size>
            </property>
            <property name="frameShape">
             <enum>QFrame::NoFrame</enum>
@@ -155,6 +161,9 @@
             </item>
             <item>
              <layout class="QGridLayout" name="gridLayout">
+              <property name="bottomMargin">
+               <number>10</number>
+              </property>
               <property name="spacing">
                <number>12</number>
               </property>
@@ -464,7 +473,7 @@
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
-                <height>87</height>
+                <height>20</height>
                </size>
               </property>
              </spacer>
@@ -474,6 +483,12 @@
          </item>
          <item>
           <widget class="QFrame" name="assetFrame">
+           <property name="minimumSize">
+            <size>
+             <width>450</width>
+             <height>150</height>
+            </size>
+           </property>
            <property name="autoFillBackground">
             <bool>true</bool>
            </property>
@@ -656,6 +671,12 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="sizeIncrement">
+            <size>
+             <width>0</width>
+             <height>300</height>
+            </size>
            </property>
            <property name="frameShape">
             <enum>QFrame::NoFrame</enum>

--- a/src/qt/forms/reissueassetdialog.ui
+++ b/src/qt/forms/reissueassetdialog.ui
@@ -10,6 +10,12 @@
     <height>1051</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>550</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string notr="true">Transaction details</string>
   </property>
@@ -578,6 +584,12 @@
      </item>
      <item>
       <widget class="QFrame" name="frame">
+       <property name="minimumSize">
+        <size>
+         <width>400</width>
+         <height>180</height>
+        </size>
+       </property>
        <property name="frameShape">
         <enum>QFrame::StyledPanel</enum>
        </property>
@@ -587,6 +599,9 @@
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="spacing">
          <number>0</number>
+        </property>
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
         </property>
         <property name="bottomMargin">
          <number>12</number>
@@ -1581,6 +1596,9 @@
      </item>
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_8">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
        <item>
         <widget class="QPushButton" name="reissueAssetButton">
          <property name="minimumSize">

--- a/src/qt/raven.cpp
+++ b/src/qt/raven.cpp
@@ -427,8 +427,8 @@ void RavenApplication::createOptionsModel(bool resetSettings)
 void RavenApplication::createWindow(const NetworkStyle *networkStyle)
 {
     window = new RavenGUI(platformStyle, networkStyle, 0);
-    window->setMinimumSize(200,200);
-    window->setBaseSize(640,640);
+    window->setMinimumSize(875,700);
+    window->setBaseSize(875,700);
 
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, SIGNAL(timeout()), window, SLOT(detectShutdown()));


### PR DESCRIPTION
Set minimum to 875x700, even that is only usable if
The toolbar is set to icons only.

Set some minimum values for layouts in overview and manage assets.