### PR TITLE
Add P2SH support for tagging addresses

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -35,6 +35,7 @@
 #define OFFSET_THREE 3
 #define OFFSET_FOUR 4
 #define OFFSET_TWENTY_THREE 23
+#define OFFSET_TWENTY_FOUR 24
 
 
 std::map<uint256, std::string> mapReissuedTx;
@@ -857,8 +858,16 @@ bool AssetNullDataFromScript(const CScript& scriptPubKey, CNullAssetTxData& asse
 
     strAddress = EncodeDestination(destination);
 
+    // Only used for P2PKH addresses
+    int offset = OFFSET_TWENTY_THREE;
+
+    // Only used for P2SH addresses
+    if (scriptPubKey[1] == OP_1NEGATE) {
+        offset = OFFSET_TWENTY_FOUR;
+    }
+
     std::vector<unsigned char> vchAssetData;
-    vchAssetData.insert(vchAssetData.end(), scriptPubKey.begin() + OFFSET_TWENTY_THREE, scriptPubKey.end());
+    vchAssetData.insert(vchAssetData.end(), scriptPubKey.begin() + offset, scriptPubKey.end());
     CDataStream ssData(vchAssetData, SER_NETWORK, PROTOCOL_VERSION);
 
     try {

--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -2047,7 +2047,7 @@ UniValue listtagsforaddress(const JSONRPCRequest &request)
 
 UniValue listaddressesfortag(const JSONRPCRequest& request)
 {
-    if (request.fHelp || !AreRestrictedAssetsDeployed() || request.params.size() !=1)
+    if (request.fHelp || !AreRestrictedAssetsDeployed() || request.params.size() != 1)
         throw std::runtime_error(
                 "listaddressesfortag tag_name\n"
                 + RestrictedActivationWarning() +

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -362,9 +362,16 @@ bool CScript::IsNullAsset() const
 
 bool CScript::IsNullAssetTxDataScript() const
 {
-    return (this->size() > 23 &&
+    bool p2pkh =  (this->size() > 23 &&
             (*this)[0] == OP_RVN_ASSET &&
             (*this)[1] == 0x14);
+
+    bool p2sh = (this->size() > 23 &&
+                 (*this)[0] == OP_RVN_ASSET &&
+                 (*this)[1] == OP_1NEGATE &&
+                 (*this)[2] == 0x14);
+
+    return p2sh || p2pkh;
 }
 
 bool CScript::IsNullGlobalRestrictionAssetTxDataScript() const


### PR DESCRIPTION
- This fixes the issue which was shared with me from @jeroz1. 

This was the bug `If you try to tag a P2SH address with a Qualifier, the tag lands instead on the P2PKH address whose HASH160 is the same as the hash of the redeem script of the intended P2SH address. In English: you can't tag P2SH addresses because the tag goes to a different address.`

This fix was written and tested via regtest. If this was to go live without the proper bip9 activation the chain could suffer a fork. Would probably be a good idea to wrap these changes with the P2SH bip9 if it hasn't gone to mainnet yet. 

Feel free to cherry-pick this commit, add the proper bip9 activation code before releasing to testnet / mainnet. 