### PR TITLE
Refine inventory send logic for peers. (60 secondes to 30 patch)  

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3541,7 +3541,15 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
             if (pto->nNextInvSend < nNow) {
                 fSendTrickle = true;
                 // Use half the delay for outbound peers, as there is less privacy concern for them.
-                pto->nNextInvSend = PoissonNextSend(nNow, INVENTORY_BROADCAST_INTERVAL >> !pto->fInbound);
+                if (pto->nNextInvSend < nNow) {
+    fSendTrickle = true;
+    if (inv.type == MSG_BLOCK) {
+        pto->nNextInvSend = nNow; // immédiat pour les blocs
+    } else {
+        pto->nNextInvSend = PoissonNextSend(nNow,
+            (INVENTORY_BROADCAST_INTERVAL / 2) >> !pto->fInbound); // tx normale
+    }
+}
             }
 
             // Time to send but the peer has requested we not relay transactions.


### PR DESCRIPTION
Adjust the inventory send timing for outbound peers and ensure immediate sending for block messages. For the 30 sec