### PR TITLE
Update assetsdialog.cpp

### DIFF
--- a/src/qt/assetsdialog.cpp
+++ b/src/qt/assetsdialog.cpp
@@ -917,7 +917,7 @@ void AssetsDialog::assetControlChangeEdited(const QString& text)
 
         if (text.isEmpty()) // Nothing entered
         {
-            ui->labelAssetControlChangeLabel->setText("");
+            ui->labelAssetControlChangeLabel->setText(tr("Warning: You must provide a valid entry"));
         }
         else if (!IsValidDestination(dest)) // Invalid address
         {


### PR DESCRIPTION
Update to include a warning message to a user that provides no entry at all to asset transfer. #1220 