### PR TITLE
Fix function test failures which depend on nonstandard transactions

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -413,6 +413,7 @@ def initialize_data_dir(dirname, n):
         os.makedirs(datadir)
     with open(os.path.join(datadir, "raven.conf"), 'w', encoding='utf8') as f:
         f.write("regtest=1\n")
+        f.write("acceptnonstdtxn=1\n")
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
         f.write("listenonion=0\n")


### PR DESCRIPTION
The "-acceptnonstdtxn" CLI option on raven-v4.3.2.1 is broken (it never has any effect). A previous PR fixed it so that it now behaves similarly to the behavior on bitcoin. But 5 functional tests assumed that regtest would by default accept non-standard transactions, and therefore broke. This PR just tells the functional test framework to use the "-acceptnonstdtxn" option, which fixes the fails.