### PR TITLE
Fix building of develop branch without adding vulnerabilities

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,6 +1,7 @@
 PACKAGE=qt
 $(package)_version=5.12.11
-$(package)_download_path=https://download.qt.io/official_releases/qt/5.12/$($(package)_version)/submodules
+#$(package)_download_path=https://download.qt.io/official_releases/qt/5.12/$($(package)_version)/submodules
+$(package)_download_path=https://download.qt.io/archive/qt/5.12/$($(package)_version)/submodules
 $(package)_suffix=everywhere-src-$($(package)_version).tar.xz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=1c1b4e33137ca77881074c140d54c3c9747e845a31338cfe8680f171f0bc3a39


### PR DESCRIPTION
In Sept-2022 the qt project changed the URL for downloading qt-5.12.11, which broke Ravencoin's build system.
Fixing this for the same version of qt requires only updating the URL as was done for Evrmore in Oct-2022.

Ravencoin PR-1224 was merged recently, but it was merged (perhaps unintentionally?) into the master branch.

I believe that PR also makes numerous unneeded changes including:
-making minor changes to the consensus ProgPow files in src/crypto/ethash/lib
-disabling libravenconsensus from being built
-downgrading libzmq from v4.3.4 to v4.3.1, which is undesirable since v4.3.1 contains multiple security issues including a heap overflow vulnerability.

This PR affects only develop branch at this time. But I suggest that action should be taken regarding PR-1224 before using master branch for the next release.