### PR TITLE
gui: create and reissue asset views - browse ipfs button

### DIFF
--- a/src/qt/createassetdialog.cpp
+++ b/src/qt/createassetdialog.cpp
@@ -38,6 +38,8 @@
 #include <QStringListModel>
 #include <QSortFilterProxyModel>
 #include <QCompleter>
+#include <QUrl>
+#include <QDesktopServices>
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
 #define QTversionPreFiveEleven
@@ -51,6 +53,7 @@ CreateAssetDialog::CreateAssetDialog(const PlatformStyle *_platformStyle, QWidge
     ui->setupUi(this);
     setWindowTitle("Create Assets");
     connect(ui->ipfsBox, SIGNAL(clicked()), this, SLOT(ipfsStateChanged()));
+    connect(ui->openIpfsButton, SIGNAL(clicked()), this, SLOT(openIpfsBrowser()));
     connect(ui->availabilityButton, SIGNAL(clicked()), this, SLOT(checkAvailabilityClicked()));
     connect(ui->nameText, SIGNAL(textChanged(QString)), this, SLOT(onNameChanged(QString)));
     connect(ui->addressText, SIGNAL(textChanged(QString)), this, SLOT(onAddressNameChanged(QString)));
@@ -264,6 +267,8 @@ void CreateAssetDialog::setUpValues()
     ui->unitBox->setValue(0);
     ui->reissuableBox->setCheckState(Qt::CheckState::Checked);
     ui->ipfsText->hide();
+    ui->openIpfsButton->hide();
+    ui->openIpfsButton->setDisabled(true);
     hideMessage();
     CheckFormState();
     ui->availabilityButton->setDisabled(true);
@@ -432,12 +437,12 @@ void CreateAssetDialog::toggleIPFSText()
 {
     if (ui->ipfsBox->isChecked()) {
         ui->ipfsText->show();
+        ui->openIpfsButton->show();
     } else {
+        ui->openIpfsButton->hide();
         ui->ipfsText->hide();
         ui->ipfsText->clear();
     }
-
-    CheckFormState();
 }
 
 void CreateAssetDialog::showMessage(QString string)
@@ -492,6 +497,8 @@ void CreateAssetDialog::enableCreateButton()
 
 bool CreateAssetDialog::checkIPFSHash(QString hash)
 {
+    ui->openIpfsButton->setDisabled(true);
+
     if (!hash.isEmpty()) {
         std::string error;
         if (!CheckEncoded(DecodeAssetData(hash.toStdString()), error)) {
@@ -505,7 +512,8 @@ bool CreateAssetDialog::checkIPFSHash(QString hash)
             showMessage(tr("IPFS/Txid Hash must have size of 46 characters, or 64 hex characters"));
             disableCreateButton();
             return false;
-        } else if (DecodeAssetData(hash.toStdString()).empty()) {
+        }
+        else if (DecodeAssetData(hash.toStdString()).empty()) {
             showMessage(tr("IPFS/Txid hash is not valid. Please use a valid IPFS/Txid hash"));
             disableCreateButton();
             return false;
@@ -515,6 +523,8 @@ bool CreateAssetDialog::checkIPFSHash(QString hash)
     // No problems where found with the hash, reset the border, and hide the messages.
     hideMessage();
     ui->ipfsText->setStyleSheet("");
+    ui->openIpfsButton->setDisabled(false);
+    
 
     return true;
 }
@@ -523,6 +533,8 @@ void CreateAssetDialog::CheckFormState()
 {
     disableCreateButton(); // Disable the button by default
     hideMessage();
+    ui->openIpfsButton->setDisabled(true);
+    ui->availabilityButton->setDisabled(true);
 
     const CTxDestination dest = DecodeDestination(ui->addressText->text().toStdString());
 
@@ -540,7 +552,7 @@ void CreateAssetDialog::CheckFormState()
         }
     }
 
-    if (!assetNameValid && name.size() != 0) {
+    if (!assetNameValid && name.size() > 2) {
         ui->nameText->setStyleSheet(STYLE_INVALID);
         showMessage(error.c_str());
         ui->availabilityButton->setDisabled(true);
@@ -636,6 +648,26 @@ void CreateAssetDialog::checkAvailabilityClicked()
     }
 
     CheckFormState();
+}
+
+void CreateAssetDialog::openIpfsBrowser()
+{
+    QString ipfshash = ui->ipfsText->text();
+    QString ipfsbrowser = model->getOptionsModel()->getIpfsUrl();
+
+    // If the ipfs hash isn't there or doesn't start with Qm, disable the action item
+    if (ipfshash.count() > 0 && ipfshash.indexOf("Qm") == 0 && ipfsbrowser.indexOf("http") == 0)
+    {
+        QUrl ipfsurl = QUrl::fromUserInput(ipfsbrowser.replace("%s", ipfshash));
+
+        // Create the box with everything.
+        if(QMessageBox::Yes == QMessageBox::question(this,
+                                                        tr("Open IPFS content?"),
+                                                        tr("Open the following IPFS content in your default browser?\n")
+                                                        + ipfsurl.toString()
+                                                    ))
+        QDesktopServices::openUrl(ipfsurl);
+    }
 }
 
 void CreateAssetDialog::onNameChanged(QString name)
@@ -1440,6 +1472,7 @@ void CreateAssetDialog::clear()
     ui->reissuableBox->setChecked(true);
     ui->ipfsBox->setChecked(false);
     ui->ipfsText->hide();
+    ui->openIpfsButton->hide();
     ui->assetList->hide();
     ui->assetList->setCurrentIndex(0);
     type = 0;

--- a/src/qt/createassetdialog.h
+++ b/src/qt/createassetdialog.h
@@ -94,12 +94,14 @@ private:
     void updateFeeMinimizedLabel();
     void minimizeFeeSection(bool fMinimize);
 
-    //Validation
+    // Validation
+    // Returns true if this is an IPFS-hash or TXID.
     bool checkIPFSHash(QString hash);
 
 private Q_SLOTS:
     void ipfsStateChanged();
     void checkAvailabilityClicked();
+    void openIpfsBrowser();
     void onNameChanged(QString name);
     void onAddressNameChanged(QString address);
     void onIPFSHashChanged(QString hash);

--- a/src/qt/forms/createassetdialog.ui
+++ b/src/qt/forms/createassetdialog.ui
@@ -829,6 +829,13 @@
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QPushButton" name="openIpfsButton">
+              <property name="text">
+               <string>Browse IPFS</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
           <item>

--- a/src/qt/forms/reissueassetdialog.ui
+++ b/src/qt/forms/reissueassetdialog.ui
@@ -910,6 +910,13 @@
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QPushButton" name="openIpfsButton">
+                <property name="text">
+                 <string>Browse IPFS</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
            </layout>

--- a/src/qt/reissueassetdialog.cpp
+++ b/src/qt/reissueassetdialog.cpp
@@ -40,6 +40,8 @@
 #include <QStringListModel>
 #include <QSortFilterProxyModel>
 #include <QCompleter>
+#include <QUrl>
+#include <QDesktopServices>
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
 #define QTversionPreFiveEleven
@@ -56,6 +58,7 @@ ReissueAssetDialog::ReissueAssetDialog(const PlatformStyle *_platformStyle, QWid
     connect(ui->comboBox, SIGNAL(activated(int)), this, SLOT(onAssetSelected(int)));
     connect(ui->quantitySpinBox, SIGNAL(valueChanged(double)), this, SLOT(onQuantityChanged(double)));
     connect(ui->ipfsBox, SIGNAL(clicked()), this, SLOT(onIPFSStateChanged()));
+    connect(ui->openIpfsButton, SIGNAL(clicked()), this, SLOT(openIpfsBrowser()));
     connect(ui->ipfsText, SIGNAL(textChanged(QString)), this, SLOT(onIPFSHashChanged(QString)));
     connect(ui->addressText, SIGNAL(textChanged(QString)), this, SLOT(onAddressNameChanged(QString)));
     connect(ui->reissueAssetButton, SIGNAL(clicked()), this, SLOT(onReissueAssetClicked()));
@@ -277,6 +280,7 @@ void ReissueAssetDialog::setUpValues()
 
     ui->reissuableBox->setCheckState(Qt::CheckState::Checked);
     ui->ipfsText->setDisabled(true);
+    ui->openIpfsButton->setDisabled(true);
     hideMessage();
 
     ui->unitExampleLabel->setStyleSheet("font-weight: bold");
@@ -526,9 +530,14 @@ void ReissueAssetDialog::CheckFormState()
         }
     }
 
-    if (ui->ipfsBox->isChecked())
-        if (!checkIPFSHash(ui->ipfsText->text()))
+    if (ui->ipfsBox->isChecked()) {
+        if (!checkIPFSHash(ui->ipfsText->text())) {
+            ui->openIpfsButton->setDisabled(true);
             return;
+        }
+        else
+            ui->openIpfsButton->setDisabled(false);
+    }
 
     if (fReissuingRestricted) {
 
@@ -584,6 +593,8 @@ void ReissueAssetDialog::CheckFormState()
     enableReissueButton();
     hideMessage();
 }
+
+
 
 void ReissueAssetDialog::disableAll()
 {
@@ -850,6 +861,26 @@ void ReissueAssetDialog::onIPFSHashChanged(QString hash)
         CheckFormState();
 
     buildUpdatedData();
+}
+
+void ReissueAssetDialog::openIpfsBrowser()
+{
+    QString ipfshash = ui->ipfsText->text();
+    QString ipfsbrowser = model->getOptionsModel()->getIpfsUrl();
+
+    // If the ipfs hash isn't there or doesn't start with Qm, disable the action item
+    if (ipfshash.count() > 0 && ipfshash.indexOf("Qm") == 0 && ipfsbrowser.indexOf("http") == 0)
+    {
+        QUrl ipfsurl = QUrl::fromUserInput(ipfsbrowser.replace("%s", ipfshash));
+
+        // Create the box with everything.
+        if(QMessageBox::Yes == QMessageBox::question(this,
+                                                        tr("Open IPFS content?"),
+                                                        tr("Open the following IPFS content in your default browser?\n")
+                                                        + ipfsurl.toString()
+                                                    ))
+        QDesktopServices::openUrl(ipfsurl);
+    }
 }
 
 void ReissueAssetDialog::onAddressNameChanged(QString address)

--- a/src/qt/reissueassetdialog.h
+++ b/src/qt/reissueassetdialog.h
@@ -105,6 +105,7 @@ private Q_SLOTS:
     void onUnitChanged(int value);
     void onClearButtonClicked();
     void onVerifierStringChanged(QString verifier);
+    void openIpfsBrowser();
 
     //CoinControl
     void coinControlFeatureChanged(bool);


### PR DESCRIPTION
    * Add button to open ipfs-hash in the configured ipfs-viewer.
      This can be handy to verify your ipfs-hash is correct, before creating the asset.

    * Remove a check that enabled the Check Availability button once the `Add IPFS/Txid hash` was enabled.