### PR TITLE
build: github action enable Skip Duplicate Actions.

### DIFF
--- a/.github/workflows/build-raven.yml
+++ b/.github/workflows/build-raven.yml
@@ -9,23 +9,49 @@ on:
       - master
       - develop
       - release*
-    paths-ignore:
-      - 'binaries/**'
-      - 'community/**'
-      - 'contrib/**'
-      - 'doc/**'
-      - 'roadmap/**'
-      - 'share/**'
-      - 'static-builds/**'
-      - 'whitepaper/**'
-      - '*.md'
+#    paths-ignore:
+#      - 'binaries/**'
+#      - 'community/**'
+#      - 'contrib/**'
+#      - 'doc/**'
+#      - 'roadmap/**'
+#      - 'share/**'
+#      - 'static-builds/**'
+#      - 'whitepaper/**'
+#      - '*.md'
 
 env:
   SCRIPTS: ${{ GITHUB.WORKSPACE }}/.github/scripts
 
 jobs:
-  build:
+  check-jobs:
+      # continue-on-error: true # Uncomment once integration is finished
+    runs-on: ubuntu-18.04
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'never'
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '[
+                          "binaries/**",
+                          "community/**",
+                          "contrib/**",
+                          "doc/**",
+                          "roadmap/**",
+                          "share/**",
+                          "static-builds/**",
+                          "whitepaper/**",
+                          "**/*.md"
+                          ]'
+          do_not_skip: '["workflow_dispatch", "schedule"]'
 
+  build:
+    needs: check-jobs
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -33,13 +59,16 @@ jobs:
 #       OS: [ 'windows', 'linux', 'linux-disable-wallet', 'osx', 'arm32v7', 'arm32v7-disable-wallet' ]
 
     steps:
-    - name: Checkout the Code
+    - if: ${{ needs.check-jobs.outputs.should_skip != 'true' }}
+      name: Checkout the Code
       uses: actions/checkout@v1
 
-    - name: Install Build Tools
+    - if: ${{ needs.check-jobs.outputs.should_skip != 'true' }}
+      name: Install Build Tools
       run: sudo ${SCRIPTS}/00-install-deps.sh ${{ MATRIX.OS }}
 
-    - name: Cache dependencies.
+    - if: ${{ needs.check-jobs.outputs.should_skip != 'true' }}
+      name: Cache dependencies.
       uses: actions/cache@v2
       with:
        path: |
@@ -48,28 +77,36 @@ jobs:
         ${{ GITHUB.WORKSPACE }}/depends/work
        key: ${{ MATRIX.OS }}
       
-    - name: Build dependencies.
+    - if: ${{ needs.check-jobs.outputs.should_skip != 'true' }}
+      name: Build dependencies.
       run: ${SCRIPTS}/02-copy-build-dependencies.sh ${{ MATRIX.OS }} ${{ GITHUB.WORKSPACE }} ${{ GITHUB.BASE_REF }} ${{ GITHUB.REF }}
 
-    - name: Add Dependencies to the System PATH
+    - if: ${{ needs.check-jobs.outputs.should_skip != 'true' }}
+      name: Add Dependencies to the System PATH
       run: ${SCRIPTS}/03-export-path.sh ${{ MATRIX.OS }} ${{ GITHUB.WORKSPACE }}
 
-    - name: Build Config
+    - if: ${{ needs.check-jobs.outputs.should_skip != 'true' }}
+      name: Build Config
       run: cd ${{ GITHUB.WORKSPACE }} && ./autogen.sh
 
-    - name: Configure Build
+    - if: ${{ needs.check-jobs.outputs.should_skip != 'true' }}
+      name: Configure Build
       run: ${SCRIPTS}/04-configure-build.sh ${{ MATRIX.OS }} ${{ GITHUB.WORKSPACE }}
 
-    - name: Build Raven
+    - if: ${{ needs.check-jobs.outputs.should_skip != 'true' }}
+      name: Build Raven
       run: make -j2
 
-    - name: Check Binary Security
+    - if: ${{ needs.check-jobs.outputs.should_skip != 'true' }}
+      name: Check Binary Security
       run: ${SCRIPTS}/05-binary-checks.sh ${{ MATRIX.OS }} ${{ GITHUB.WORKSPACE }}
 
-    - name: Package Up the Build
+    - if: ${{ needs.check-jobs.outputs.should_skip != 'true' }}
+      name: Package Up the Build
       run: ${SCRIPTS}/06-package.sh ${{ MATRIX.OS }} ${{ GITHUB.WORKSPACE }} ${{ GITHUB.BASE_REF }} ${{ GITHUB.REF }}
     
-    - name: Upload Artifacts to Job
+    - if: ${{ needs.check-jobs.outputs.should_skip != 'true' }}
+      name: Upload Artifacts to Job
       uses: actions/upload-artifact@master
       with:
         name: ${{ MATRIX.OS }}


### PR DESCRIPTION
    Setup Skip Duplicate Actions in the workflow.
    The reason for doing this, is that githubs path-ignore feature
    does not play well with required checks on master.

    Skip Duplicate Actions include a better paths_ignore feature.
    https://github.com/marketplace/actions/skip-duplicate-actions

This should work around the unnecessary building for doc changes and similar trivial non code changes.
While still reporting the checks as successfull.

Demo result of skipped run: 
https://github.com/fdoving/Ravencoin/pull/13/checks?check_run_id=2851996052





