### PR TITLE
gui: search for string in whole asset name.

### DIFF
--- a/src/qt/assetfilterproxy.cpp
+++ b/src/qt/assetfilterproxy.cpp
@@ -7,17 +7,23 @@
 
 AssetFilterProxy::AssetFilterProxy(QObject *parent) :
         QSortFilterProxyModel(parent),
-        assetNamePrefix()
+        assetNamePrefix(),
+        assetNameContains()
 {
 }
 
 bool AssetFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
 {
     QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-
     QString assetName = index.data(AssetTableModel::AssetNameRole).toString();
 
-    if(!assetName.startsWith(assetNamePrefix, Qt::CaseInsensitive))
+    if(assetNameContains.isEmpty()) {
+        if(!assetName.startsWith(assetNamePrefix, Qt::CaseInsensitive))
+            return false;
+
+        return true;
+    }
+    if(!assetName.contains(assetNameContains, Qt::CaseInsensitive))
         return false;
 
     return true;
@@ -26,5 +32,11 @@ bool AssetFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &source
 void AssetFilterProxy::setAssetNamePrefix(const QString &_assetNamePrefix)
 {
     this->assetNamePrefix = _assetNamePrefix;
+    invalidateFilter();
+}
+
+void AssetFilterProxy::setAssetNameContains(const QString &_assetNameContains)
+{
+    this->assetNameContains = _assetNameContains;
     invalidateFilter();
 }

--- a/src/qt/assetfilterproxy.h
+++ b/src/qt/assetfilterproxy.h
@@ -15,12 +15,14 @@ public:
     explicit AssetFilterProxy(QObject *parent = 0);
 
     void setAssetNamePrefix(const QString &assetNamePrefix);
+    void setAssetNameContains(const QString &assetNameContains);
 
 protected:
     bool filterAcceptsRow(int source_row, const QModelIndex & source_parent) const;
 
 private:
     QString assetNamePrefix;
+    QString assetNameContains;
 };
 
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -703,7 +703,7 @@ void OverviewPage::assetSearchChanged()
 {
     if (!assetFilter)
         return;
-    assetFilter->setAssetNamePrefix(ui->assetSearch->text());
+    assetFilter->setAssetNameContains(ui->assetSearch->text());
 }
 
 void OverviewPage::openIPFSForAsset(const QModelIndex &index)


### PR DESCRIPTION
    * AssetFilterProxy expanded to be able to search
      for strings in the whole asset name.
      Previously only the prefix was searchable.