### PR TITLE
backport: [qt] Fix potential memory leak in newPossibleKey(ChangeCWallet *wallet) (bitcoin #10920)

### DIFF
--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -11,7 +11,6 @@
 WalletModelTransaction::WalletModelTransaction(const QList<SendCoinsRecipient> &_recipients) :
     recipients(_recipients),
     walletTransaction(0),
-    keyChange(0),
     fee(0)
 {
     walletTransaction = new CWalletTx();
@@ -19,7 +18,6 @@ WalletModelTransaction::WalletModelTransaction(const QList<SendCoinsRecipient> &
 
 WalletModelTransaction::~WalletModelTransaction()
 {
-    delete keyChange;
     delete walletTransaction;
 }
 
@@ -92,10 +90,10 @@ CAmount WalletModelTransaction::getTotalTransactionAmount() const
 
 void WalletModelTransaction::newPossibleKeyChange(CWallet *wallet)
 {
-    keyChange = new CReserveKey(wallet);
+    keyChange.reset(new CReserveKey(wallet));
 }
 
 CReserveKey *WalletModelTransaction::getPossibleKeyChange()
 {
-    return keyChange;
+    return keyChange.get();
 }

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -42,7 +42,7 @@ public:
 private:
     QList<SendCoinsRecipient> recipients;
     CWalletTx *walletTransaction;
-    CReserveKey *keyChange;
+    std::unique_ptr<CReserveKey> keyChange;
     CAmount fee;
 };
 


### PR DESCRIPTION
Backport of bitcoin PR #10920

https://github.com/bitcoin/bitcoin/pull/10920
