### PR TITLE
Put the how-to md files front and center for novice users

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Raven Core integration/staging tree
 
 https://ravencoin.org
 
+To see how to run Ravencoin, please read the respective files in [the doc folder](doc)
+
+
 What is Ravencoin?
 ----------------
 


### PR DESCRIPTION
It seems many users don't know what to do when accessing the Ravencoin repo. This is a trivial commit. Should I create some sort of how-to index file linking to respective md files in docs?