### PR TITLE
Fix mining bug - lockup in CreateNewBlock loop

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2551,6 +2551,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
         {
             CAmount txfee = 0;
             if (!Consensus::CheckTxInputs(tx, state, view, pindex->nHeight, txfee)) {
+                state.SetFailedTransaction(tx.GetHash());
                 return error("%s: Consensus::CheckTxInputs: %s, %s", __func__, tx.GetHash().ToString(), FormatStateMessage(state));
             }
             nFees += txfee;
@@ -4067,10 +4068,12 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
             fCheckBlock = CHECK_BLOCK_TRANSACTION_FALSE;
         }
 
-        if (!CheckTransaction(*tx, state, fCheckDuplicates, fCheckMempool, fCheckBlock))
+        if (!CheckTransaction(*tx, state, fCheckDuplicates, fCheckMempool, fCheckBlock)) {
+            state.SetFailedTransaction(tx.GetHash());
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s %s", tx->GetHash().ToString(),
                                            state.GetDebugMessage(), state.GetRejectReason()));
+        }
     }
 
     unsigned int nSigOps = 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4069,7 +4069,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
         }
 
         if (!CheckTransaction(*tx, state, fCheckDuplicates, fCheckMempool, fCheckBlock)) {
-            state.SetFailedTransaction(tx.GetHash());
+            state.SetFailedTransaction(tx->GetHash());
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s %s", tx->GetHash().ToString(),
                                            state.GetDebugMessage(), state.GetRejectReason()));


### PR DESCRIPTION
This bug was discovered in Dec-2021 on mainnet when two blocks were mined within one second. Pool operators locked up and required restarting. 

It happened because when CheckTxInputs finds a double spend, ConnectBlock fails but does not mark the bad transaction to be flushed from the mempool.

It is described in detail in Issue [#1183](https://github.com/RavenProject/Ravencoin/issues/1183) which this PR fixes.

Thanks go to Jeremy for help with this bug.
