### PR TITLE
lockedpool: avoid sensitive data in core files (Linux and FreeBSD)

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -231,6 +231,11 @@ void *PosixLockedPageAllocator::AllocateLocked(size_t len, bool *lockingSuccess)
     addr = mmap(nullptr, len, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
     if (addr) {
         *lockingSuccess = mlock(addr, len) == 0;
+#if defined(MADV_DONTDUMP) // Linux
+        madvise(addr, len, MADV_DONTDUMP); 
+#elif defined(MADV_NOCORE) // FreeBSD
+        madvise(addr, len, MADV_NOCORE);
+#endif
     }
     return addr;
 }


### PR DESCRIPTION
Manual backport of bitcoin PR#18443 and bitcoin PR#15633.

Use madvise on Linux and FreeBSD to avoid sensitive data from secure_allocator to be writte to swap and core-files.

Fixes #1117 

https://github.com/bitcoin/bitcoin/pull/15600/commits/d831831822885717e9841f1ff67c19add566fa45
https://github.com/bitcoin/bitcoin/pull/18443/commits/f85203097f78d9daa1d35c4097a80beab31da2a4