### PR TITLE
gui: click network icon in status bar opens peers

### DIFF
--- a/src/qt/ravengui.cpp
+++ b/src/qt/ravengui.cpp
@@ -270,7 +270,7 @@ RavenGUI::RavenGUI(const PlatformStyle *_platformStyle, const NetworkStyle *netw
     // Subscribe to notifications from core
     subscribeToCoreSignals();
 
-    connect(connectionsControl, SIGNAL(clicked(QPoint)), this, SLOT(toggleNetworkActive()));
+    connect(connectionsControl, SIGNAL(clicked(QPoint)), this, SLOT(showDebugWindowActivatePeers()));
 
     modalOverlay = new ModalOverlay(this->centralWidget());
 #ifdef ENABLE_WALLET
@@ -1144,6 +1144,12 @@ void RavenGUI::showDebugWindowActivateConsole()
     showDebugWindow();
 }
 
+void RavenGUI::showDebugWindowActivatePeers()
+{
+    rpcConsole->setTabFocus(RPCConsole::TAB_PEERS);
+    showDebugWindow();
+}
+
 void RavenGUI::showWalletRepair()
 {
     rpcConsole->setTabFocus(RPCConsole::TAB_REPAIR);
@@ -1242,7 +1248,7 @@ void RavenGUI::updateNetworkState()
     QString tooltip;
 
     if (clientModel->getNetworkActive()) {
-        tooltip = tr("%n active connection(s) to Raven network", "", count) + QString(".<br>") + tr("Click to disable network activity.");
+        tooltip = tr("%n active connection(s) to Raven network", "", count) + QString(".<br>") + tr("Click to show network activity.");
     } else {
         tooltip = tr("Network activity disabled.") + QString("<br>") + tr("Click to enable network activity again.");
         icon = ":/icons/network_disabled";

--- a/src/qt/ravengui.h
+++ b/src/qt/ravengui.h
@@ -286,6 +286,8 @@ private Q_SLOTS:
     void showDebugWindow();
     /** Show debug window and set focus to the console */
     void showDebugWindowActivateConsole();
+    /** Show debug window and set focus to the peers tab */
+    void showDebugWindowActivatePeers();
     /** Show debug window and set focus to the wallet repair tab */
     void showWalletRepair();
     /** Show help message dialog */


### PR DESCRIPTION
    * Clicking the network icon in the statusbar opens
    the debug-window at the peers tab.

    Previously, clicking it toggeled all network activity.