### PR TITLE
backport: Fix shutdown in case of errors during initialization

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -210,8 +210,8 @@ void PrepareShutdown()
 
     // Because these depend on each-other, we make sure that neither can be
     // using the other before destroying them.
-    UnregisterValidationInterface(peerLogic.get());
-    if(g_connman) g_connman->Stop();
+    if (peerLogic) UnregisterValidationInterface(peerLogic.get());
+    if (g_connman) g_connman->Stop();
     peerLogic.reset();
     g_connman.reset();
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -55,7 +55,9 @@ void CMainSignals::UnregisterBackgroundSignalScheduler() {
 }
 
 void CMainSignals::FlushBackgroundCallbacks() {
-    m_internals->m_schedulerClient.EmptyQueue();
+    if (m_internals) {
+        m_internals->m_schedulerClient.EmptyQueue();
+    }
 }
 
 CMainSignals& GetMainSignals()
@@ -92,6 +94,9 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
 }
 
 void UnregisterAllValidationInterfaces() {
+    if (!g_signals.m_internals) {
+        return;
+    }
     g_signals.m_internals->BlockChecked.disconnect_all_slots();
     g_signals.m_internals->Broadcast.disconnect_all_slots();
     g_signals.m_internals->SetBestChain.disconnect_all_slots();


### PR DESCRIPTION

bitcoin PR #10286 introduced a few steps which are not robust to early shutdown
in initialization.

Stumbled upon this with #11781, not sure if there are other scenarios
that can trigger it, but it's harden against this in any case.