### PR TITLE
gui: fix ui squishing on restrict addresses/global tab

### DIFF
--- a/src/qt/raven.cpp
+++ b/src/qt/raven.cpp
@@ -430,8 +430,8 @@ void RavenApplication::createOptionsModel(bool resetSettings)
 void RavenApplication::createWindow(const NetworkStyle *networkStyle)
 {
     window = new RavenGUI(platformStyle, networkStyle, 0);
-    window->setMinimumSize(1024,700);
-    window->setBaseSize(1024,700);
+    window->setMinimumSize(1024,820);
+    window->setBaseSize(1024, 820);
 
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, SIGNAL(timeout()), window, SLOT(detectShutdown()));


### PR DESCRIPTION
Fixes #1178 
Before:
![image](https://user-images.githubusercontent.com/108390075/176891121-cfe81963-347a-4022-8500-55be8d2e559e.png)
After:
![Screenshot_20220701_050631](https://user-images.githubusercontent.com/108390075/176891341-6eea19e8-57f6-425a-b4d9-5c961cf3036f.png)