### PR TITLE
gui: optional seed extension word rename

### DIFF
--- a/src/qt/forms/mnemonicdialog2.ui
+++ b/src/qt/forms/mnemonicdialog2.ui
@@ -202,20 +202,22 @@
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Passphrase:</string>
+      <string>Optional Seed Extension Word:</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <widget class="QLineEdit" name="passphraseEdit">
         <property name="toolTip">
-         <string>Enter a Passphrase to protect your seed words  (optional).</string>
+         <string>A 12 word seed phrase is a useful way of backing up a wallet, because it is a system for generating the keys to all Ravencoin and Assets. However, anyone who finds/learns your seed phrase will likewise have control of your wallet. For this reason, some users choose to add another level of security to these 12 words. Unlike your 12 word phrase, which is generated randomly, this 13th word (known as the Seed Extension Word) is something the user comes up with themselves and memorizes, or stores separately from their seed phrase.
+                
+                The Seed Extension Word is like adding a password to your randomly generated seed phrase. If someone finds your written 12 word seed phrase, but you’ve chosen to use a Seed Extension Word, they will not be able to access your wallet.</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QLabel" name="passphraseLabel">
         <property name="text">
-         <string>You may enter an optional Passphrase to protect your seed words.</string>
+         <string>You may enter an optional extension word to protect your seed.</string>
         </property>
        </widget>
       </item>
@@ -253,8 +255,8 @@
      <item row="1" column="1">
       <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Please write down your 12 seed words and Passphrase before Accepting. 
-They are not recoverable !!</string>
+        <string>Please write down your 12 seed words and the optional seed extension word before accepting.
+They are not recoverable!!</string>
        </property>
       </widget>
      </item>

--- a/src/qt/forms/mnemonicdialog3.ui
+++ b/src/qt/forms/mnemonicdialog3.ui
@@ -253,20 +253,20 @@
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Passphrase:</string>
+      <string>Seed Extension Word:</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <widget class="QLineEdit" name="passphraseEdit">
         <property name="toolTip">
-         <string>You will need the Passphrase if your previous wallet used one.</string>
+         <string>The Seed Extension Word is like adding a password to your randomly generated seed phrase. If someone finds your written 12 word seed phrase, but you’ve chosen to use a Seed Extension Word, they will not be able to access your wallet.</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QLabel" name="passwordLabel">
         <property name="text">
-         <string>Enter the Passphrase from your previous wallet if it used one.</string>
+         <string>Enter the Seed Extension Word from your previous wallet (if it used one).</string>
         </property>
        </widget>
       </item>
@@ -304,8 +304,8 @@
      <item row="1" column="1">
       <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Please continue to remember your 12 seed words and Passphrase before Accepting.
-They are not recoverable !!</string>
+        <string>Please continue to remember your 12 seed words and extension word before accepting.
+They are not recoverable!!</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
    * Re-word in the import dialog.
    * Passphrase is used multiple times, renaming this to Seed Extension Word.
    * Add better tooltip.

Co-authored-by: kinkajou
Co-authored-by: LSJI07
Co-authored-by: Hraf