### PR TITLE
backport: Remove redundant locks (bitcoin #11733)

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -388,11 +388,8 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
     }
 
     // Add entry
-    {
-        LOCK(wallet->cs_wallet);
-        wallet->SetAddressBook(DecodeDestination(strAddress), strLabel,
-                               (type == Send ? "send" : "receive"));
-    }
+    wallet->SetAddressBook(DecodeDestination(strAddress), strLabel,
+                           (type == Send ? "send" : "receive"));
     return QString::fromStdString(strAddress);
 }
 
@@ -406,10 +403,7 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex &parent
         // Also refuse to remove receiving addresses.
         return false;
     }
-    {
-        LOCK(wallet->cs_wallet);
-        wallet->DelAddressBook(DecodeDestination(rec->address.toStdString()));
-    }
+    wallet->DelAddressBook(DecodeDestination(rec->address.toStdString()));
     return true;
 }
 


### PR DESCRIPTION
* SetAddressBook(...) is locking cs_wallet internally
* DelAddressBook(...) is locking cs_wallet internally