### PR TITLE
Mineable assets (G-PoW accrual model)

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -5,6 +5,7 @@ $(package)_download_path=https://archives.boost.io/release/1.71.0/source/
 $(package)_file_name=boost_$($(package)_version).tar.bz2
 $(package)_sha256_hash=d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee
 $(package)_dependencies=native_b2
+$(package)_patches=pthread_stack_min.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -30,6 +31,7 @@ $(package)_cxxflags_android=-fPIC
 endef
 
 define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/pthread_stack_min.patch && \
   echo "using $($(package)_toolset_$(host_os)) : : $($(package)_cxx) : <cflags>\"$($(package)_cflags)\" <cxxflags>\"$($(package)_cxxflags)\" <compileflags>\"$($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$($(package)_ar)\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 

--- a/depends/patches/boost/pthread_stack_min.patch
+++ b/depends/patches/boost/pthread_stack_min.patch
@@ -1,0 +1,13 @@
+Fix Boost 1.71 build on glibc >= 2.34 where PTHREAD_STACK_MIN is dynamic.
+
+--- a/boost/thread/pthread/thread_data.hpp
++++ b/boost/thread/pthread/thread_data.hpp
+@@ -57,7 +57,7 @@ namespace boost
+ #else
+           std::size_t page_size = ::sysconf( _SC_PAGESIZE);
+ #endif
+-#if PTHREAD_STACK_MIN > 0
++#ifdef PTHREAD_STACK_MIN
+           if (size<PTHREAD_STACK_MIN) size=PTHREAD_STACK_MIN;
+ #endif
+           size = ((size+page_size-1)/page_size)*page_size;

--- a/doc/rip-mineable-assets.md
+++ b/doc/rip-mineable-assets.md
@@ -1,0 +1,39 @@
+# RIP: Mineable Assets (G-PoW accrual)
+
+Status: Draft (feature branch `feature/mineable-assets` on 2miners/Ravencoin v4.8.0)
+
+Activation: BIP9 deployment `mineable_assets` (bit 12). Intended to activate after
+consensus stabilizes (post-4.8.0) and alongside future work such as `p2sh-protocol-update`.
+
+## Summary
+
+Mineable assets (`&NAME`) are minted through optional coinbase claims. Each asset keeps
+one accrual bucket: unclaimed schedule periods increase the claimable amount until a
+miner includes a full-balance claim in a block.
+
+## Accrual
+
+Per active schedule:
+
+- `total_periods = total_qty / per_block`
+- `matured_periods = min(total_periods, (height - start_height) / nth_block)` when `height > start_height`
+- `accrued_amount = (matured_periods - claimed_periods) * per_block`, capped by remaining supply
+- `accrued_fund = (matured_periods - claimed_periods) * fund_amt`
+
+## Claim rules
+
+- Any block may claim any asset with `accrued_amount > 0` (delayed claim allowed).
+- Claim must mint the **full** accrued balance (miner + optional fund outputs).
+- At most one claim per mineable asset per block.
+- Block weight is the only limit on claims per block.
+
+## Issuance
+
+`issuemineable` registers a schedule. Issuer must hold the root asset ownership token.
+Cost: `max(500 RVN, total_periods * 1 RVN)`. A new schedule for the same root asset
+preempts the prior schedule and resets accrual.
+
+## Coinbase
+
+When `mineable_assets` is active, coinbase may include `&` asset transfer outputs that
+match validated accrual. The prior coinbase asset ban still applies to non-mineable assets.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -134,6 +134,8 @@ RAVEN_CORE_H = \
   assets/messages.h \
   assets/myassetsdb.h \
   assets/restricteddb.h \
+  assets/mineable.h \
+  assets/mineabledb.h \
   assets/snapshotrequestdb.h \
   assets/assetsnapshotdb.h \
   assets/rewards.h \
@@ -269,6 +271,8 @@ libraven_server_a_SOURCES = \
   assets/messages.cpp \
   assets/myassetsdb.cpp \
   assets/restricteddb.cpp \
+  assets/mineable.cpp \
+  assets/mineabledb.cpp \
   assets/snapshotrequestdb.cpp \
   assets/assetsnapshotdb.cpp \
   assets/rewards.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -35,6 +35,8 @@ RAVEN_TESTS =\
   test/assets/restricted_tests.cpp \
   test/assets/qualifier_tests.cpp \
   test/assets/unique_tests.cpp \
+  test/assets/mineable_tests.cpp \
+  test/assets/asset_regression_stress_tests.cpp \
   test/assets/verifier_string_tests.cpp \
   test/arith_uint256_tests.cpp \
   test/scriptnum10.h \

--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -24,6 +24,7 @@
 #include "assetdb.h"
 #include "assettypes.h"
 #include "mineable.h"
+#include "mineabledb.h"
 #include "protocol.h"
 #include "wallet/coincontrol.h"
 #include "utilmoneystr.h"
@@ -1471,9 +1472,11 @@ bool CTransaction::IsReissueAsset() const
 
 bool CTransaction::IsIssueMineableAsset() const
 {
-    if (vout.empty())
-        return false;
-    return CheckIssueMineableDataTx(vout[vout.size() - 1]);
+    for (const auto& out : vout) {
+        if (CheckIssueMineableDataTx(out))
+            return true;
+    }
+    return false;
 }
 
 bool CTransaction::VerifyIssueMineable(std::string& strError) const
@@ -1482,7 +1485,15 @@ bool CTransaction::VerifyIssueMineable(std::string& strError) const
         strError = "bad-txns-mineable-vout-size";
         return false;
     }
-    if (!CheckIssueMineableDataTx(vout[vout.size() - 1])) {
+
+    const CTxOut* mineableOut = nullptr;
+    for (const auto& out : vout) {
+        if (CheckIssueMineableDataTx(out)) {
+            mineableOut = &out;
+            break;
+        }
+    }
+    if (!mineableOut) {
         strError = "bad-txns-mineable-data-not-found";
         return false;
     }
@@ -1513,9 +1524,11 @@ bool CTransaction::VerifyIssueMineable(std::string& strError) const
 
 bool CTransaction::IsReissueMineableAsset() const
 {
-    if (vout.empty())
-        return false;
-    return CheckReissueMineableDataTx(vout[vout.size() - 1]);
+    for (const auto& out : vout) {
+        if (CheckReissueMineableDataTx(out))
+            return true;
+    }
+    return false;
 }
 
 bool CTransaction::VerifyReissueMineable(std::string& strError) const
@@ -1524,7 +1537,15 @@ bool CTransaction::VerifyReissueMineable(std::string& strError) const
         strError = "bad-txns-mineable-reissue-vout-size";
         return false;
     }
-    if (!CheckReissueMineableDataTx(vout[vout.size() - 1])) {
+
+    const CTxOut* reissueOut = nullptr;
+    for (const auto& out : vout) {
+        if (CheckReissueMineableDataTx(out)) {
+            reissueOut = &out;
+            break;
+        }
+    }
+    if (!reissueOut) {
         strError = "bad-txns-mineable-reissue-data-not-found";
         return false;
     }

--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -23,6 +23,7 @@
 #include "assets.h"
 #include "assetdb.h"
 #include "assettypes.h"
+#include "mineable.h"
 #include "protocol.h"
 #include "wallet/coincontrol.h"
 #include "utilmoneystr.h"
@@ -75,6 +76,7 @@ static const std::regex VOTE_INDICATOR(R"(^[^^~#!]+\^[^~#!\/]+$)");
 static const std::regex QUALIFIER_INDICATOR("^[#][A-Z0-9._]{3,}$"); // Starts with #
 static const std::regex SUB_QUALIFIER_INDICATOR("^#[A-Z0-9._]+\\/#[A-Z0-9._]+$"); // Starts with #
 static const std::regex RESTRICTED_INDICATOR("^[\\$][A-Z0-9._]{3,}$"); // Starts with $
+static const std::regex MINEABLE_INDICATOR("^[&][A-Z0-9._]{3,}$"); // Starts with &
 
 static const std::regex RAVEN_NAMES("^RVN$|^RAVEN$|^RAVENCOIN$|^#RVN$|^#RAVEN$|^#RAVENCOIN$");
 
@@ -272,6 +274,14 @@ bool IsAssetNameValid(const std::string& name, AssetType& assetType, std::string
 
         return ret;
     }
+    else if (std::regex_match(name, MINEABLE_INDICATOR))
+    {
+        bool ret = IsTypeCheckNameValid(AssetType::MINEABLE, name, error);
+        if (ret)
+            assetType = AssetType::MINEABLE;
+
+        return ret;
+    }
     else
     {
         auto type = IsAssetNameASubasset(name) ? AssetType::SUB : AssetType::ROOT;
@@ -365,6 +375,13 @@ bool IsTypeCheckNameValid(const AssetType type, const std::string& name, std::st
         if (name.size() > MAX_NAME_LENGTH) { error = "Name is greater than max length of " + std::to_string(MAX_NAME_LENGTH); return false; }
         bool valid = IsRestrictedNameValid(name);
         if (!valid) { error = "Restricted name contains invalid characters (Valid characters are: A-Z 0-9 _ .) ($ must be the first character, _ . special characters can't be the first or last characters)";  return false; }
+        return true;
+    } else if (type == AssetType::MINEABLE) {
+        if (name.size() > MAX_NAME_LENGTH) { error = "Name is greater than max length of " + std::to_string(MAX_NAME_LENGTH); return false; }
+        if (name.size() < 4) { error = "Mineable name must contain at least 3 characters after &"; return false; }
+        std::string body = name.substr(1);
+        bool valid = IsRootNameValid(body);
+        if (!valid) { error = "Mineable name contains invalid characters"; return false; }
         return true;
     } else {
         if (name.size() > MAX_NAME_LENGTH - 1) { error = "Name is greater than max length of " + std::to_string(MAX_NAME_LENGTH - 1); return false; }  //Assets and sub-assets need to leave one extra char for OWNER indicator
@@ -1448,6 +1465,139 @@ bool CTransaction::IsReissueAsset() const
     // Check for the reissue asset data CTxOut. This will always be the last output in the transaction
     if (!CheckReissueDataTx(vout[vout.size() - 1]))
         return false;
+
+    return true;
+}
+
+bool CTransaction::IsIssueMineableAsset() const
+{
+    if (vout.empty())
+        return false;
+    return CheckIssueMineableDataTx(vout[vout.size() - 1]);
+}
+
+bool CTransaction::VerifyIssueMineable(std::string& strError) const
+{
+    if (vout.size() < 2) {
+        strError = "bad-txns-mineable-vout-size";
+        return false;
+    }
+    if (!CheckIssueMineableDataTx(vout[vout.size() - 1])) {
+        strError = "bad-txns-mineable-data-not-found";
+        return false;
+    }
+
+    CIssueMineable issue;
+    std::string address;
+    if (!IssueMineableFromTransaction(*this, issue, address)) {
+        strError = "bad-txns-mineable-serialization-failed";
+        return false;
+    }
+    if (!CheckIssueMineable(issue, strError))
+        return false;
+
+    const CAmount expectedBurn = CalculateMineableIssuanceCost(issue);
+    bool foundBurn = false;
+    for (const auto& out : vout) {
+        if (out.scriptPubKey == GetScriptForDestination(DecodeDestination(GetParams().IssueAssetBurnAddress()))) {
+            if (out.nValue == expectedBurn)
+                foundBurn = true;
+        }
+    }
+    if (!foundBurn) {
+        strError = "bad-txns-mineable-burn";
+        return false;
+    }
+    return true;
+}
+
+bool CTransaction::IsReissueMineableAsset() const
+{
+    if (vout.empty())
+        return false;
+    return CheckReissueMineableDataTx(vout[vout.size() - 1]);
+}
+
+bool CTransaction::VerifyReissueMineable(std::string& strError) const
+{
+    if (vout.size() < 2) {
+        strError = "bad-txns-mineable-reissue-vout-size";
+        return false;
+    }
+    if (!CheckReissueMineableDataTx(vout[vout.size() - 1])) {
+        strError = "bad-txns-mineable-reissue-data-not-found";
+        return false;
+    }
+
+    CReissueMineableSchedule reissue;
+    std::string address;
+    if (!ReissueMineableFromTransaction(*this, reissue, address)) {
+        strError = "bad-txns-mineable-reissue-serialization-failed";
+        return false;
+    }
+    if (!CheckReissueMineableSchedule(reissue, strError))
+        return false;
+
+    if (!pmineabledb) {
+        strError = "bad-txns-mineable-reissue-no-db";
+        return false;
+    }
+
+    CMineableSchedule schedule;
+    if (!pmineabledb->ReadSchedule(reissue.strMineableAsset, schedule) || !schedule.fActive) {
+        strError = "bad-txns-mineable-reissue-unknown";
+        return false;
+    }
+
+    const CAmount expectedBurn = CalculateMineableExtensionCost(schedule, reissue.nAddQty, reissue.nNewNthBlock);
+    if (expectedBurn > 0) {
+        bool foundBurn = false;
+        for (const auto& out : vout) {
+            if (out.scriptPubKey == GetScriptForDestination(DecodeDestination(GetParams().IssueAssetBurnAddress()))) {
+                if (out.nValue == expectedBurn)
+                    foundBurn = true;
+            }
+        }
+        if (!foundBurn) {
+            strError = "bad-txns-mineable-reissue-burn";
+            return false;
+        }
+    }
+
+    bool fOwnerOutFound = false;
+    for (const auto& out : vout) {
+        CAssetTransfer transfer;
+        std::string transferAddress;
+        if (TransferAssetFromScript(out.scriptPubKey, transfer, transferAddress)) {
+            if (schedule.strRootAsset + OWNER_TAG == transfer.strName) {
+                fOwnerOutFound = true;
+                break;
+            }
+        }
+    }
+    if (!fOwnerOutFound) {
+        strError = "bad-txns-mineable-reissue-owner-outpoint-not-found";
+        return false;
+    }
+
+    int nMineableReissues = 0;
+    int nTransfers = 0;
+    for (const auto& out : vout) {
+        if (IsScriptReissueMineableAsset(out.scriptPubKey))
+            nMineableReissues++;
+        int nType = 0;
+        bool fIsOwner = false;
+        if (out.scriptPubKey.IsAssetScript(nType, fIsOwner) && nType == TX_TRANSFER_ASSET)
+            nTransfers++;
+    }
+    if (nMineableReissues != 1) {
+        strError = "bad-txns-mineable-reissue-format";
+        return false;
+    }
+    if (nTransfers < 1) {
+        strError = "bad-txns-mineable-reissue-owner-transfer-missing";
+        return false;
+    }
 
     return true;
 }
@@ -3144,6 +3294,16 @@ bool CheckReissueDataTx(const CTxOut& txOut)
     return IsScriptReissueAsset(scriptPubKey);
 }
 
+bool CheckIssueMineableDataTx(const CTxOut& txOut)
+{
+    return IsScriptIssueMineableAsset(txOut.scriptPubKey);
+}
+
+bool CheckReissueMineableDataTx(const CTxOut& txOut)
+{
+    return IsScriptReissueMineableAsset(txOut.scriptPubKey);
+}
+
 bool CheckOwnerDataTx(const CTxOut& txOut)
 {
     // Verify 'rvnq' is in the transaction
@@ -3258,6 +3418,26 @@ bool IsScriptReissueAsset(const CScript& scriptPubKey, int& nStartingIndex)
         return nType == TX_REISSUE_ASSET;
     }
 
+    return false;
+}
+
+bool IsScriptIssueMineableAsset(const CScript& scriptPubKey)
+{
+    int nType = 0;
+    bool fIsOwner = false;
+    int nStartingIndex = 0;
+    if (scriptPubKey.IsAssetScript(nType, fIsOwner, nStartingIndex))
+        return nType == TX_ISSUE_MINEABLE;
+    return false;
+}
+
+bool IsScriptReissueMineableAsset(const CScript& scriptPubKey)
+{
+    int nType = 0;
+    bool fIsOwner = false;
+    int nStartingIndex = 0;
+    if (scriptPubKey.IsAssetScript(nType, fIsOwner, nStartingIndex))
+        return nType == TX_REISSUE_MINEABLE;
     return false;
 }
 

--- a/src/assets/assets.h
+++ b/src/assets/assets.h
@@ -22,6 +22,8 @@
 #define RVN_Q 113
 #define RVN_T 116
 #define RVN_O 111
+#define RVN_M 77
+#define RVN_E 69
 
 #define DEFAULT_UNITS 0
 #define DEFAULT_REISSUABLE 1
@@ -466,6 +468,8 @@ bool CheckReissueBurnTx(const CTxOut& txOut);
 bool CheckIssueDataTx(const CTxOut& txOut); // OP_RAVEN_ASSET RVNQ (That is a Q as in Que not an O)
 bool CheckOwnerDataTx(const CTxOut& txOut);// OP_RAVEN_ASSET RVNO
 bool CheckReissueDataTx(const CTxOut& txOut);// OP_RAVEN_ASSET RVNR
+bool CheckIssueMineableDataTx(const CTxOut& txOut);// OP_RAVEN_ASSET RVNM
+bool CheckReissueMineableDataTx(const CTxOut& txOut);// OP_RAVEN_ASSET RVNE
 bool CheckTransferOwnerTx(const CTxOut& txOut);// OP_RAVEN_ASSET RVNT
 
 //! Check the Encoded hash and make sure it is either an IPFS hash or a OIP hash
@@ -489,6 +493,8 @@ bool IsScriptOwnerAsset(const CScript& scriptPubKey, int& nStartingIndex);
 //! Check script and see if it matches the reissue template
 bool IsScriptReissueAsset(const CScript& scriptPubKey);
 bool IsScriptReissueAsset(const CScript& scriptPubKey, int& nStartingIndex);
+bool IsScriptIssueMineableAsset(const CScript& scriptPubKey);
+bool IsScriptReissueMineableAsset(const CScript& scriptPubKey);
 
 //! Check script and see if it matches the transfer asset template
 bool IsScriptTransferAsset(const CScript& scriptPubKey);

--- a/src/assets/assettypes.h
+++ b/src/assets/assettypes.h
@@ -31,7 +31,8 @@ enum class AssetType
     REISSUE = 8,
     OWNER = 9,
     NULL_ADD_QUALIFIER = 10,
-    INVALID = 11
+    MINEABLE = 11,
+    INVALID = 12
 };
 
 enum class QualifierType

--- a/src/assets/mineable.cpp
+++ b/src/assets/mineable.cpp
@@ -1,0 +1,714 @@
+// Copyright (c) 2026 The Ravencoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "assets/mineable.h"
+#include "assets/mineabledb.h"
+#include "assets/assets.h"
+#include "base58.h"
+#include "consensus/validation.h"
+#include "assets/assetdb.h"
+#include "validation.h"
+
+#include <algorithm>
+
+CMineableSchedule::CMineableSchedule()
+{
+    strRootAsset.clear();
+    strMineableAsset.clear();
+    nTotalQty = 0;
+    nPerBlock = 0;
+    nNthBlock = 10;
+    nFundAmt = 0;
+    nUnits = 0;
+    nHasIPFS = 0;
+    strIPFSHash.clear();
+    nStartHeight = 0;
+    nMaturedPeriods = 0;
+    nClaimedPeriods = 0;
+    nTotalMinted = 0;
+    issuanceTxid.SetNull();
+    fActive = false;
+    fAllowExtension = false;
+    nMaxTotalQty = 0;
+}
+
+int CMineableSchedule::GetTotalPeriods() const
+{
+    if (nPerBlock <= 0)
+        return 0;
+    return static_cast<int>(nTotalQty / nPerBlock);
+}
+
+void CMineableSchedule::UpdateMaturity(int nHeight)
+{
+    if (!fActive || IsComplete())
+        return;
+    if (nHeight <= nStartHeight || nNthBlock <= 0)
+        return;
+
+    const int elapsed = nHeight - nStartHeight;
+    const int shouldMature = std::min(GetTotalPeriods(), elapsed / nNthBlock);
+    if (shouldMature > nMaturedPeriods)
+        nMaturedPeriods = shouldMature;
+}
+
+CAmount CMineableSchedule::GetAccruedAmount() const
+{
+    const int delta = nMaturedPeriods - nClaimedPeriods;
+    if (delta <= 0)
+        return 0;
+    CAmount remaining = nTotalQty - nTotalMinted;
+    if (remaining <= 0)
+        return 0;
+    CAmount accrued = delta * nPerBlock;
+    return std::min(accrued, remaining);
+}
+
+CAmount CMineableSchedule::GetAccruedFundAmount() const
+{
+    const int delta = nMaturedPeriods - nClaimedPeriods;
+    if (delta <= 0 || nFundAmt <= 0)
+        return 0;
+    return delta * nFundAmt;
+}
+
+CAmount CMineableSchedule::GetAccruedMinerAmount() const
+{
+    CAmount total = GetAccruedAmount();
+    CAmount fund = GetAccruedFundAmount();
+    if (total <= fund)
+        return 0;
+    return total - fund;
+}
+
+bool CMineableSchedule::IsComplete() const
+{
+    return nTotalMinted >= nTotalQty || nClaimedPeriods >= GetTotalPeriods();
+}
+
+CIssueMineable::CIssueMineable()
+{
+    strRootAsset.clear();
+    strMineableAsset.clear();
+    nTotalQty = 0;
+    nPerBlock = 0;
+    nNthBlock = 10;
+    nFundAmt = 0;
+    nUnits = 0;
+    nHasIPFS = 0;
+    strIPFSHash.clear();
+    fAllowExtension = false;
+    nMaxTotalQty = 0;
+}
+
+CReissueMineableSchedule::CReissueMineableSchedule()
+{
+    strMineableAsset.clear();
+    nAddQty = 0;
+    nNewNthBlock = 0;
+}
+
+void CIssueMineable::ConstructTransaction(CScript& script) const
+{
+    CDataStream ssIssue(SER_NETWORK, PROTOCOL_VERSION);
+    ssIssue << *this;
+
+    std::vector<unsigned char> vchMessage;
+    vchMessage.push_back(RVN_R);
+    vchMessage.push_back(RVN_V);
+    vchMessage.push_back(RVN_N);
+    vchMessage.push_back(RVN_M);
+    vchMessage.insert(vchMessage.end(), ssIssue.begin(), ssIssue.end());
+    script << OP_RVN_ASSET << ToByteVector(vchMessage) << OP_DROP;
+}
+
+void CReissueMineableSchedule::ConstructTransaction(CScript& script) const
+{
+    CDataStream ssReissue(SER_NETWORK, PROTOCOL_VERSION);
+    ssReissue << *this;
+
+    std::vector<unsigned char> vchMessage;
+    vchMessage.push_back(RVN_R);
+    vchMessage.push_back(RVN_V);
+    vchMessage.push_back(RVN_N);
+    vchMessage.push_back(RVN_E);
+    vchMessage.insert(vchMessage.end(), ssReissue.begin(), ssReissue.end());
+    script << OP_RVN_ASSET << ToByteVector(vchMessage) << OP_DROP;
+}
+
+bool CReissueMineableSchedule::IsNull() const
+{
+    return strMineableAsset.empty() || (nAddQty <= 0 && nNewNthBlock <= 0);
+}
+
+bool CIssueMineable::IsNull() const
+{
+    return strRootAsset.empty() || nTotalQty <= 0 || nPerBlock <= 0;
+}
+
+bool IsMineableAssetName(const std::string& name)
+{
+    return name.size() >= 4 && name[0] == MINEABLE_CHAR;
+}
+
+std::string MineableAssetNameFromRoot(const std::string& rootAsset)
+{
+    return std::string(1, MINEABLE_CHAR) + rootAsset;
+}
+
+CAmount CalculateMineableIssuanceCost(const CIssueMineable& issue)
+{
+    if (issue.nPerBlock <= 0)
+        return MIN_MINEABLE_ISSUANCE_COST;
+    const int periods = static_cast<int>(issue.nTotalQty / issue.nPerBlock);
+    CAmount cost = periods * MINEABLE_COST_PER_PERIOD;
+    return std::max(MIN_MINEABLE_ISSUANCE_COST, cost);
+}
+
+void GetMineableIssuanceEstimate(const CIssueMineable& issue, CAmount& cost, int& days, int& months)
+{
+    cost = CalculateMineableIssuanceCost(issue);
+    days = 0;
+    months = 0;
+    if (issue.nPerBlock <= 0 || issue.nNthBlock <= 0)
+        return;
+    const int periods = static_cast<int>(issue.nTotalQty / issue.nPerBlock);
+    const int blocks = periods * issue.nNthBlock;
+    days = blocks / (60 * 24);
+    months = days / 30;
+}
+
+bool CheckIssueMineable(const CIssueMineable& issue, std::string& strError)
+{
+    strError.clear();
+    if (issue.strRootAsset.empty()) {
+        strError = "bad-txns-mineable-empty-root";
+        return false;
+    }
+    if (issue.strMineableAsset != MineableAssetNameFromRoot(issue.strRootAsset)) {
+        strError = "bad-txns-mineable-name-mismatch";
+        return false;
+    }
+    if (issue.nTotalQty <= 0 || issue.nTotalQty > MAX_MONEY) {
+        strError = "bad-txns-mineable-qty";
+        return false;
+    }
+    if (issue.nPerBlock <= 0 || issue.nTotalQty % issue.nPerBlock != 0) {
+        strError = "bad-txns-mineable-per-block";
+        return false;
+    }
+    if (issue.nNthBlock < 1 || issue.nNthBlock > 10080) {
+        strError = "bad-txns-mineable-nth-block";
+        return false;
+    }
+    if (issue.nFundAmt < 0 || issue.nFundAmt > issue.nPerBlock) {
+        strError = "bad-txns-mineable-fund-amt";
+        return false;
+    }
+    if (issue.nUnits < MIN_UNIT || issue.nUnits > MAX_UNIT) {
+        strError = "bad-txns-mineable-units";
+        return false;
+    }
+    if (issue.nMaxTotalQty < 0 || issue.nMaxTotalQty > MAX_MONEY) {
+        strError = "bad-txns-mineable-max-qty";
+        return false;
+    }
+    if (issue.fAllowExtension) {
+        const CAmount cap = issue.nMaxTotalQty > 0 ? issue.nMaxTotalQty : issue.nTotalQty;
+        if (cap < issue.nTotalQty) {
+            strError = "bad-txns-mineable-max-below-total";
+            return false;
+        }
+    } else if (issue.nMaxTotalQty > 0 && issue.nMaxTotalQty != issue.nTotalQty) {
+        strError = "bad-txns-mineable-max-without-extension";
+        return false;
+    }
+    AssetType rootType;
+    if (!IsAssetNameValid(issue.strRootAsset, rootType) || rootType != AssetType::ROOT) {
+        strError = "bad-txns-mineable-root-invalid";
+        return false;
+    }
+    return true;
+}
+
+bool IsNthBlockExtensionCompatible(int oldNth, int newNth)
+{
+    if (newNth <= 0 || newNth == oldNth)
+        return true;
+    if (newNth > oldNth)
+        return false;
+    return oldNth % newNth == 0;
+}
+
+CAmount CalculateMineableExtensionCost(const CMineableSchedule& schedule, CAmount nAddQty, int nNewNthBlock)
+{
+    CAmount cost = 0;
+    if (nAddQty > 0) {
+        if (schedule.nPerBlock <= 0)
+            return 0;
+        const int addPeriods = static_cast<int>(nAddQty / schedule.nPerBlock);
+        cost += addPeriods * MINEABLE_COST_PER_PERIOD;
+    }
+
+    const int effectiveNewNth = nNewNthBlock > 0 ? nNewNthBlock : schedule.nNthBlock;
+    if (effectiveNewNth != schedule.nNthBlock) {
+        if (effectiveNewNth == 1 && schedule.nNthBlock % effectiveNewNth != 0) {
+            const int remaining = schedule.GetTotalPeriods() - schedule.nClaimedPeriods;
+            if (remaining > 0)
+                cost += static_cast<CAmount>(remaining) * (schedule.nNthBlock - 1) * MINEABLE_COST_PER_PERIOD;
+        } else if (!IsNthBlockExtensionCompatible(schedule.nNthBlock, effectiveNewNth)) {
+            return MAX_MONEY;
+        }
+    }
+    return cost;
+}
+
+bool CheckReissueMineableSchedule(const CReissueMineableSchedule& reissue, std::string& strError)
+{
+    strError.clear();
+    if (!IsMineableAssetName(reissue.strMineableAsset)) {
+        strError = "bad-txns-mineable-reissue-name";
+        return false;
+    }
+    if (reissue.nAddQty < 0 || reissue.nAddQty > MAX_MONEY) {
+        strError = "bad-txns-mineable-reissue-qty";
+        return false;
+    }
+    if (reissue.nAddQty == 0 && reissue.nNewNthBlock <= 0) {
+        strError = "bad-txns-mineable-reissue-empty";
+        return false;
+    }
+    if (reissue.nNewNthBlock < 0 || reissue.nNewNthBlock > 10080) {
+        strError = "bad-txns-mineable-reissue-nth";
+        return false;
+    }
+    return true;
+}
+
+bool ApplyScheduleExtension(CMineableSchedule& schedule, CAmount nAddQty, int nNewNthBlock, std::string& strError)
+{
+    strError.clear();
+    if (nAddQty > 0) {
+        if (schedule.nPerBlock <= 0 || nAddQty % schedule.nPerBlock != 0) {
+            strError = "bad-txns-mineable-reissue-per-block";
+            return false;
+        }
+        if (schedule.nTotalQty + nAddQty > schedule.nMaxTotalQty) {
+            strError = "bad-txns-mineable-reissue-cap";
+            return false;
+        }
+        schedule.nTotalQty += nAddQty;
+    }
+
+    if (nNewNthBlock > 0 && nNewNthBlock != schedule.nNthBlock) {
+        if (nNewNthBlock > schedule.nNthBlock) {
+            strError = "bad-txns-mineable-reissue-slower-nth";
+            return false;
+        }
+        if (nNewNthBlock != 1 && schedule.nNthBlock % nNewNthBlock != 0) {
+            strError = "bad-txns-mineable-reissue-nth-indivisible";
+            return false;
+        }
+        schedule.nNthBlock = nNewNthBlock;
+    }
+    return true;
+}
+
+bool ContextualCheckReissueMineableSchedule(CAssetsCache* assetCache, CMineableAssetsDB& db,
+                                            const CReissueMineableSchedule& reissue,
+                                            const std::string& address, std::string& strError)
+{
+    if (!CheckReissueMineableSchedule(reissue, strError))
+        return false;
+
+    CMineableSchedule schedule;
+    if (!db.ReadSchedule(reissue.strMineableAsset, schedule) || !schedule.fActive) {
+        strError = "bad-txns-mineable-reissue-unknown";
+        return false;
+    }
+    if (!schedule.fAllowExtension) {
+        strError = "bad-txns-mineable-reissue-not-extendable";
+        return false;
+    }
+    if (reissue.nAddQty > 0 && schedule.nPerBlock > 0 && reissue.nAddQty % schedule.nPerBlock != 0) {
+        strError = "bad-txns-mineable-reissue-per-block";
+        return false;
+    }
+    if (reissue.nAddQty > 0 && schedule.nTotalQty + reissue.nAddQty > schedule.nMaxTotalQty) {
+        strError = "bad-txns-mineable-reissue-cap";
+        return false;
+    }
+    const int effectiveNewNth = reissue.nNewNthBlock > 0 ? reissue.nNewNthBlock : schedule.nNthBlock;
+    if (effectiveNewNth != schedule.nNthBlock) {
+        if (effectiveNewNth > schedule.nNthBlock) {
+            strError = "bad-txns-mineable-reissue-slower-nth";
+            return false;
+        }
+        if (effectiveNewNth != 1 && schedule.nNthBlock % effectiveNewNth != 0) {
+            strError = "bad-txns-mineable-reissue-nth-indivisible";
+            return false;
+        }
+    }
+    if (CalculateMineableExtensionCost(schedule, reissue.nAddQty, reissue.nNewNthBlock) >= MAX_MONEY) {
+        strError = "bad-txns-mineable-reissue-nth-indivisible";
+        return false;
+    }
+
+    if (assetCache && !address.empty()) {
+        const std::string ownerName = schedule.strRootAsset + OWNER_TAG;
+        const auto key = std::make_pair(ownerName, address);
+        if (!assetCache->mapAssetsAddressAmount.count(key) ||
+            assetCache->mapAssetsAddressAmount.at(key) < OWNER_ASSET_AMOUNT) {
+            strError = "bad-txns-mineable-reissue-not-owner";
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool ContextualCheckIssueMineable(CAssetsCache* assetCache, const CIssueMineable& issue,
+                                  const std::string& address, int nHeight, std::string& strError)
+{
+    if (!CheckIssueMineable(issue, strError))
+        return false;
+
+    if (!assetCache) {
+        strError = "bad-txns-mineable-no-cache";
+        return false;
+    }
+
+    CNewAsset root;
+    if (!assetCache->GetAssetMetaDataIfExists(issue.strRootAsset, root)) {
+        strError = "bad-txns-mineable-root-missing";
+        return false;
+    }
+
+    (void)address;
+    (void)nHeight;
+    return true;
+}
+
+static bool GetOwnerTokenHolder(const std::string& rootAsset, std::string& holderAddress)
+{
+    if (!passetsdb)
+        return false;
+    std::vector<std::pair<std::string, CAmount>> holders;
+    int total = 0;
+    if (!passetsdb->AssetAddressDir(holders, total, true, rootAsset + OWNER_TAG, 0, 0))
+        return false;
+    if (holders.empty())
+        return false;
+    holderAddress = holders[0].first;
+    return true;
+}
+
+bool RegisterMineableScheduleFromTx(const CTransaction& tx, int nHeight, const uint256& blockHash,
+                                    CMineableAssetsDB& db, CAssetsCache* assetsCache)
+{
+    CIssueMineable issue;
+    std::string address;
+    if (!IssueMineableFromTransaction(tx, issue, address))
+        return false;
+
+    CMineableSchedule schedule;
+    schedule.strRootAsset = issue.strRootAsset;
+    schedule.strMineableAsset = issue.strMineableAsset;
+    schedule.nTotalQty = issue.nTotalQty;
+    schedule.nPerBlock = issue.nPerBlock;
+    schedule.nNthBlock = issue.nNthBlock;
+    schedule.nFundAmt = issue.nFundAmt;
+    schedule.nUnits = issue.nUnits;
+    schedule.nHasIPFS = issue.nHasIPFS;
+    schedule.strIPFSHash = issue.strIPFSHash;
+    schedule.nStartHeight = nHeight;
+    schedule.nMaturedPeriods = 0;
+    schedule.nClaimedPeriods = 0;
+    schedule.nTotalMinted = 0;
+    schedule.issuanceTxid = tx.GetHash();
+    schedule.fActive = true;
+    schedule.fAllowExtension = issue.fAllowExtension;
+    schedule.nMaxTotalQty = issue.nMaxTotalQty > 0 ? issue.nMaxTotalQty : issue.nTotalQty;
+
+    if (!assetsCache)
+        return false;
+
+    CNewAsset asset(issue.strMineableAsset, 0, issue.nUnits, 0, issue.nHasIPFS, issue.strIPFSHash);
+    if (!assetsCache->CheckIfAssetExists(issue.strMineableAsset)) {
+        if (!assetsCache->AddNewAsset(asset, address, nHeight, blockHash))
+            return error("%s: failed to register mineable asset metadata", __func__);
+    }
+
+    return db.WriteSchedule(schedule);
+}
+
+bool ExtendMineableScheduleFromTx(const CTransaction& tx, int nHeight, CMineableAssetsDB& db)
+{
+    CReissueMineableSchedule reissue;
+    std::string address;
+    if (!ReissueMineableFromTransaction(tx, reissue, address))
+        return false;
+
+    CMineableSchedule schedule;
+    if (!db.ReadSchedule(reissue.strMineableAsset, schedule) || !schedule.fActive)
+        return false;
+
+    std::string strError;
+    if (!ContextualCheckReissueMineableSchedule(nullptr, db, reissue, address, strError))
+        return false;
+
+    if (!ApplyScheduleExtension(schedule, reissue.nAddQty, reissue.nNewNthBlock, strError))
+        return false;
+
+    (void)nHeight;
+    return db.WriteSchedule(schedule);
+}
+
+static bool DeserializeIssueMineableFromScript(const CScript& script, CIssueMineable& issue, std::string& address)
+{
+    int nType = 0;
+    bool fIsOwner = false;
+    int nStartingIndex = 0;
+    if (!script.IsAssetScript(nType, fIsOwner, nStartingIndex) || nType != TX_ISSUE_MINEABLE)
+        return false;
+
+    CDataStream ssAsset(SER_NETWORK, PROTOCOL_VERSION);
+    ssAsset << script;
+    ssAsset.seek(nStartingIndex);
+    try {
+        ssAsset >> issue;
+    } catch (const std::exception&) {
+        return false;
+    }
+
+    txnouttype type;
+    std::vector<CTxDestination> vDest;
+    if (!ExtractDestinations(script, type, vDest, address) || vDest.empty())
+        return false;
+    address = EncodeDestination(vDest[0]);
+    return true;
+}
+
+bool IssueMineableFromScript(const CScript& script, CIssueMineable& issue, std::string& address)
+{
+    return DeserializeIssueMineableFromScript(script, issue, address);
+}
+
+bool IssueMineableFromTransaction(const CTransaction& tx, CIssueMineable& issue, std::string& address)
+{
+    if (tx.vout.empty())
+        return false;
+    return IssueMineableFromScript(tx.vout[tx.vout.size() - 1].scriptPubKey, issue, address);
+}
+
+static bool DeserializeReissueMineableFromScript(const CScript& script, CReissueMineableSchedule& reissue, std::string& address)
+{
+    int nType = 0;
+    bool fIsOwner = false;
+    int nStartingIndex = 0;
+    if (!script.IsAssetScript(nType, fIsOwner, nStartingIndex) || nType != TX_REISSUE_MINEABLE)
+        return false;
+
+    CDataStream ssAsset(SER_NETWORK, PROTOCOL_VERSION);
+    ssAsset << script;
+    ssAsset.seek(nStartingIndex);
+    try {
+        ssAsset >> reissue;
+    } catch (const std::exception&) {
+        return false;
+    }
+
+    txnouttype type;
+    std::vector<CTxDestination> vDest;
+    if (!ExtractDestinations(script, type, vDest, address) || vDest.empty())
+        return false;
+    address = EncodeDestination(vDest[0]);
+    return true;
+}
+
+bool ReissueMineableFromScript(const CScript& script, CReissueMineableSchedule& reissue, std::string& address)
+{
+    return DeserializeReissueMineableFromScript(script, reissue, address);
+}
+
+bool ReissueMineableFromTransaction(const CTransaction& tx, CReissueMineableSchedule& reissue, std::string& address)
+{
+    if (tx.vout.empty())
+        return false;
+    return ReissueMineableFromScript(tx.vout[tx.vout.size() - 1].scriptPubKey, reissue, address);
+}
+
+bool IsMineableCoinbaseAssetOutput(const CTxOut& out, CAssetTransfer& transfer, std::string& address)
+{
+    if (!IsMineableAssetsDeployed())
+        return false;
+    if (!TransferAssetFromScript(out.scriptPubKey, transfer, address))
+        return false;
+    return IsMineableAssetName(transfer.strName);
+}
+
+bool ProcessMineableMaturityAtHeight(int nHeight, CMineableAssetsDB& db)
+{
+    if (!IsMineableAssetsDeployed())
+        return true;
+
+    std::vector<CMineableSchedule> schedules;
+    if (!db.ListSchedules(schedules))
+        return false;
+
+    for (auto& schedule : schedules) {
+        schedule.UpdateMaturity(nHeight);
+        if (!db.WriteSchedule(schedule))
+            return false;
+    }
+    return true;
+}
+
+bool GetMineableAccrualForAsset(const std::string& assetName, int nHeight,
+                                CMineableAssetsDB& db, CMineableAccrualInfo& info)
+{
+    CMineableSchedule schedule;
+    if (!db.ReadSchedule(assetName, schedule) || !schedule.fActive)
+        return false;
+
+    schedule.UpdateMaturity(nHeight);
+    info.matured_periods = schedule.nMaturedPeriods;
+    info.claimed_periods = schedule.nClaimedPeriods;
+    info.delta_periods = schedule.nMaturedPeriods - schedule.nClaimedPeriods;
+    info.accrued_amount = schedule.GetAccruedAmount();
+    info.accrued_fund = schedule.GetAccruedFundAmount();
+    info.accrued_miner = schedule.GetAccruedMinerAmount();
+    return true;
+}
+
+bool ValidateMineableCoinbaseClaims(const CTransaction& coinbase, int nHeight,
+                                    CAssetsCache* assetCache, CMineableAssetsDB& db,
+                                    CValidationState& state)
+{
+    if (!IsMineableAssetsDeployed())
+        return true;
+    if (!coinbase.IsCoinBase())
+        return state.DoS(100, false, REJECT_INVALID, "bad-mineable-not-coinbase");
+
+    std::map<std::string, CAmount> minerByAsset;
+    std::map<std::string, CAmount> fundByAsset;
+
+    for (const auto& out : coinbase.vout) {
+        CAssetTransfer transfer;
+        std::string address;
+        if (!IsMineableCoinbaseAssetOutput(out, transfer, address))
+            continue;
+
+        CMineableSchedule schedule;
+        if (!db.ReadSchedule(transfer.strName, schedule) || !schedule.fActive) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-mineable-unknown-schedule");
+        }
+
+        schedule.UpdateMaturity(nHeight);
+        const CAmount expectedFund = schedule.GetAccruedFundAmount();
+        std::string ownerAddress;
+        if (expectedFund > 0 && !GetOwnerTokenHolder(schedule.strRootAsset, ownerAddress)) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-mineable-owner-address");
+        }
+
+        if (expectedFund > 0 && address == ownerAddress) {
+            fundByAsset[transfer.strName] += transfer.nAmount;
+        } else {
+            if (minerByAsset.count(transfer.strName)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-mineable-duplicate-claim");
+            }
+            minerByAsset[transfer.strName] = transfer.nAmount;
+        }
+    }
+
+    for (const auto& entry : minerByAsset) {
+        CMineableSchedule schedule;
+        if (!db.ReadSchedule(entry.first, schedule))
+            return state.DoS(100, false, REJECT_INVALID, "bad-mineable-unknown-schedule");
+        schedule.UpdateMaturity(nHeight);
+
+        const CAmount expectedTotal = schedule.GetAccruedAmount();
+        const CAmount expectedMiner = schedule.GetAccruedMinerAmount();
+        const CAmount expectedFund = schedule.GetAccruedFundAmount();
+
+        if (expectedTotal <= 0) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-mineable-nothing-accrued");
+        }
+        if (entry.second != expectedMiner) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-mineable-claim-amount");
+        }
+        if (expectedFund > 0) {
+            if (!fundByAsset.count(entry.first) || fundByAsset.at(entry.first) != expectedFund) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-mineable-fund-amount");
+            }
+        }
+        (void)assetCache;
+    }
+
+    for (const auto& entry : fundByAsset) {
+        if (!minerByAsset.count(entry.first)) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-mineable-fund-without-miner");
+        }
+    }
+
+    return true;
+}
+
+bool ApplyMineableCoinbaseClaims(const CTransaction& coinbase, int nHeight,
+                                 CAssetsCache* assetCache, CMineableAssetsDB& db)
+{
+    if (!IsMineableAssetsDeployed())
+        return true;
+
+    std::set<std::string> claimed;
+
+    for (const auto& out : coinbase.vout) {
+        CAssetTransfer transfer;
+        std::string address;
+        if (!IsMineableCoinbaseAssetOutput(out, transfer, address))
+            continue;
+        if (claimed.count(transfer.strName))
+            continue;
+
+        CMineableSchedule schedule;
+        if (!db.ReadSchedule(transfer.strName, schedule))
+            return false;
+
+        schedule.UpdateMaturity(nHeight);
+        const CAmount accrued = schedule.GetAccruedAmount();
+        const CAmount expectedMiner = schedule.GetAccruedMinerAmount();
+        if (accrued <= 0)
+            continue;
+
+        CAmount claimedMiner = 0;
+        for (const auto& claimOut : coinbase.vout) {
+            CAssetTransfer t;
+            std::string addr;
+            if (!IsMineableCoinbaseAssetOutput(claimOut, t, addr))
+                continue;
+            if (t.strName != transfer.strName)
+                continue;
+            std::string ownerAddress;
+            if (schedule.GetAccruedFundAmount() > 0 && GetOwnerTokenHolder(schedule.strRootAsset, ownerAddress) && addr == ownerAddress)
+                continue;
+            claimedMiner = t.nAmount;
+            break;
+        }
+        if (claimedMiner != expectedMiner)
+            continue;
+
+        schedule.nClaimedPeriods = schedule.nMaturedPeriods;
+        schedule.nTotalMinted += accrued;
+        if (schedule.IsComplete())
+            schedule.fActive = false;
+
+        if (!db.WriteSchedule(schedule))
+            return false;
+
+        claimed.insert(transfer.strName);
+        (void)assetCache;
+    }
+
+    return true;
+}

--- a/src/assets/mineable.cpp
+++ b/src/assets/mineable.cpp
@@ -253,7 +253,7 @@ CAmount CalculateMineableExtensionCost(const CMineableSchedule& schedule, CAmoun
 
     const int effectiveNewNth = nNewNthBlock > 0 ? nNewNthBlock : schedule.nNthBlock;
     if (effectiveNewNth != schedule.nNthBlock) {
-        if (effectiveNewNth == 1 && schedule.nNthBlock % effectiveNewNth != 0) {
+        if (effectiveNewNth == 1 && schedule.nNthBlock > 1) {
             const int remaining = schedule.GetTotalPeriods() - schedule.nClaimedPeriods;
             if (remaining > 0)
                 cost += static_cast<CAmount>(remaining) * (schedule.nNthBlock - 1) * MINEABLE_COST_PER_PERIOD;
@@ -473,9 +473,9 @@ static bool DeserializeIssueMineableFromScript(const CScript& script, CIssueMine
     if (!script.IsAssetScript(nType, fIsOwner, nStartingIndex) || nType != TX_ISSUE_MINEABLE)
         return false;
 
-    CDataStream ssAsset(SER_NETWORK, PROTOCOL_VERSION);
-    ssAsset << script;
-    ssAsset.seek(nStartingIndex);
+    std::vector<unsigned char> vchAsset;
+    vchAsset.insert(vchAsset.end(), script.begin() + nStartingIndex, script.end());
+    CDataStream ssAsset(vchAsset, SER_NETWORK, PROTOCOL_VERSION);
     try {
         ssAsset >> issue;
     } catch (const std::exception&) {
@@ -484,7 +484,8 @@ static bool DeserializeIssueMineableFromScript(const CScript& script, CIssueMine
 
     txnouttype type;
     std::vector<CTxDestination> vDest;
-    if (!ExtractDestinations(script, type, vDest, address) || vDest.empty())
+    int nRequired = 0;
+    if (!ExtractDestinations(script, type, vDest, nRequired) || vDest.empty())
         return false;
     address = EncodeDestination(vDest[0]);
     return true;
@@ -497,9 +498,11 @@ bool IssueMineableFromScript(const CScript& script, CIssueMineable& issue, std::
 
 bool IssueMineableFromTransaction(const CTransaction& tx, CIssueMineable& issue, std::string& address)
 {
-    if (tx.vout.empty())
-        return false;
-    return IssueMineableFromScript(tx.vout[tx.vout.size() - 1].scriptPubKey, issue, address);
+    for (const auto& out : tx.vout) {
+        if (IsScriptIssueMineableAsset(out.scriptPubKey))
+            return IssueMineableFromScript(out.scriptPubKey, issue, address);
+    }
+    return false;
 }
 
 static bool DeserializeReissueMineableFromScript(const CScript& script, CReissueMineableSchedule& reissue, std::string& address)
@@ -510,9 +513,9 @@ static bool DeserializeReissueMineableFromScript(const CScript& script, CReissue
     if (!script.IsAssetScript(nType, fIsOwner, nStartingIndex) || nType != TX_REISSUE_MINEABLE)
         return false;
 
-    CDataStream ssAsset(SER_NETWORK, PROTOCOL_VERSION);
-    ssAsset << script;
-    ssAsset.seek(nStartingIndex);
+    std::vector<unsigned char> vchAsset;
+    vchAsset.insert(vchAsset.end(), script.begin() + nStartingIndex, script.end());
+    CDataStream ssAsset(vchAsset, SER_NETWORK, PROTOCOL_VERSION);
     try {
         ssAsset >> reissue;
     } catch (const std::exception&) {
@@ -521,7 +524,8 @@ static bool DeserializeReissueMineableFromScript(const CScript& script, CReissue
 
     txnouttype type;
     std::vector<CTxDestination> vDest;
-    if (!ExtractDestinations(script, type, vDest, address) || vDest.empty())
+    int nRequired = 0;
+    if (!ExtractDestinations(script, type, vDest, nRequired) || vDest.empty())
         return false;
     address = EncodeDestination(vDest[0]);
     return true;
@@ -534,9 +538,11 @@ bool ReissueMineableFromScript(const CScript& script, CReissueMineableSchedule& 
 
 bool ReissueMineableFromTransaction(const CTransaction& tx, CReissueMineableSchedule& reissue, std::string& address)
 {
-    if (tx.vout.empty())
-        return false;
-    return ReissueMineableFromScript(tx.vout[tx.vout.size() - 1].scriptPubKey, reissue, address);
+    for (const auto& out : tx.vout) {
+        if (IsScriptReissueMineableAsset(out.scriptPubKey))
+            return ReissueMineableFromScript(out.scriptPubKey, reissue, address);
+    }
+    return false;
 }
 
 bool IsMineableCoinbaseAssetOutput(const CTxOut& out, CAssetTransfer& transfer, std::string& address)

--- a/src/assets/mineable.h
+++ b/src/assets/mineable.h
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 The Ravencoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef RAVENCOIN_MINEABLE_H
+#define RAVENCOIN_MINEABLE_H
+
+#include "amount.h"
+#include "assets/assettypes.h"
+#include "primitives/transaction.h"
+#include "script/standard.h"
+#include "uint256.h"
+
+#include <string>
+
+class CMineableAssetsDB;
+
+#define MINEABLE_CHAR '&'
+#define MIN_MINEABLE_ISSUANCE_COST (500 * COIN)
+#define MINEABLE_COST_PER_PERIOD (1 * COIN)
+
+class CAssetsCache;
+class CValidationState;
+
+/** Schedule registered by issuemineable. */
+class CMineableSchedule
+{
+public:
+    std::string strRootAsset;
+    std::string strMineableAsset;
+    CAmount nTotalQty;
+    CAmount nPerBlock;
+    int nNthBlock;
+    CAmount nFundAmt;
+    int8_t nUnits;
+    int8_t nHasIPFS;
+    std::string strIPFSHash;
+    int nStartHeight;
+    int nMaturedPeriods;
+    int nClaimedPeriods;
+    CAmount nTotalMinted;
+    uint256 issuanceTxid;
+    bool fActive;
+    /** When false, schedule qty and nth_block are fixed after issuance. */
+    bool fAllowExtension;
+    /** Hard cap on total mineable qty (>= nTotalQty). No mint beyond this. */
+    CAmount nMaxTotalQty;
+
+    CMineableSchedule();
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(strRootAsset);
+        READWRITE(strMineableAsset);
+        READWRITE(nTotalQty);
+        READWRITE(nPerBlock);
+        READWRITE(nNthBlock);
+        READWRITE(nFundAmt);
+        READWRITE(nUnits);
+        READWRITE(nHasIPFS);
+        if (nHasIPFS == 1) {
+            ReadWriteAssetHash(s, ser_action, strIPFSHash);
+        } else if (ser_action.ForRead()) {
+            strIPFSHash.clear();
+        }
+        READWRITE(nStartHeight);
+        READWRITE(nMaturedPeriods);
+        READWRITE(nClaimedPeriods);
+        READWRITE(nTotalMinted);
+        READWRITE(issuanceTxid);
+        READWRITE(fActive);
+        READWRITE(fAllowExtension);
+        READWRITE(nMaxTotalQty);
+    }
+
+    int GetTotalPeriods() const;
+    void UpdateMaturity(int nHeight);
+    CAmount GetAccruedAmount() const;
+    CAmount GetAccruedFundAmount() const;
+    CAmount GetAccruedMinerAmount() const;
+    bool IsComplete() const;
+};
+
+/** Payload in issuemineable transactions (rvnm script). */
+class CIssueMineable
+{
+public:
+    std::string strRootAsset;
+    std::string strMineableAsset;
+    CAmount nTotalQty;
+    CAmount nPerBlock;
+    int nNthBlock;
+    CAmount nFundAmt;
+    int8_t nUnits;
+    int8_t nHasIPFS;
+    std::string strIPFSHash;
+    /** When true, root owner may extend schedule up to nMaxTotalQty. */
+    bool fAllowExtension;
+    /** Maximum total qty (0 = fixed at nTotalQty). */
+    CAmount nMaxTotalQty;
+
+    CIssueMineable();
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(strRootAsset);
+        READWRITE(strMineableAsset);
+        READWRITE(nTotalQty);
+        READWRITE(nPerBlock);
+        READWRITE(nNthBlock);
+        READWRITE(nFundAmt);
+        READWRITE(nUnits);
+        READWRITE(nHasIPFS);
+        if (nHasIPFS == 1) {
+            ReadWriteAssetHash(s, ser_action, strIPFSHash);
+        } else if (ser_action.ForRead()) {
+            strIPFSHash.clear();
+        }
+        READWRITE(fAllowExtension);
+        READWRITE(nMaxTotalQty);
+    }
+
+    void ConstructTransaction(CScript& script) const;
+    bool IsNull() const;
+};
+
+/** Additive schedule extension (reissuemineable). Only increases qty and/or nth frequency. */
+class CReissueMineableSchedule
+{
+public:
+    std::string strMineableAsset;
+    CAmount nAddQty;
+    /** 0 = keep current nth_block. Must divide current nth or be 1 with recost. */
+    int nNewNthBlock;
+
+    CReissueMineableSchedule();
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(strMineableAsset);
+        READWRITE(nAddQty);
+        READWRITE(nNewNthBlock);
+    }
+
+    void ConstructTransaction(CScript& script) const;
+    bool IsNull() const;
+};
+
+bool IsMineableAssetName(const std::string& name);
+std::string MineableAssetNameFromRoot(const std::string& rootAsset);
+
+CAmount CalculateMineableIssuanceCost(const CIssueMineable& issue);
+void GetMineableIssuanceEstimate(const CIssueMineable& issue, CAmount& cost, int& days, int& months);
+
+/** True when new_nth divides old_nth (faster issuance) or new_nth is 0 (unchanged). */
+bool IsNthBlockExtensionCompatible(int oldNth, int newNth);
+CAmount CalculateMineableExtensionCost(const CMineableSchedule& schedule, CAmount nAddQty, int nNewNthBlock);
+
+bool CheckIssueMineable(const CIssueMineable& issue, std::string& strError);
+bool ContextualCheckIssueMineable(CAssetsCache* assetCache, const CIssueMineable& issue,
+                                  const std::string& address, int nHeight, std::string& strError);
+
+bool IssueMineableFromScript(const CScript& script, CIssueMineable& issue, std::string& address);
+bool IssueMineableFromTransaction(const CTransaction& tx, CIssueMineable& issue, std::string& address);
+
+bool CheckReissueMineableSchedule(const CReissueMineableSchedule& reissue, std::string& strError);
+bool ContextualCheckReissueMineableSchedule(CAssetsCache* assetCache, CMineableAssetsDB& db,
+                                            const CReissueMineableSchedule& reissue,
+                                            const std::string& address, std::string& strError);
+bool ReissueMineableFromScript(const CScript& script, CReissueMineableSchedule& reissue, std::string& address);
+bool ReissueMineableFromTransaction(const CTransaction& tx, CReissueMineableSchedule& reissue, std::string& address);
+bool ApplyScheduleExtension(CMineableSchedule& schedule, CAmount nAddQty, int nNewNthBlock, std::string& strError);
+bool ExtendMineableScheduleFromTx(const CTransaction& tx, int nHeight, CMineableAssetsDB& db);
+
+bool IsMineableCoinbaseAssetOutput(const CTxOut& out, CAssetTransfer& transfer, std::string& address);
+
+bool ProcessMineableMaturityAtHeight(int nHeight, CMineableAssetsDB& db);
+bool ValidateMineableCoinbaseClaims(const CTransaction& coinbase, int nHeight,
+                                    CAssetsCache* assetCache, CMineableAssetsDB& db,
+                                    CValidationState& state);
+bool ApplyMineableCoinbaseClaims(const CTransaction& coinbase, int nHeight,
+                                 CAssetsCache* assetCache, CMineableAssetsDB& db);
+bool RegisterMineableScheduleFromTx(const CTransaction& tx, int nHeight, const uint256& blockHash,
+                                    CMineableAssetsDB& db, CAssetsCache* assetsCache);
+
+struct CMineableAccrualInfo
+{
+    int matured_periods;
+    int claimed_periods;
+    int delta_periods;
+    CAmount accrued_amount;
+    CAmount accrued_miner;
+    CAmount accrued_fund;
+};
+
+bool GetMineableAccrualForAsset(const std::string& assetName, int nHeight,
+                                CMineableAssetsDB& db, CMineableAccrualInfo& info);
+
+#endif // RAVENCOIN_MINEABLE_H

--- a/src/assets/mineabledb.cpp
+++ b/src/assets/mineabledb.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 The Ravencoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "assets/mineabledb.h"
+#include "validation.h"
+
+static const char SCHEDULE_FLAG = 'M';
+
+CMineableAssetsDB::CMineableAssetsDB(size_t nCacheSize, bool fMemory, bool fWipe)
+    : CDBWrapper(GetDataDir() / "assets" / "mineable", nCacheSize, fMemory, fWipe)
+{
+}
+
+bool CMineableAssetsDB::WriteSchedule(const CMineableSchedule& schedule)
+{
+    return Write(std::make_pair(SCHEDULE_FLAG, schedule.strMineableAsset), schedule);
+}
+
+bool CMineableAssetsDB::ReadSchedule(const std::string& assetName, CMineableSchedule& schedule)
+{
+    return Read(std::make_pair(SCHEDULE_FLAG, assetName), schedule);
+}
+
+bool CMineableAssetsDB::EraseSchedule(const std::string& assetName)
+{
+    return Erase(std::make_pair(SCHEDULE_FLAG, assetName));
+}
+
+bool CMineableAssetsDB::ListSchedules(std::vector<CMineableSchedule>& schedules)
+{
+    schedules.clear();
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
+    pcursor->Seek(std::make_pair(SCHEDULE_FLAG, std::string()));
+
+    while (pcursor->Valid()) {
+        std::pair<char, std::string> key;
+        if (!pcursor->GetKey(key) || key.first != SCHEDULE_FLAG)
+            break;
+        CMineableSchedule schedule;
+        if (!pcursor->GetValue(schedule))
+            return false;
+        if (schedule.fActive)
+            schedules.push_back(schedule);
+        pcursor->Next();
+    }
+    return true;
+}
+
+bool CMineableAssetsDB::Flush()
+{
+    return CDBWrapper::Flush();
+}

--- a/src/assets/mineabledb.h
+++ b/src/assets/mineabledb.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 The Ravencoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef RAVENCOIN_MINEABLEDB_H
+#define RAVENCOIN_MINEABLEDB_H
+
+#include "assets/mineable.h"
+#include <dbwrapper.h>
+#include <string>
+#include <vector>
+
+class CMineableAssetsDB : public CDBWrapper
+{
+public:
+    explicit CMineableAssetsDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+
+    CMineableAssetsDB(const CMineableAssetsDB&) = delete;
+    CMineableAssetsDB& operator=(const CMineableAssetsDB&) = delete;
+
+    bool WriteSchedule(const CMineableSchedule& schedule);
+    bool ReadSchedule(const std::string& assetName, CMineableSchedule& schedule);
+    bool EraseSchedule(const std::string& assetName);
+    bool ListSchedules(std::vector<CMineableSchedule>& schedules);
+
+    bool Flush();
+};
+
+#endif // RAVENCOIN_MINEABLEDB_H

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -167,6 +167,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_OVERFLOW].nTimeout = 1812844799; // UTC: Sat June 12 2027 23:59:59
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_OVERFLOW].nOverrideRuleChangeActivationThreshold = 1411; // Approx 70% of 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_OVERFLOW].nOverrideMinerConfirmationWindow = 2016;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].bit = 12;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nStartTime = 1830316801; // UTC: Sat Jan 1 2028 00:00:01
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nTimeout = 1861852799; // UTC: Sun Jan 1 2029 23:59:59
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nOverrideRuleChangeActivationThreshold = 1411;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nOverrideMinerConfirmationWindow = 2016;
 
 
         // The best chain should have at least this much work
@@ -339,6 +344,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_OVERFLOW].nTimeout = 1812844799; // UTC: Sat June 12 2027 23:59:59
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_OVERFLOW].nOverrideRuleChangeActivationThreshold = 1411; // Approx 70% of 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_OVERFLOW].nOverrideMinerConfirmationWindow = 2016;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].bit = 12;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nStartTime = 1830316801;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nTimeout = 1861852799;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nOverrideRuleChangeActivationThreshold = 1411;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nOverrideMinerConfirmationWindow = 2016;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000000000168050db560b4");
@@ -565,6 +575,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_OVERFLOW].nTimeout = 999999999999ULL;
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_OVERFLOW].nOverrideRuleChangeActivationThreshold = 400;
         consensus.vDeployments[Consensus::DEPLOYMENT_TRANSFER_OVERFLOW].nOverrideMinerConfirmationWindow = 500;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].bit = 12;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nStartTime = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nTimeout = 999999999999ULL;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nOverrideRuleChangeActivationThreshold = 400;
+        consensus.vDeployments[Consensus::DEPLOYMENT_MINEABLE_ASSETS].nOverrideMinerConfirmationWindow = 500;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -15,6 +15,7 @@
 
 #include <assert.h>
 #include <assets/assets.h>
+#include <assets/mineable.h>
 #include <wallet/wallet.h>
 
 bool CCoinsView::GetCoin(const COutPoint &outpoint, Coin &coin) const { return false; }
@@ -247,6 +248,16 @@ void AddCoins(CCoinsViewCache& cache, const CTransaction &tx, int nHeight, uint2
 
                         break;
                     }
+                }
+            } else if (tx.IsIssueMineableAsset()) {
+                if (IsMineableAssetsDeployed() && pmineabledb && assetsCache) {
+                    if (!RegisterMineableScheduleFromTx(tx, nHeight, blockHash, *pmineabledb, assetsCache))
+                        error("%s: Failed to register mineable schedule", __func__);
+                }
+            } else if (tx.IsReissueMineableAsset()) {
+                if (IsMineableAssetsDeployed() && pmineabledb) {
+                    if (!ExtendMineableScheduleFromTx(tx, nHeight, *pmineabledb))
+                        error("%s: Failed to extend mineable schedule", __func__);
                 }
             }
         }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -21,7 +21,8 @@ enum DeploymentPos
     DEPLOYMENT_TRANSFER_SCRIPT_SIZE,
     DEPLOYMENT_ENFORCE_VALUE,
     DEPLOYMENT_COINBASE_ASSETS,
-    DEPLOYMENT_TRANSFER_OVERFLOW,   // Deployment of asset transfer qty overflow check   
+    DEPLOYMENT_TRANSFER_OVERFLOW,   // Deployment of asset transfer qty overflow check
+    DEPLOYMENT_MINEABLE_ASSETS,     // G-PoW mineable asset accrual and coinbase claims
     // DEPLOYMENT_CSV, // Deployment of BIP68, BIP112, and BIP113.
 //    DEPLOYMENT_SEGWIT, // Deployment of BIP141, BIP143, and BIP147.
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <assets/assets.h>
+#include <assets/mineable.h>
 #include <script/standard.h>
 #include <util.h>
 #include <validation.h>
@@ -382,6 +383,12 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
         if (AreCoinbaseCheckAssetsDeployed()) {
             for (auto vout : tx.vout) {
                 if (vout.scriptPubKey.IsAssetScript() || vout.scriptPubKey.IsNullAsset()) {
+                    if (IsMineableAssetsDeployed()) {
+                        CAssetTransfer transfer;
+                        std::string address;
+                        if (IsMineableCoinbaseAssetOutput(vout, transfer, address))
+                            continue;
+                    }
                     return state.DoS(0, error("%s: coinbase contains asset transaction", __func__),
                                      REJECT_INVALID, "bad-txns-coinbase-contains-asset-txes");
                 }
@@ -449,6 +456,38 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
 
             fContainsRestrictedAssetReissue = true;
         }
+
+    } else if (tx.IsIssueMineableAsset()) {
+        if (!IsMineableAssetsDeployed())
+            return state.DoS(100, false, REJECT_INVALID, "bad-txns-mineable-not-active");
+
+        std::string strError;
+        if (!tx.VerifyIssueMineable(strError))
+            return state.DoS(100, false, REJECT_INVALID, strError);
+
+        CIssueMineable issue;
+        std::string strAddress;
+        if (!IssueMineableFromTransaction(tx, issue, strAddress))
+            return state.DoS(100, false, REJECT_INVALID, "bad-txns-mineable-from-transaction");
+
+        if (!CheckIssueMineable(issue, strError))
+            return state.DoS(100, false, REJECT_INVALID, strError);
+
+    } else if (tx.IsReissueMineableAsset()) {
+        if (!IsMineableAssetsDeployed())
+            return state.DoS(100, false, REJECT_INVALID, "bad-txns-mineable-not-active");
+
+        std::string strError;
+        if (!tx.VerifyReissueMineable(strError))
+            return state.DoS(100, false, REJECT_INVALID, strError);
+
+        CReissueMineableSchedule reissue;
+        std::string strAddress;
+        if (!ReissueMineableFromTransaction(tx, reissue, strAddress))
+            return state.DoS(100, false, REJECT_INVALID, "bad-txns-mineable-reissue-from-transaction");
+
+        if (!CheckReissueMineableSchedule(reissue, strError))
+            return state.DoS(100, false, REJECT_INVALID, strError);
 
     } else if (tx.IsNewUniqueAsset()) {
 
@@ -816,6 +855,28 @@ bool Consensus::CheckTxAssets(const CTransaction& tx, CValidationState& state, c
             }
             if (!ContextualCheckReissueAsset(assetCache, reissue_asset, strError, tx))
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-reissue-contextual-" + strError, false, "", tx.GetHash());
+        } else if (tx.IsIssueMineableAsset()) {
+            if (!IsMineableAssetsDeployed())
+                return state.DoS(100, false, REJECT_INVALID, "bad-txns-mineable-not-active", false, "", tx.GetHash());
+
+            CIssueMineable issue;
+            std::string address;
+            if (!IssueMineableFromTransaction(tx, issue, address)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-txns-mineable-serialization-failed", false, "", tx.GetHash());
+            }
+            if (!ContextualCheckIssueMineable(assetCache, issue, address, 0, strError))
+                return state.DoS(100, false, REJECT_INVALID, strError, false, "", tx.GetHash());
+        } else if (tx.IsReissueMineableAsset()) {
+            if (!IsMineableAssetsDeployed())
+                return state.DoS(100, false, REJECT_INVALID, "bad-txns-mineable-not-active", false, "", tx.GetHash());
+
+            CReissueMineableSchedule reissue;
+            std::string address;
+            if (!ReissueMineableFromTransaction(tx, reissue, address)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-txns-mineable-reissue-serialization-failed", false, "", tx.GetHash());
+            }
+            if (!pmineabledb || !ContextualCheckReissueMineableSchedule(assetCache, *pmineabledb, reissue, address, strError))
+                return state.DoS(100, false, REJECT_INVALID, strError, false, "", tx.GetHash());
         } else if (tx.IsNewUniqueAsset()) {
             if (!ContextualCheckUniqueAssetTx(assetCache, strError, tx))
                 return state.DoS(100, false, REJECT_INVALID, "bad-txns-issue-unique-contextual-" + strError, false, "", tx.GetHash());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -22,6 +22,7 @@
 #include "httprpc.h"
 #include "key.h"
 #include "validation.h"
+#include "assets/mineabledb.h"
 #include "miner.h"
 #include "netbase.h"
 #include "net.h"
@@ -305,6 +306,9 @@ void PrepareShutdown()
 
         delete prestricteddb;
         prestricteddb = nullptr;
+
+        delete pmineabledb;
+        pmineabledb = nullptr;
 
         delete pmessagechanneldb;
         pmessagechanneldb = nullptr;
@@ -1566,6 +1570,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     delete passetsQualifierCache;
                     delete passetsRestrictionCache;
                     delete passetsGlobalRestrictionCache;
+                    delete pmineabledb;
 
                     //  Rewards
                     delete pSnapshotRequestDb;
@@ -1589,6 +1594,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
                     // Restricted assets
                     prestricteddb = new CRestrictedDB(nBlockTreeDBCache, false, fReset || fReindexChainState);
+                    pmineabledb = new CMineableAssetsDB(nBlockTreeDBCache, false, fReset || fReindexChainState);
                     passetsVerifierCache = new CLRUCache<std::string, CNullAssetTxVerifierString>(
                             MAX_CACHE_ASSETS_SIZE);
                     passetsQualifierCache = new CLRUCache<std::string, int8_t>(MAX_CACHE_ASSETS_SIZE);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -335,6 +335,10 @@ public:
     bool IsNewUniqueAsset() const;
     bool VerifyNewUniqueAsset(std::string& strError) const;
     bool IsReissueAsset() const;
+    bool IsIssueMineableAsset() const;
+    bool IsReissueMineableAsset() const;
+    bool VerifyIssueMineable(std::string& strError) const;
+    bool VerifyReissueMineable(std::string& strError) const;
     bool VerifyReissueAsset(std::string& strError) const;
     bool IsNewMsgChannelAsset() const;
     bool VerifyNewMsgChannelAsset(std::string& strError) const;

--- a/src/rpc/assets.cpp
+++ b/src/rpc/assets.cpp
@@ -5,6 +5,8 @@
 //#include <amount.h>
 //#include <base58.h>
 #include "assets/assets.h"
+#include "assets/mineable.h"
+#include "assets/mineabledb.h"
 #include "assets/assetdb.h"
 #include <map>
 #include "tinyformat.h"
@@ -3032,6 +3034,73 @@ UniValue purgesnapshot(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+UniValue getmineableaccrual(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 1)
+        throw std::runtime_error(
+            "getmineableaccrual \"asset_name\"\n"
+            "\nReturns mineable accrual state for a & asset.\n");
+
+    if (!IsMineableAssetsDeployed())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "mineable_assets soft fork is not active");
+
+    std::string asset_name = request.params[0].get_str();
+    if (!IsMineableAssetName(asset_name))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "asset must use & prefix");
+
+    if (!pmineabledb)
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "mineable database unavailable");
+
+    LOCK(cs_main);
+    const int height = chainActive.Height();
+
+    CMineableAccrualInfo info;
+    if (!GetMineableAccrualForAsset(asset_name, height, *pmineabledb, info))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "no active mineable schedule for asset");
+
+    UniValue ret(UniValue::VOBJ);
+    ret.push_back(Pair("matured_periods", info.matured_periods));
+    ret.push_back(Pair("claimed_periods", info.claimed_periods));
+    ret.push_back(Pair("delta_periods", info.delta_periods));
+    ret.push_back(Pair("accrued_amount", ValueFromAmount(info.accrued_amount)));
+    ret.push_back(Pair("accrued_miner", ValueFromAmount(info.accrued_miner)));
+    ret.push_back(Pair("accrued_fund", ValueFromAmount(info.accrued_fund)));
+    return ret;
+}
+
+UniValue issuemineabletestrun(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() < 3 || request.params.size() > 6)
+        throw std::runtime_error(
+            "issuemineabletestrun \"root_asset\" qty per_block ( nth_block fund_amt units )\n"
+            "\nEstimate mineable issuance cost and duration.\n");
+
+    CIssueMineable issue;
+    issue.strRootAsset = request.params[0].get_str();
+    issue.strMineableAsset = MineableAssetNameFromRoot(issue.strRootAsset);
+    issue.nTotalQty = AmountFromValue(request.params[1]);
+    issue.nPerBlock = AmountFromValue(request.params[2]);
+    issue.nNthBlock = request.params.size() > 3 ? request.params[3].get_int() : 10;
+    issue.nFundAmt = request.params.size() > 4 ? AmountFromValue(request.params[4]) : 0;
+    issue.nUnits = request.params.size() > 5 ? request.params[5].get_int() : 0;
+
+    std::string strError;
+    if (!CheckIssueMineable(issue, strError))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strError);
+
+    CAmount cost = 0;
+    int days = 0;
+    int months = 0;
+    GetMineableIssuanceEstimate(issue, cost, days, months);
+
+    UniValue ret(UniValue::VOBJ);
+    ret.push_back(Pair("cost", ValueFromAmount(cost)));
+    ret.push_back(Pair("days", days));
+    ret.push_back(Pair("months", months));
+    ret.push_back(Pair("mineable_asset", issue.strMineableAsset));
+    return ret;
+}
+
 static const CRPCCommand commands[] =
 { //  category    name                          actor (function)             argNames
   //  ----------- ------------------------      -----------------------      ----------
@@ -3076,6 +3145,8 @@ static const CRPCCommand commands[] =
 
     { "assets",   "getsnapshot",                &getsnapshot,                {"asset_name", "block_height"}},
     { "assets",   "purgesnapshot",              &purgesnapshot,              {"asset_name", "block_height"}},
+    { "assets",   "getmineableaccrual",         &getmineableaccrual,         {"asset_name"}},
+    { "assets",   "issuemineabletestrun",       &issuemineabletestrun,       {"root_asset", "qty", "per_block", "nth_block", "fund_amt", "units"}},
 };
 
 void RegisterAssetRPCCommands(CRPCTable &t)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1505,6 +1505,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BIP9SoftForkDescPushBack(bip9_softforks, "enforce", consensusParams, Consensus::DEPLOYMENT_ENFORCE_VALUE);
     BIP9SoftForkDescPushBack(bip9_softforks, "coinbase", consensusParams, Consensus::DEPLOYMENT_COINBASE_ASSETS);
     BIP9SoftForkDescPushBack(bip9_softforks, "transfer_overflow", consensusParams, Consensus::DEPLOYMENT_TRANSFER_OVERFLOW);
+    BIP9SoftForkDescPushBack(bip9_softforks, "mineable_assets", consensusParams, Consensus::DEPLOYMENT_MINEABLE_ASSETS);
     obj.push_back(Pair("softforks",             softforks));
     obj.push_back(Pair("bip9_softforks", bip9_softforks));
 

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -274,6 +274,12 @@ bool CScript::IsAssetScript(int& nType, bool& fIsOwner, int& nStartingIndex) con
                 } else if ((*this)[index] == RVN_R) {
                     nType = TX_REISSUE_ASSET;
                     return true;
+                } else if ((*this)[index] == RVN_M) {
+                    nType = TX_ISSUE_MINEABLE;
+                    return true;
+                } else if ((*this)[index] == RVN_E) {
+                    nType = TX_REISSUE_MINEABLE;
+                    return true;
                 }
             }
         }
@@ -309,6 +315,26 @@ bool CScript::IsReissueAsset() const
     bool fIsOwner = false;
     if (IsAssetScript(nType, fIsOwner))
         return nType == TX_REISSUE_ASSET;
+
+    return false;
+}
+
+bool CScript::IsIssueMineableAsset() const
+{
+    int nType = 0;
+    bool fIsOwner = false;
+    if (IsAssetScript(nType, fIsOwner))
+        return nType == TX_ISSUE_MINEABLE;
+
+    return false;
+}
+
+bool CScript::IsReissueMineableAsset() const
+{
+    int nType = 0;
+    bool fIsOwner = false;
+    if (IsAssetScript(nType, fIsOwner))
+        return nType == TX_REISSUE_MINEABLE;
 
     return false;
 }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -670,6 +670,8 @@ public:
     bool IsNewAsset() const;
     bool IsOwnerAsset() const;
     bool IsReissueAsset() const;
+    bool IsIssueMineableAsset() const;
+    bool IsReissueMineableAsset() const;
     bool IsTransferAsset() const;
     bool IsAsset() const;
     bool IsNullAsset() const; // Checks all three of the NULL Asset Tx types

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -39,6 +39,8 @@ const char* GetTxnOutputType(txnouttype t)
     case TX_NEW_ASSET: return ASSET_NEW_STRING;
     case TX_TRANSFER_ASSET: return ASSET_TRANSFER_STRING;
     case TX_REISSUE_ASSET: return ASSET_REISSUE_STRING;
+    case TX_ISSUE_MINEABLE: return "issuemineable";
+    case TX_REISSUE_MINEABLE: return "reissuemineable";
     /** RVN END */
     }
     return nullptr;
@@ -234,7 +236,8 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
         addressRet = CScriptID(uint160(vSolutions[0]));
         return true;
     /** RVN START */
-    } else if (whichType == TX_NEW_ASSET || whichType == TX_REISSUE_ASSET || whichType == TX_TRANSFER_ASSET) {
+    } else if (whichType == TX_NEW_ASSET || whichType == TX_REISSUE_ASSET || whichType == TX_TRANSFER_ASSET
+               || whichType == TX_ISSUE_MINEABLE || whichType == TX_REISSUE_MINEABLE) {
         addressRet = CKeyID(uint160(vSolutions[0]));
         return true;
     } else if (whichType == TX_RESTRICTED_ASSET_DATA) {

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -70,6 +70,8 @@ enum txnouttype
     TX_REISSUE_ASSET = 9,
     TX_TRANSFER_ASSET = 10,
     TX_RESTRICTED_ASSET_DATA = 11, //!< unspendable OP_RAVEN_ASSET script that carries data
+    TX_ISSUE_MINEABLE = 12,
+    TX_REISSUE_MINEABLE = 13,
     /** RVN END */
 };
 

--- a/src/test/assets/asset_regression_stress_tests.cpp
+++ b/src/test/assets/asset_regression_stress_tests.cpp
@@ -16,7 +16,11 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <base58.h>
+#include <chainparams.h>
 #include <consensus/tx_verify.h>
+#include <consensus/validation.h>
+#include <script/standard.h>
 #include <validation.h>
 
 namespace {
@@ -212,7 +216,8 @@ BOOST_AUTO_TEST_CASE(verify_transfer_and_null_data_scripts)
     BOOST_CHECK(AssetNullDataFromScript(tagScript, parsed, addr));
     BOOST_CHECK(AssetNullDataFromScript(freezeScript, parsed, addr));
     BOOST_CHECK(GlobalAssetNullDataFromScript(globalScript, parsed));
-    BOOST_CHECK(CheckVerifierAssetTxOut(CTxOut(0, verifierScript)));
+    std::string verifyErr;
+    BOOST_CHECK(CheckVerifierAssetTxOut(CTxOut(0, verifierScript), verifyErr));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/assets/asset_regression_stress_tests.cpp
+++ b/src/test/assets/asset_regression_stress_tests.cpp
@@ -1,0 +1,620 @@
+// Copyright (c) 2026 The Ravencoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/**
+ * Full asset regression and stress tests.
+ * Covers every major asset transaction type and restricted operations.
+ */
+
+#include <assets/assets.h>
+#include <assets/mineable.h>
+#include <assets/mineabledb.h>
+
+#include <test/assets/asset_test_helpers.h>
+#include <test/test_raven.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <consensus/tx_verify.h>
+#include <validation.h>
+
+namespace {
+
+CScript IssueMineableBurnScript()
+{
+    return GetScriptForDestination(DecodeDestination(GetParams().IssueAssetBurnAddress()));
+}
+
+CMutableTransaction MakeValidIssueRootTx(const CScript& dest)
+{
+    CMutableTransaction tx;
+    CNewAsset asset("REGROOT", COIN, 0, 1, 0, "");
+    tx.vout.emplace_back(GetBurnAmount(AssetType::ROOT), AssetBurnScript(AssetType::ROOT));
+    CScript ownerScript = dest;
+    asset.ConstructOwnerTransaction(ownerScript);
+    tx.vout.emplace_back(0, ownerScript);
+    CScript assetScript = dest;
+    asset.ConstructTransaction(assetScript);
+    tx.vout.emplace_back(0, assetScript);
+    return tx;
+}
+
+CMutableTransaction MakeValidReissueTx(const std::string& root, const CScript& dest)
+{
+    CMutableTransaction tx;
+    tx.vout.emplace_back(GetReissueAssetBurnAmount(), GetScriptForDestination(
+        DecodeDestination(GetParams().ReissueAssetBurnAddress())));
+    CReissueAsset reissue(root, COIN, 0, 0, "");
+    CScript reissueScript = dest;
+    reissue.ConstructTransaction(reissueScript);
+    tx.vout.emplace_back(0, reissueScript);
+    CAssetTransfer ownerReturn(root + OWNER_TAG, OWNER_ASSET_AMOUNT);
+    CScript ownerScript = dest;
+    ownerReturn.ConstructTransaction(ownerScript);
+    tx.vout.emplace_back(0, ownerScript);
+    return tx;
+}
+
+CMutableTransaction MakeValidRestrictedIssueTx(const std::string& root, const CScript& dest)
+{
+    CMutableTransaction tx;
+    tx.vout.emplace_back(GetBurnAmount(AssetType::RESTRICTED), AssetBurnScript(AssetType::RESTRICTED));
+    CAssetTransfer rootOwner(root + OWNER_TAG, OWNER_ASSET_AMOUNT);
+    CScript rootOwnerScript = dest;
+    rootOwner.ConstructTransaction(rootOwnerScript);
+    tx.vout.emplace_back(0, rootOwnerScript);
+    CScript verifierScript;
+    CNullAssetTxVerifierString verifier("true");
+    verifier.ConstructTransaction(verifierScript);
+    tx.vout.emplace_back(0, verifierScript);
+    CNewAsset restricted("$" + root, 5 * COIN, 0, 0, 0, "");
+    CScript assetScript = dest;
+    restricted.ConstructTransaction(assetScript);
+    tx.vout.emplace_back(0, assetScript);
+    return tx;
+}
+
+CMutableTransaction MakeValidQualifierIssueTx(const CScript& dest)
+{
+    CMutableTransaction tx;
+    tx.vout.emplace_back(GetBurnAmount(AssetType::QUALIFIER), AssetBurnScript(AssetType::QUALIFIER));
+    CNewAsset qual("#REGQUAL", 5 * COIN, 0, 0, 0, "");
+    CScript qualScript = dest;
+    qual.ConstructTransaction(qualScript);
+    tx.vout.emplace_back(0, qualScript);
+    return tx;
+}
+
+CMutableTransaction MakeValidUniqueIssueTx(const std::string& root, const CScript& dest)
+{
+    CMutableTransaction tx;
+    tx.vout.emplace_back(GetBurnAmount(AssetType::UNIQUE), AssetBurnScript(AssetType::UNIQUE));
+    CAssetTransfer rootOwner(root + OWNER_TAG, OWNER_ASSET_AMOUNT);
+    CScript rootOwnerScript = dest;
+    rootOwner.ConstructTransaction(rootOwnerScript);
+    tx.vout.emplace_back(0, rootOwnerScript);
+    CNewAsset unique(root + "#UNIQ1", 1, 0, 0, 0, "");
+    CScript uniqueScript = dest;
+    unique.ConstructTransaction(uniqueScript);
+    tx.vout.emplace_back(0, uniqueScript);
+    return tx;
+}
+
+CMutableTransaction MakeValidMsgChannelTx(const std::string& root, const CScript& dest)
+{
+    CMutableTransaction tx;
+    tx.vout.emplace_back(GetBurnAmount(AssetType::MSGCHANNEL), AssetBurnScript(AssetType::MSGCHANNEL));
+    CAssetTransfer rootOwner(root + OWNER_TAG, OWNER_ASSET_AMOUNT);
+    CScript rootOwnerScript = dest;
+    rootOwner.ConstructTransaction(rootOwnerScript);
+    tx.vout.emplace_back(0, rootOwnerScript);
+    CNewAsset channel(root + "~CHANNEL", 1 * COIN, 0, 0, 0, "");
+    CScript channelScript = dest;
+    channel.ConstructTransaction(channelScript);
+    tx.vout.emplace_back(0, channelScript);
+    return tx;
+}
+
+CMutableTransaction MakeValidIssueMineableTx(const std::string& root, const CScript& dest)
+{
+    CMutableTransaction tx;
+    CIssueMineable issue;
+    issue.strRootAsset = root;
+    issue.strMineableAsset = MineableAssetNameFromRoot(root);
+    issue.nTotalQty = 500 * COIN;
+    issue.nPerBlock = 50 * COIN;
+    issue.nNthBlock = 5;
+    issue.nUnits = 0;
+    tx.vout.emplace_back(CalculateMineableIssuanceCost(issue), IssueMineableBurnScript());
+    CScript mineScript = dest;
+    issue.ConstructTransaction(mineScript);
+    tx.vout.emplace_back(0, mineScript);
+    return tx;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Suite 1: Verify* matrix — every issuance / reissue transaction shape
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_SUITE(asset_regression_verify_matrix, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(verify_all_issue_types)
+{
+    ActivateAllAssetFeaturesForTest();
+    const CScript dest = GetScriptForDestination(DecodeDestination(GetParams().GlobalBurnAddress()));
+    std::string err;
+
+    BOOST_CHECK(CTransaction(MakeValidIssueRootTx(dest)).VerifyNewAsset(err));
+
+    BOOST_CHECK(CTransaction(MakeValidQualifierIssueTx(dest)).VerifyNewQualfierAsset(err));
+
+    BOOST_CHECK(CTransaction(MakeValidRestrictedIssueTx("RESTROOT", dest)).VerifyNewRestrictedAsset(err));
+
+    BOOST_CHECK(CTransaction(MakeValidUniqueIssueTx("UNIQROOT", dest)).VerifyNewUniqueAsset(err));
+
+    BOOST_CHECK(CTransaction(MakeValidMsgChannelTx("MSGROOT", dest)).VerifyNewMsgChannelAsset(err));
+
+    CMutableTransaction subQual = MakeValidQualifierIssueTx(dest);
+    CNewAsset subQ("#REGQUAL/#SUB1", 5 * COIN, 0, 0, 0, "");
+    subQual.vout.clear();
+    subQual.vout.emplace_back(GetBurnAmount(AssetType::SUB_QUALIFIER), AssetBurnScript(AssetType::SUB_QUALIFIER));
+    CAssetTransfer parent("#REGQUAL", OWNER_ASSET_AMOUNT);
+    CScript parentScript = dest;
+    parent.ConstructTransaction(parentScript);
+    subQual.vout.emplace_back(0, parentScript);
+    CScript sqScript = dest;
+    subQ.ConstructTransaction(sqScript);
+    subQual.vout.emplace_back(0, sqScript);
+    BOOST_CHECK(CTransaction(subQual).VerifyNewQualfierAsset(err));
+
+    CMutableTransaction sub = MakeValidIssueRootTx(dest);
+    sub.vout.clear();
+    CNewAsset subAsset("UNIQROOT/SUB1", COIN, 0, 1, 0, "");
+    sub.vout.emplace_back(GetBurnAmount(AssetType::SUB), AssetBurnScript(AssetType::SUB));
+    CAssetTransfer parentOwner("UNIQROOT!", OWNER_ASSET_AMOUNT);
+    CScript poScript = dest;
+    parentOwner.ConstructTransaction(poScript);
+    sub.vout.emplace_back(0, poScript);
+    CScript saScript = dest;
+    subAsset.ConstructTransaction(saScript);
+    sub.vout.emplace_back(0, saScript);
+    BOOST_CHECK(CTransaction(sub).VerifyNewAsset(err));
+}
+
+BOOST_AUTO_TEST_CASE(verify_transfer_and_null_data_scripts)
+{
+    ActivateAllAssetFeaturesForTest();
+    const CScript dest = GetScriptForDestination(DecodeDestination(GetParams().GlobalBurnAddress()));
+
+    CAssetTransfer transfer("REGROOT", 100 * COIN);
+    CScript xferScript = dest;
+    transfer.ConstructTransaction(xferScript);
+    CNullAssetTxData tagData("#TAG", (int)QualifierType::ADD_QUALIFIER);
+    CScript tagScript = GetScriptForNullAssetDataDestination(DecodeDestination(GetParams().GlobalBurnAddress()));
+    tagData.ConstructTransaction(tagScript);
+
+    CNullAssetTxData freezeData("$ASSET", (int)RestrictedType::FREEZE_ADDRESS);
+    CScript freezeScript = tagScript;
+    freezeData.ConstructTransaction(freezeScript);
+
+    CNullAssetTxData globalFreeze("$ASSET", (int)RestrictedType::GLOBAL_FREEZE);
+    CScript globalScript;
+    globalFreeze.ConstructGlobalRestrictionTransaction(globalScript);
+
+    CNullAssetTxVerifierString verifier("true");
+    CScript verifierScript;
+    verifier.ConstructTransaction(verifierScript);
+
+    CNullAssetTxData parsed;
+    std::string addr;
+    BOOST_CHECK(AssetNullDataFromScript(tagScript, parsed, addr));
+    BOOST_CHECK(AssetNullDataFromScript(freezeScript, parsed, addr));
+    BOOST_CHECK(GlobalAssetNullDataFromScript(globalScript, parsed));
+    BOOST_CHECK(CheckVerifierAssetTxOut(CTxOut(0, verifierScript)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+// ---------------------------------------------------------------------------
+// Suite 2: Cache / contextual — restricted + reissue without full chain
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_SUITE(asset_regression_cache_ops, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(verify_reissue_and_mineable_tx)
+{
+    ActivateAllAssetFeaturesForTest();
+    const CScript dest = GetScriptForDestination(DecodeDestination(GetParams().GlobalBurnAddress()));
+    std::string err;
+
+    BOOST_CHECK(CTransaction(MakeValidReissueTx("REISSUE_ROOT", dest)).VerifyReissueAsset(err));
+
+    passets->mapAssetsAddressAmount[std::make_pair("MINE_ROOT!", GetParams().GlobalBurnAddress())] = OWNER_ASSET_AMOUNT;
+    CMineableSchedule sched;
+    sched.strRootAsset = "MINE_ROOT";
+    sched.strMineableAsset = "&MINE_ROOT";
+    sched.nTotalQty = 500 * COIN;
+    sched.nPerBlock = 50 * COIN;
+    sched.nNthBlock = 5;
+    sched.fAllowExtension = true;
+    sched.nMaxTotalQty = 1000 * COIN;
+    sched.fActive = true;
+    pmineabledb->WriteSchedule(sched);
+
+    CMutableTransaction mineIssue = MakeValidIssueMineableTx("MINE_ROOT", dest);
+    BOOST_CHECK(CTransaction(mineIssue).VerifyIssueMineable(err));
+
+    CReissueMineableSchedule ext;
+    ext.strMineableAsset = "&MINE_ROOT";
+    ext.nAddQty = 50 * COIN;
+    CMutableTransaction mineExt;
+    mineExt.vout.emplace_back(CalculateMineableExtensionCost(sched, ext.nAddQty, 0), IssueMineableBurnScript());
+    CAssetTransfer ownerReturn("MINE_ROOT!", OWNER_ASSET_AMOUNT);
+    CScript ownerScript = dest;
+    ownerReturn.ConstructTransaction(ownerScript);
+    mineExt.vout.emplace_back(0, ownerScript);
+    CScript extScript = dest;
+    ext.ConstructTransaction(extScript);
+    mineExt.vout.emplace_back(0, extScript);
+    BOOST_CHECK(CTransaction(mineExt).VerifyReissueMineable(err));
+}
+
+BOOST_AUTO_TEST_CASE(cache_reissue_roundtrip)
+{
+    ActivateAllAssetFeaturesForTest();
+    CAssetsCache cache;
+    const std::string root = "CACHERT";
+    CNewAsset asset(root, 100 * COIN, 0, 1, 0, "");
+    BOOST_CHECK(cache.AddNewAsset(asset, GetParams().GlobalBurnAddress(), 1, uint256()));
+
+    CReissueAsset reissue(root, 10 * COIN, 0, 0, "");
+    COutPoint out(uint256S("ab"), 1);
+    BOOST_CHECK(cache.AddReissueAsset(reissue, GetParams().GlobalBurnAddress(), out));
+
+    CNewAsset updated;
+    BOOST_CHECK(cache.GetAssetMetaDataIfExists(root, updated));
+    BOOST_CHECK_EQUAL(updated.nAmount, 110 * COIN);
+
+    std::vector<std::pair<std::string, CBlockAssetUndo>> undo;
+    undo.emplace_back(root, CBlockAssetUndo{true, false, "", 0, ASSET_UNDO_INCLUDES_VERIFIER_STRING, false, ""});
+    BOOST_CHECK(cache.RemoveReissueAsset(reissue, GetParams().GlobalBurnAddress(), out, undo));
+    BOOST_CHECK(cache.GetAssetMetaDataIfExists(root, updated));
+    BOOST_CHECK_EQUAL(updated.nAmount, 100 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(cache_restricted_qualifier_freeze_ops)
+{
+    ActivateAllAssetFeaturesForTest();
+    CAssetsCache cache;
+    const std::string restricted = "$RESTEST";
+    const std::string address = GetParams().GlobalBurnAddress();
+    const std::string qual = "#VIP";
+
+    CNewAsset asset(restricted.substr(1), 100 * COIN, 0, 1, 0, "");
+    cache.AddNewAsset(CNewAsset(restricted, 100 * COIN, 0, 0, 0, ""), address, 1, uint256());
+    cache.AddRestrictedVerifier(restricted, "true");
+
+    CNullAssetTxData addTag(qual, (int)QualifierType::ADD_QUALIFIER);
+    std::string err;
+    BOOST_CHECK(VerifyQualifierChange(cache, addTag, address, err));
+    BOOST_CHECK(cache.AddQualifierAddress(restricted, address, QualifierType::ADD_QUALIFIER));
+
+    CNullAssetTxData freeze(restricted, (int)RestrictedType::FREEZE_ADDRESS);
+    BOOST_CHECK(VerifyRestrictedAddressChange(cache, freeze, address, err));
+    BOOST_CHECK(cache.AddRestrictedAddress(restricted, address, RestrictedType::FREEZE_ADDRESS));
+
+    CNullAssetTxData globalFreeze(restricted, (int)RestrictedType::GLOBAL_FREEZE);
+    BOOST_CHECK(VerifyGlobalRestrictedChange(cache, globalFreeze, err));
+    BOOST_CHECK(cache.AddGlobalRestricted(restricted, RestrictedType::GLOBAL_FREEZE));
+
+    CNullAssetTxData unfreeze(restricted, (int)RestrictedType::UNFREEZE_ADDRESS);
+    BOOST_CHECK(VerifyRestrictedAddressChange(cache, unfreeze, address, err));
+
+    CNullAssetTxData removeTag(qual, (int)QualifierType::REMOVE_QUALIFIER);
+    BOOST_CHECK(VerifyQualifierChange(cache, removeTag, address, err));
+
+    CNullAssetTxData globalUnfreeze(restricted, (int)RestrictedType::GLOBAL_UNFREEZE);
+    BOOST_CHECK(VerifyGlobalRestrictedChange(cache, globalUnfreeze, err));
+}
+
+BOOST_AUTO_TEST_CASE(contextual_transfer_and_reissue_checks)
+{
+    ActivateAllAssetFeaturesForTest();
+    CAssetsCache cache;
+    const std::string root = "CTXROOT";
+    CNewAsset asset(root, 1000 * COIN, 0, 1, 0, "");
+    cache.AddNewAsset(asset, GetParams().GlobalBurnAddress(), 1, uint256());
+
+    CAssetTransfer xfer(root, 100 * COIN);
+    std::string err;
+    BOOST_CHECK(ContextualCheckTransferAsset(&cache, xfer, GetParams().GlobalBurnAddress(), err));
+
+    CReissueAsset reissue(root, 50 * COIN, 0, 0, "");
+    BOOST_CHECK(ContextualCheckReissueAsset(&cache, reissue, err));
+
+    CNewAsset duplicate(root, 1 * COIN, 0, 1, 0, "");
+    BOOST_CHECK(!ContextualCheckNewAsset(&cache, duplicate, err, true));
+}
+
+BOOST_AUTO_TEST_CASE(check_tx_assets_transfer_balance)
+{
+    ActivateAllAssetFeaturesForTest();
+    CCoinsView view;
+    CCoinsViewCache coins(&view);
+
+    CAssetTransfer asset("BALTEST", 1000 * COIN);
+    CScript script = GetScriptForDestination(DecodeDestination(GetParams().GlobalBurnAddress()));
+    asset.ConstructTransaction(script);
+    uint256 hash = uint256S("1111111111111111111111111111111111111111111111111111111111111111");
+    coins.AddCoin(COutPoint(hash, 0), Coin(CTxOut(0, script), 200, 0), true);
+
+    CMutableTransaction spend;
+    spend.vin.emplace_back(COutPoint(hash, 0));
+    CAssetTransfer outXfer("BALTEST", 1000 * COIN);
+    CScript outScript = script;
+    outXfer.ConstructTransaction(outScript);
+    spend.vout.emplace_back(0, outScript);
+
+    CValidationState state;
+    std::vector<std::pair<std::string, uint256>> vReissue;
+    BOOST_CHECK(Consensus::CheckTxAssets(spend, state, coins, passets, false, vReissue, true));
+
+    spend.vout[0].nValue = 1;
+    CScript badScript = script;
+    CAssetTransfer badXfer("BALTEST", 500 * COIN);
+    badXfer.ConstructTransaction(badScript);
+    spend.vout[0].scriptPubKey = badScript;
+    BOOST_CHECK(!Consensus::CheckTxAssets(spend, state, coins, passets, false, vReissue, true));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+// ---------------------------------------------------------------------------
+// Suite 3: On-chain regression — every major type on regtest chain
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_SUITE(asset_regression_chain, TestChain100Setup)
+
+BOOST_AUTO_TEST_CASE(chain_issue_root_sub_unique_qualifier_restricted_msg_mineable)
+{
+    ActivateAllAssetFeaturesForTest();
+    AssetChainHelper H(*this);
+
+    const std::string root = H.NextName("ROOT");
+    H.IssueRootOnChain(root);
+
+    CMutableTransaction subTx = H.BuildIssueSubTx(root, root + "/SUBA");
+    std::string err;
+    BOOST_CHECK(CTransaction(subTx).VerifyNewAsset(err));
+    H.SubmitBlock(subTx);
+
+    CMutableTransaction uniqueTx = H.BuildIssueUniqueTx(root, root + "#U001");
+    BOOST_CHECK(CTransaction(uniqueTx).VerifyNewUniqueAsset(err));
+    H.SubmitBlock(uniqueTx);
+
+    const std::string qualName = "#" + H.NextName("Q");
+    CMutableTransaction qualTx = H.BuildIssueQualifierTx(qualName);
+    BOOST_CHECK(CTransaction(qualTx).VerifyNewQualfierAsset(err));
+    H.SubmitBlock(qualTx);
+
+    CMutableTransaction subQualTx = H.BuildIssueSubQualifierTx(qualName, qualName + "/SUBQ");
+    BOOST_CHECK(CTransaction(subQualTx).VerifyNewQualfierAsset(err));
+    H.SubmitBlock(subQualTx);
+
+    CMutableTransaction restTx = H.BuildIssueRestrictedTx(root, "$" + root);
+    BOOST_CHECK(CTransaction(restTx).VerifyNewRestrictedAsset(err));
+    H.SubmitBlock(restTx);
+
+    CMutableTransaction msgTx = H.BuildIssueMsgChannelTx(root, root + "~CH01");
+    BOOST_CHECK(CTransaction(msgTx).VerifyNewMsgChannelAsset(err));
+    H.SubmitBlock(msgTx);
+
+    CIssueMineable mine;
+    mine.strRootAsset = root;
+    mine.strMineableAsset = MineableAssetNameFromRoot(root);
+    mine.nTotalQty = 200 * COIN;
+    mine.nPerBlock = 50 * COIN;
+    mine.nNthBlock = 2;
+    mine.nUnits = 0;
+    CMutableTransaction mineTx = H.BuildIssueMineableTx(mine);
+    BOOST_CHECK(CTransaction(mineTx).VerifyIssueMineable(err));
+    H.SubmitBlock(mineTx);
+
+    CMineableSchedule mineSched;
+    BOOST_CHECK(pmineabledb->ReadSchedule(mine.strMineableAsset, mineSched));
+    BOOST_CHECK(passets->CheckIfAssetExists(root));
+    BOOST_CHECK(passets->CheckIfAssetExists("$" + root));
+}
+
+BOOST_AUTO_TEST_CASE(chain_reissue_and_transfer)
+{
+    ActivateAllAssetFeaturesForTest();
+    AssetChainHelper H(*this);
+    const std::string root = H.IssueRootOnChain(H.NextName("RIS"));
+
+    CMutableTransaction reissueTx = H.BuildReissueTx(root, 5 * COIN);
+    std::string err;
+    BOOST_CHECK(CTransaction(reissueTx).VerifyReissueAsset(err));
+    H.SubmitBlock(reissueTx);
+
+    CNewAsset meta;
+    BOOST_CHECK(passets->GetAssetMetaDataIfExists(root, meta));
+    BOOST_CHECK(meta.nAmount >= 6 * COIN);
+
+    CMutableTransaction xferTx = H.BuildTransferTx(H.assetOutpoints.at(root), H.issueTxByRoot.at(root),
+                                                    root, 1 * COIN, H.miner);
+    CValidationState state;
+    std::vector<std::pair<std::string, uint256>> vReissue;
+    CCoinsViewCache coins(pcoinsTip);
+    BOOST_CHECK(Consensus::CheckTxAssets(xferTx, state, coins, passets, false, vReissue, true));
+    H.SubmitBlock(xferTx);
+}
+
+BOOST_AUTO_TEST_CASE(chain_mineable_mine_claim)
+{
+    ActivateAllAssetFeaturesForTest();
+    AssetChainHelper H(*this);
+    const std::string root = H.IssueRootOnChain(H.NextName("MNE"));
+    CIssueMineable issue;
+    issue.strRootAsset = root;
+    issue.strMineableAsset = MineableAssetNameFromRoot(root);
+    issue.nTotalQty = 200 * COIN;
+    issue.nPerBlock = 50 * COIN;
+    issue.nNthBlock = 2;
+    issue.nUnits = 0;
+    CMutableTransaction mineTx = H.BuildIssueMineableTx(issue);
+    H.SubmitBlock(mineTx);
+
+    H.MineBlocks(4);
+    H.ClaimMineable(issue.strMineableAsset);
+
+    CMineableSchedule s;
+    pmineabledb->ReadSchedule(issue.strMineableAsset, s);
+    BOOST_CHECK(s.nTotalMinted > 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+// ---------------------------------------------------------------------------
+// Suite 4: Full stress — enumerate assets, all operation types in a loop
+// ---------------------------------------------------------------------------
+BOOST_FIXTURE_TEST_SUITE(asset_regression_stress, TestChain100Setup)
+
+BOOST_AUTO_TEST_CASE(stress_multi_type_regression_loop)
+{
+    ActivateAllAssetFeaturesForTest();
+    AssetChainHelper H(*this);
+    const int rounds = 6;
+    int rootsIssued = 0;
+    int restrictedIssued = 0;
+    int mineableClaimed = 0;
+    int reissues = 0;
+
+    for (int r = 0; r < rounds; ++r) {
+        const std::string root = H.NextName("STR");
+        H.IssueRootOnChain(root);
+        ++rootsIssued;
+
+        if (r % 2 == 0) {
+            CMutableTransaction reissueTx = H.BuildReissueTx(root, 1 * COIN);
+            H.SubmitBlock(reissueTx);
+            ++reissues;
+        }
+
+        const std::string qual = "#" + H.NextName("TQ");
+        H.SubmitBlock(H.BuildIssueQualifierTx(qual));
+
+        CMutableTransaction restTx = H.BuildIssueRestrictedTx(root, "$" + root, "true");
+        H.SubmitBlock(restTx);
+        ++restrictedIssued;
+
+        passets->AddRestrictedVerifier("$" + root, "true");
+        const std::string addr = H.MinerAddress();
+        CNullAssetTxData addTag(qual, (int)QualifierType::ADD_QUALIFIER);
+        std::string err;
+        VerifyQualifierChange(*passets, addTag, addr, err);
+        passets->AddQualifierAddress("$" + root, addr, QualifierType::ADD_QUALIFIER);
+
+        CIssueMineable mine;
+        mine.strRootAsset = root;
+        mine.strMineableAsset = MineableAssetNameFromRoot(root);
+        mine.nTotalQty = 100 * COIN;
+        mine.nPerBlock = 25 * COIN;
+        mine.nNthBlock = 2;
+        mine.nUnits = 0;
+        mine.fAllowExtension = (r % 3 == 0);
+        mine.nMaxTotalQty = mine.fAllowExtension ? 200 * COIN : 0;
+        CMutableTransaction mineTx = H.BuildIssueMineableTx(mine);
+        H.SubmitBlock(mineTx);
+
+        H.MineBlocks(3);
+        H.ClaimMineable(mine.strMineableAsset);
+
+        CMineableSchedule ms;
+        if (pmineabledb->ReadSchedule(mine.strMineableAsset, ms) && ms.nTotalMinted > 0)
+            ++mineableClaimed;
+
+        if (mine.fAllowExtension) {
+            CReissueMineableSchedule ext;
+            ext.strMineableAsset = mine.strMineableAsset;
+            ext.nAddQty = 25 * COIN;
+            CMineableSchedule sched;
+            pmineabledb->ReadSchedule(mine.strMineableAsset, sched);
+            CMutableTransaction extTx = H.BuildReissueMineableTx(ext, sched);
+            H.SubmitBlock(extTx);
+        }
+
+        H.SubmitBlock(H.BuildIssueUniqueTx(root, root + "#S" + std::to_string(r)));
+
+        if (r % 3 == 1)
+            H.SubmitBlock(H.BuildIssueMsgChannelTx(root, root + "~M" + std::to_string(r)));
+    }
+
+    BOOST_CHECK_EQUAL(rootsIssued, rounds);
+    BOOST_CHECK(restrictedIssued >= rounds);
+    BOOST_CHECK(reissues >= rounds / 2);
+    BOOST_CHECK(mineableClaimed >= rounds / 2);
+
+    std::vector<CMineableSchedule> mineableSchedules;
+    pmineabledb->ListSchedules(mineableSchedules);
+    BOOST_CHECK(static_cast<int>(mineableSchedules.size()) >= rounds);
+}
+
+BOOST_AUTO_TEST_CASE(stress_restricted_lifecycle_cache)
+{
+    ActivateAllAssetFeaturesForTest();
+    CAssetsCache cache;
+    const std::string restricted = "$STRESSREST";
+    const std::string addr = GetParams().GlobalBurnAddress();
+
+    cache.AddNewAsset(CNewAsset(restricted, 100 * COIN, 0, 0, 0, ""), addr, 1, uint256());
+    cache.AddRestrictedVerifier(restricted, "true");
+
+    for (int i = 0; i < 10; ++i) {
+        const std::string qual = "#TAG" + std::to_string(i);
+        CNullAssetTxData add(qual, (int)QualifierType::ADD_QUALIFIER);
+        std::string err;
+        BOOST_CHECK(VerifyQualifierChange(cache, add, addr, err));
+        cache.AddQualifierAddress(restricted, addr, QualifierType::ADD_QUALIFIER);
+
+        CNullAssetTxData freeze(restricted, (int)RestrictedType::FREEZE_ADDRESS);
+        BOOST_CHECK(VerifyRestrictedAddressChange(cache, freeze, addr, err));
+        cache.AddRestrictedAddress(restricted, addr, RestrictedType::FREEZE_ADDRESS);
+
+        CNullAssetTxData unfreeze(restricted, (int)RestrictedType::UNFREEZE_ADDRESS);
+        BOOST_CHECK(VerifyRestrictedAddressChange(cache, unfreeze, addr, err));
+
+        CNullAssetTxData remove(qual, (int)QualifierType::REMOVE_QUALIFIER);
+        BOOST_CHECK(VerifyQualifierChange(cache, remove, addr, err));
+    }
+
+    CNullAssetTxData gFreeze(restricted, (int)RestrictedType::GLOBAL_FREEZE);
+    std::string err;
+    BOOST_CHECK(VerifyGlobalRestrictedChange(cache, gFreeze, err));
+    cache.AddGlobalRestricted(restricted, RestrictedType::GLOBAL_FREEZE);
+    CNullAssetTxData gUnfreeze(restricted, (int)RestrictedType::GLOBAL_UNFREEZE);
+    BOOST_CHECK(VerifyGlobalRestrictedChange(cache, gUnfreeze, err));
+}
+
+BOOST_AUTO_TEST_CASE(stress_verify_matrix_all_types_not_broken)
+{
+    ActivateAllAssetFeaturesForTest();
+    const CScript dest = GetScriptForDestination(DecodeDestination(GetParams().GlobalBurnAddress()));
+    std::string err;
+
+    BOOST_CHECK(CTransaction(MakeValidIssueRootTx(dest)).VerifyNewAsset(err));
+    err.clear();
+    BOOST_CHECK(CTransaction(MakeValidReissueTx("XROOT", dest)).VerifyReissueAsset(err));
+    err.clear();
+    BOOST_CHECK(CTransaction(MakeValidQualifierIssueTx(dest)).VerifyNewQualfierAsset(err));
+    err.clear();
+    BOOST_CHECK(CTransaction(MakeValidRestrictedIssueTx("RROOT", dest)).VerifyNewRestrictedAsset(err));
+    err.clear();
+    BOOST_CHECK(CTransaction(MakeValidUniqueIssueTx("UROOT", dest)).VerifyNewUniqueAsset(err));
+    err.clear();
+    BOOST_CHECK(CTransaction(MakeValidMsgChannelTx("MROOT", dest)).VerifyNewMsgChannelAsset(err));
+    err.clear();
+    BOOST_CHECK(CTransaction(MakeValidIssueMineableTx("IROOT", dest)).VerifyIssueMineable(err));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/assets/asset_test_helpers.h
+++ b/src/test/assets/asset_test_helpers.h
@@ -1,0 +1,334 @@
+// Copyright (c) 2026 The Ravencoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef RAVEN_TEST_ASSET_TEST_HELPERS_H
+#define RAVEN_TEST_ASSET_TEST_HELPERS_H
+
+#include <assets/assets.h>
+#include <assets/mineable.h>
+#include <consensus/consensus.h>
+#include <consensus/tx_verify.h>
+#include <key.h>
+#include <keystore.h>
+#include <script/sign.h>
+#include <test/test_raven.h>
+#include <util.h>
+#include <validation.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+/** Force all asset soft forks active in unit / chain tests. */
+inline void ActivateAllAssetFeaturesForTest()
+{
+    SetAssetsActive(true);
+    SetRip5AssetsActive(true);
+    SetMineableAssetsActive(true);
+    SetEnforcedValues(true);
+    SetEnforcedCoinbase(true);
+    SetTransferOverflow(true);
+    fAssetIndex = true;
+}
+
+inline CScript MinerP2PKHScript(const CKey& key)
+{
+    return CScript() << ToByteVector(key.GetPubKey()) << OP_CHECKSIG;
+}
+
+inline CScript AssetBurnScript(AssetType type)
+{
+    return GetScriptForDestination(DecodeDestination(GetBurnAddress(type)));
+}
+
+/** Signed regtest chain helper for asset regression tests. */
+struct AssetChainHelper
+{
+    TestChain100Setup& chain;
+    CScript miner;
+    CBasicKeyStore keystore;
+    int nextCoinbase;
+    int nameSerial;
+
+    std::map<std::string, COutPoint> ownerOutpoints;
+    std::map<std::string, CMutableTransaction> issueTxByRoot;
+    std::map<std::string, COutPoint> assetOutpoints;
+
+    explicit AssetChainHelper(TestChain100Setup& setup)
+        : chain(setup), miner(MinerP2PKHScript(setup.coinbaseKey)), nextCoinbase(0), nameSerial(0)
+    {
+        keystore.AddKey(setup.coinbaseKey);
+    }
+
+    std::string NextName(const std::string& prefix = "REG")
+    {
+        return strprintf("%s%04d", prefix, nameSerial++);
+    }
+
+    std::string MinerAddress() const
+    {
+        return EncodeDestination(chain.coinbaseKey.GetPubKey().GetID());
+    }
+
+    void SignPrevout(CMutableTransaction& tx, unsigned int nIn, const CTransaction& prevTx) const
+    {
+        const CAmount amount = prevTx.vout[tx.vin[nIn].prevout.n].nValue;
+        if (!SignSignature(keystore, prevTx, tx, nIn, amount, SIGHASH_ALL))
+            throw std::runtime_error("SignSignature failed");
+    }
+
+    void AppendCoinbaseInput(CMutableTransaction& tx)
+    {
+        if (nextCoinbase >= static_cast<int>(chain.coinbaseTxns.size()))
+            throw std::runtime_error("out of coinbase txns");
+        tx.vin.emplace_back(COutPoint(chain.coinbaseTxns[nextCoinbase].GetHash(), 0));
+        ++nextCoinbase;
+    }
+
+    void AppendAssetInput(CMutableTransaction& tx, const COutPoint& out, const CMutableTransaction& prevTx)
+    {
+        tx.vin.emplace_back(out);
+        SignPrevout(tx, tx.vin.size() - 1, prevTx);
+    }
+
+    uint256 SubmitBlock(const CMutableTransaction& tx)
+    {
+        chain.CreateAndProcessBlock({tx}, miner);
+        return tx.GetHash();
+    }
+
+    CMutableTransaction BuildIssueRootTx(const std::string& root, CAmount qty = COIN)
+    {
+        CMutableTransaction tx;
+        AppendCoinbaseInput(tx);
+        CNewAsset asset(root, qty, 0, 1, 0, "");
+        tx.vout.emplace_back(GetBurnAmount(AssetType::ROOT), AssetBurnScript(AssetType::ROOT));
+        CScript ownerScript = miner;
+        asset.ConstructOwnerTransaction(ownerScript);
+        tx.vout.emplace_back(0, ownerScript);
+        CScript assetScript = miner;
+        asset.ConstructTransaction(assetScript);
+        tx.vout.emplace_back(0, assetScript);
+        tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    std::string IssueRootOnChain(const std::string& root, CAmount qty = COIN)
+    {
+        CMutableTransaction tx = BuildIssueRootTx(root, qty);
+        SubmitBlock(tx);
+        ownerOutpoints[root] = COutPoint(tx.GetHash(), 1);
+        assetOutpoints[root] = COutPoint(tx.GetHash(), 2);
+        issueTxByRoot[root] = tx;
+        return root;
+    }
+
+    CMutableTransaction BuildIssueSubTx(const std::string& root, const std::string& subName, CAmount qty = COIN)
+    {
+        CMutableTransaction tx;
+        AppendCoinbaseInput(tx);
+        CNewAsset asset(subName, qty, 0, 1, 0, "");
+        tx.vout.emplace_back(GetBurnAmount(AssetType::SUB), AssetBurnScript(AssetType::SUB));
+        CAssetTransfer parentOwner(root + OWNER_TAG, OWNER_ASSET_AMOUNT);
+        CScript parentScript = miner;
+        parentOwner.ConstructTransaction(parentScript);
+        tx.vout.emplace_back(0, parentScript);
+        CScript assetScript = miner;
+        asset.ConstructTransaction(assetScript);
+        tx.vout.emplace_back(0, assetScript);
+        tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    CMutableTransaction BuildIssueUniqueTx(const std::string& root, const std::string& uniqueName)
+    {
+        CMutableTransaction tx;
+        AppendCoinbaseInput(tx);
+        CNewAsset unique(uniqueName, 1, 0, 0, 0, "");
+        tx.vout.emplace_back(GetBurnAmount(AssetType::UNIQUE), AssetBurnScript(AssetType::UNIQUE));
+        CAssetTransfer parentOwner(root + OWNER_TAG, OWNER_ASSET_AMOUNT);
+        CScript parentScript = miner;
+        parentOwner.ConstructTransaction(parentScript);
+        tx.vout.emplace_back(0, parentScript);
+        CScript uniqueScript = miner;
+        unique.ConstructTransaction(uniqueScript);
+        tx.vout.emplace_back(0, uniqueScript);
+        tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    CMutableTransaction BuildIssueQualifierTx(const std::string& qualName, CAmount qty = 5 * COIN)
+    {
+        CMutableTransaction tx;
+        AppendCoinbaseInput(tx);
+        CNewAsset qual(qualName, qty, 0, 0, 0, "");
+        tx.vout.emplace_back(GetBurnAmount(AssetType::QUALIFIER), AssetBurnScript(AssetType::QUALIFIER));
+        CScript qualScript = miner;
+        qual.ConstructTransaction(qualScript);
+        tx.vout.emplace_back(0, qualScript);
+        tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    CMutableTransaction BuildIssueSubQualifierTx(const std::string& parentQual, const std::string& subQual)
+    {
+        CMutableTransaction tx;
+        AppendCoinbaseInput(tx);
+        CNewAsset qual(subQual, 5 * COIN, 0, 0, 0, "");
+        tx.vout.emplace_back(GetBurnAmount(AssetType::SUB_QUALIFIER), AssetBurnScript(AssetType::SUB_QUALIFIER));
+        CAssetTransfer parentTransfer(parentQual, OWNER_ASSET_AMOUNT);
+        CScript parentScript = miner;
+        parentTransfer.ConstructTransaction(parentScript);
+        tx.vout.emplace_back(0, parentScript);
+        CScript qualScript = miner;
+        qual.ConstructTransaction(qualScript);
+        tx.vout.emplace_back(0, qualScript);
+        tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    CMutableTransaction BuildIssueRestrictedTx(const std::string& root, const std::string& restrictedName,
+                                               const std::string& verifier = "true")
+    {
+        CMutableTransaction tx;
+        AppendCoinbaseInput(tx);
+        CNewAsset restricted(restrictedName, 5 * COIN, 0, 0, 0, "");
+        tx.vout.emplace_back(GetBurnAmount(AssetType::RESTRICTED), AssetBurnScript(AssetType::RESTRICTED));
+        CAssetTransfer rootOwner(root + OWNER_TAG, OWNER_ASSET_AMOUNT);
+        CScript rootOwnerScript = miner;
+        rootOwner.ConstructTransaction(rootOwnerScript);
+        tx.vout.emplace_back(0, rootOwnerScript);
+        CScript verifierScript;
+        CNullAssetTxVerifierString verifierData(verifier);
+        verifierData.ConstructTransaction(verifierScript);
+        tx.vout.emplace_back(0, verifierScript);
+        CScript assetScript = miner;
+        restricted.ConstructTransaction(assetScript);
+        tx.vout.emplace_back(0, assetScript);
+        tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    CMutableTransaction BuildIssueMsgChannelTx(const std::string& root, const std::string& channelName)
+    {
+        CMutableTransaction tx;
+        AppendCoinbaseInput(tx);
+        CNewAsset channel(channelName, 1 * COIN, 0, 0, 0, "");
+        tx.vout.emplace_back(GetBurnAmount(AssetType::MSGCHANNEL), AssetBurnScript(AssetType::MSGCHANNEL));
+        CAssetTransfer rootOwner(root + OWNER_TAG, OWNER_ASSET_AMOUNT);
+        CScript rootOwnerScript = miner;
+        rootOwner.ConstructTransaction(rootOwnerScript);
+        tx.vout.emplace_back(0, rootOwnerScript);
+        CScript channelScript = miner;
+        channel.ConstructTransaction(channelScript);
+        tx.vout.emplace_back(0, channelScript);
+        tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    CMutableTransaction BuildReissueTx(const std::string& root, CAmount addQty)
+    {
+        CMutableTransaction tx;
+        tx.vin.emplace_back(ownerOutpoints.at(root));
+        AppendCoinbaseInput(tx);
+        tx.vout.emplace_back(GetReissueAssetBurnAmount(), GetScriptForDestination(
+            DecodeDestination(GetParams().ReissueAssetBurnAddress())));
+        CReissueAsset reissue(root, addQty, 0, 0, "");
+        CScript reissueScript = miner;
+        reissue.ConstructTransaction(reissueScript);
+        tx.vout.emplace_back(0, reissueScript);
+        CAssetTransfer ownerReturn(root + OWNER_TAG, OWNER_ASSET_AMOUNT);
+        CScript ownerScript = miner;
+        ownerReturn.ConstructTransaction(ownerScript);
+        tx.vout.emplace_back(0, ownerScript);
+        tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, issueTxByRoot.at(root));
+        SignPrevout(tx, 1, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    CMutableTransaction BuildTransferTx(const COutPoint& assetIn, const CMutableTransaction& prevIssueTx,
+                                        const std::string& assetName, CAmount amount, const CScript& dest)
+    {
+        CMutableTransaction tx;
+        tx.vin.emplace_back(assetIn);
+        CAssetTransfer xfer(assetName, amount);
+        CScript outScript = dest;
+        xfer.ConstructTransaction(outScript);
+        tx.vout.emplace_back(0, outScript);
+        SignPrevout(tx, 0, prevIssueTx);
+        return tx;
+    }
+
+    CMutableTransaction BuildIssueMineableTx(const CIssueMineable& issue)
+    {
+        CMutableTransaction tx;
+        AppendCoinbaseInput(tx);
+        const CAmount burn = CalculateMineableIssuanceCost(issue);
+        tx.vout.emplace_back(burn, GetScriptForDestination(
+            DecodeDestination(GetParams().IssueAssetBurnAddress())));
+        CScript mineScript = miner;
+        issue.ConstructTransaction(mineScript);
+        tx.vout.emplace_back(0, mineScript);
+        tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    CMutableTransaction BuildReissueMineableTx(const CReissueMineableSchedule& reissue,
+                                             const CMineableSchedule& schedule)
+    {
+        CMutableTransaction tx;
+        tx.vin.emplace_back(ownerOutpoints.at(schedule.strRootAsset));
+        const CAmount burn = CalculateMineableExtensionCost(schedule, reissue.nAddQty, reissue.nNewNthBlock);
+        unsigned int coinbaseVin = 0;
+        if (burn > 0) {
+            AppendCoinbaseInput(tx);
+            coinbaseVin = 1;
+            tx.vout.emplace_back(burn, GetScriptForDestination(
+                DecodeDestination(GetParams().IssueAssetBurnAddress())));
+        }
+        CAssetTransfer ownerReturn(schedule.strRootAsset + OWNER_TAG, OWNER_ASSET_AMOUNT);
+        CScript ownerScript = miner;
+        ownerReturn.ConstructTransaction(ownerScript);
+        tx.vout.emplace_back(0, ownerScript);
+        CScript reissueScript = miner;
+        reissue.ConstructTransaction(reissueScript);
+        tx.vout.emplace_back(0, reissueScript);
+        if (burn > 0)
+            tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, issueTxByRoot.at(schedule.strRootAsset));
+        if (burn > 0)
+            SignPrevout(tx, coinbaseVin, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    void MineBlocks(int n)
+    {
+        for (int i = 0; i < n; ++i)
+            chain.CreateAndProcessBlock({}, miner);
+    }
+
+    void ClaimMineable(const std::string& mineableAsset)
+    {
+        CMineableSchedule live;
+        pmineabledb->ReadSchedule(mineableAsset, live);
+        live.UpdateMaturity(chainActive.Height());
+        const CAmount amt = live.GetAccruedAmount();
+        if (amt <= 0)
+            return;
+        std::map<std::string, CAmount> claims;
+        claims[mineableAsset] = amt;
+        chain.CreateAndProcessBlockWithMineableClaims({}, miner, claims);
+    }
+};
+
+#endif // RAVEN_TEST_ASSET_TEST_HELPERS_H

--- a/src/test/assets/asset_test_helpers.h
+++ b/src/test/assets/asset_test_helpers.h
@@ -7,6 +7,8 @@
 
 #include <assets/assets.h>
 #include <assets/mineable.h>
+#include <base58.h>
+#include <chainparams.h>
 #include <consensus/consensus.h>
 #include <consensus/tx_verify.h>
 #include <key.h>
@@ -29,6 +31,7 @@ inline void ActivateAllAssetFeaturesForTest()
     SetEnforcedValues(true);
     SetEnforcedCoinbase(true);
     SetTransferOverflow(true);
+    SetTransferScriptsSizeActive(true);
     fAssetIndex = true;
 }
 
@@ -73,8 +76,7 @@ struct AssetChainHelper
 
     void SignPrevout(CMutableTransaction& tx, unsigned int nIn, const CTransaction& prevTx) const
     {
-        const CAmount amount = prevTx.vout[tx.vin[nIn].prevout.n].nValue;
-        if (!SignSignature(keystore, prevTx, tx, nIn, amount, SIGHASH_ALL))
+        if (!SignSignature(keystore, prevTx, tx, nIn, SIGHASH_ALL))
             throw std::runtime_error("SignSignature failed");
     }
 

--- a/src/test/assets/mineable_tests.cpp
+++ b/src/test/assets/mineable_tests.cpp
@@ -6,6 +6,7 @@
 #include <assets/mineable.h>
 #include <assets/mineabledb.h>
 
+#include <test/assets/asset_test_helpers.h>
 #include <test/test_raven.h>
 
 #include <boost/test/unit_test.hpp>
@@ -69,8 +70,8 @@ struct MineableChainHelper
     std::map<std::string, COutPoint> ownerOutpoints;
     std::map<std::string, CMutableTransaction> rootIssueTxs;
 
-    explicit MineableChainHelper(TestChain100Setup& setup)
-        : chain(setup), miner(MinerScript(setup.coinbaseKey)), nextCoinbase(0), assetSerial(0)
+    explicit     MineableChainHelper(TestChain100Setup& setup)
+        : chain(setup), miner(GetScriptForDestination(setup.coinbaseKey.GetPubKey().GetID())), nextCoinbase(0), assetSerial(0)
     {
         keystore.AddKey(setup.coinbaseKey);
     }
@@ -82,8 +83,7 @@ struct MineableChainHelper
 
     void SignPrevout(CMutableTransaction& tx, unsigned int nIn, const CTransaction& prevTx) const
     {
-        const CAmount amount = prevTx.vout[tx.vin[nIn].prevout.n].nValue;
-        BOOST_REQUIRE(SignSignature(keystore, prevTx, tx, nIn, amount, SIGHASH_ALL));
+        BOOST_REQUIRE(SignSignature(keystore, prevTx, tx, nIn, SIGHASH_ALL));
     }
 
     void AppendCoinbaseInput(CMutableTransaction& tx)
@@ -102,10 +102,10 @@ struct MineableChainHelper
         CScript ownerScript = miner;
         asset.ConstructOwnerTransaction(ownerScript);
         tx.vout.emplace_back(0, ownerScript);
+        tx.vout.emplace_back(50 * COIN, miner);
         CScript assetScript = miner;
         asset.ConstructTransaction(assetScript);
         tx.vout.emplace_back(0, assetScript);
-        tx.vout.emplace_back(50 * COIN, miner);
         SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
         return tx;
     }
@@ -125,10 +125,10 @@ struct MineableChainHelper
         AppendCoinbaseInput(tx);
         const CAmount burn = CalculateMineableIssuanceCost(issue);
         tx.vout.emplace_back(burn, IssueBurnScript());
+        tx.vout.emplace_back(50 * COIN, miner);
         CScript mineScript = miner;
         issue.ConstructTransaction(mineScript);
         tx.vout.emplace_back(0, mineScript);
-        tx.vout.emplace_back(50 * COIN, miner);
         SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
         return tx;
     }
@@ -184,11 +184,11 @@ struct MineableChainHelper
         CScript ownerScript = miner;
         ownerReturn.ConstructTransaction(ownerScript);
         tx.vout.emplace_back(0, ownerScript);
+        if (burn > 0)
+            tx.vout.emplace_back(50 * COIN, miner);
         CScript reissueScript = miner;
         reissue.ConstructTransaction(reissueScript);
         tx.vout.emplace_back(0, reissueScript);
-        if (burn > 0)
-            tx.vout.emplace_back(50 * COIN, miner);
 
         SignPrevout(tx, 0, rootIssueTxs.at(schedule.strRootAsset));
         if (burn > 0)
@@ -210,17 +210,18 @@ struct MineableChainHelper
             chain.CreateAndProcessBlock({}, miner);
     }
 
-    CAmount AccruedForAsset(const std::string& mineableAsset) const
+    CAmount AccruedForAsset(const std::string& mineableAsset, int atHeight = -1) const
     {
         CMineableSchedule live;
         pmineabledb->ReadSchedule(mineableAsset, live);
-        live.UpdateMaturity(chainActive.Height());
+        const int height = atHeight >= 0 ? atHeight : chainActive.Height();
+        live.UpdateMaturity(height);
         return live.GetAccruedAmount();
     }
 
     void ClaimAsset(const std::string& mineableAsset)
     {
-        const CAmount amt = AccruedForAsset(mineableAsset);
+        const CAmount amt = AccruedForAsset(mineableAsset, chainActive.Height() + 1);
         BOOST_REQUIRE(amt > 0);
         std::map<std::string, CAmount> claims;
         claims[mineableAsset] = amt;
@@ -248,12 +249,18 @@ struct MineableChainHelper
 };
 
 CMutableTransaction BuildReissueMineableTx(const CReissueMineableSchedule& reissue, CAmount burn,
-                                           const CScript& destScript)
+                                           const CScript& destScript, const std::string& rootAsset = "")
 {
     CMutableTransaction tx;
     if (burn > 0) {
         tx.vout.emplace_back(burn, GetScriptForDestination(
             DecodeDestination(GetParams().IssueAssetBurnAddress())));
+    }
+    if (!rootAsset.empty()) {
+        CAssetTransfer ownerReturn(rootAsset + OWNER_TAG, OWNER_ASSET_AMOUNT);
+        CScript ownerScript = destScript;
+        ownerReturn.ConstructTransaction(ownerScript);
+        tx.vout.emplace_back(0, ownerScript);
     }
     CScript script = destScript;
     reissue.ConstructTransaction(script);
@@ -277,7 +284,7 @@ BOOST_FIXTURE_TEST_SUITE(mineable_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(mineable_accrual_math)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     CMineableSchedule s = MakeSchedule("ROOTA", 1000 * COIN, 100 * COIN, 10, 100);
     s.UpdateMaturity(110);
     BOOST_CHECK_EQUAL(s.nMaturedPeriods, 1);
@@ -296,7 +303,7 @@ BOOST_AUTO_TEST_CASE(mineable_accrual_math)
 
 BOOST_AUTO_TEST_CASE(mineable_delayed_claim_accrual)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     CMineableSchedule s = MakeSchedule("ROOTB", 500 * COIN, 50 * COIN, 5, 200);
     s.UpdateMaturity(220);
     BOOST_CHECK_EQUAL(s.nMaturedPeriods, 4);
@@ -408,8 +415,8 @@ BOOST_AUTO_TEST_CASE(mineable_db_persistence_restart)
 
 BOOST_AUTO_TEST_CASE(mineable_coinbase_claim_validation)
 {
-    SetMineableAssetsActive(true);
-    CMineableSchedule s = MakeSchedule("ROOTK", 300 * COIN, 100 * COIN, 5, chainActive.Height());
+    ActivateAllAssetFeaturesForTest();
+    CMineableSchedule s = MakeSchedule("ROOTK", 300 * COIN, 100 * COIN, 5, chainActive.Height() - 10);
     RegisterScheduleOnChain(s);
 
     const int h = chainActive.Height() + 1;
@@ -422,7 +429,7 @@ BOOST_AUTO_TEST_CASE(mineable_coinbase_claim_validation)
     BOOST_CHECK(accrued > 0);
 
     CMutableTransaction coinbase;
-    coinbase.vin.emplace_back(COutPoint(uint256S("00"), 0));
+    coinbase.vin.emplace_back(COutPoint(uint256(), (uint32_t)-1));
     CKey key;
     key.MakeNewKey(true);
     CScript miner = MinerScript(key);
@@ -436,7 +443,7 @@ BOOST_AUTO_TEST_CASE(mineable_coinbase_claim_validation)
 
     CAssetTransfer badClaim(s.strMineableAsset, accrued - COIN);
     CMutableTransaction badCoinbase;
-    badCoinbase.vin.emplace_back(COutPoint(uint256S("01"), 0));
+    badCoinbase.vin.emplace_back(COutPoint(uint256(), (uint32_t)-1));
     CScript badScript = miner;
     badClaim.ConstructTransaction(badScript);
     badCoinbase.vout.emplace_back(0, badScript);
@@ -446,8 +453,8 @@ BOOST_AUTO_TEST_CASE(mineable_coinbase_claim_validation)
 
 BOOST_AUTO_TEST_CASE(mineable_coinbase_duplicate_miner_claim)
 {
-    SetMineableAssetsActive(true);
-    CMineableSchedule s = MakeSchedule("DUPD", 200 * COIN, 100 * COIN, 2, chainActive.Height());
+    ActivateAllAssetFeaturesForTest();
+    CMineableSchedule s = MakeSchedule("DUPD", 200 * COIN, 100 * COIN, 2, chainActive.Height() - 10);
     RegisterScheduleOnChain(s);
     const int h = chainActive.Height() + 1;
     ProcessMineableMaturityAtHeight(h, *pmineabledb);
@@ -461,7 +468,7 @@ BOOST_AUTO_TEST_CASE(mineable_coinbase_duplicate_miner_claim)
     key.MakeNewKey(true);
     CScript miner = MinerScript(key);
     CMutableTransaction coinbase;
-    coinbase.vin.emplace_back(COutPoint(uint256S("02"), 0));
+    coinbase.vin.emplace_back(COutPoint(uint256(), (uint32_t)-1));
     for (int i = 0; i < 2; ++i) {
         CAssetTransfer claim(s.strMineableAsset, amt / 2);
         CScript claimScript = miner;
@@ -474,7 +481,7 @@ BOOST_AUTO_TEST_CASE(mineable_coinbase_duplicate_miner_claim)
 
 BOOST_AUTO_TEST_CASE(mineable_coinbase_zero_accrued_rejected)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     CMineableSchedule s = MakeSchedule("ZERO", 100 * COIN, 50 * COIN, 50, chainActive.Height() + 100);
     RegisterScheduleOnChain(s);
     const int h = chainActive.Height() + 1;
@@ -483,7 +490,7 @@ BOOST_AUTO_TEST_CASE(mineable_coinbase_zero_accrued_rejected)
     key.MakeNewKey(true);
     CScript miner = MinerScript(key);
     CMutableTransaction coinbase;
-    coinbase.vin.emplace_back(COutPoint(uint256S("03"), 0));
+    coinbase.vin.emplace_back(COutPoint(uint256(), (uint32_t)-1));
     CAssetTransfer claim(s.strMineableAsset, 50 * COIN);
     CScript claimScript = miner;
     claim.ConstructTransaction(claimScript);
@@ -491,6 +498,34 @@ BOOST_AUTO_TEST_CASE(mineable_coinbase_zero_accrued_rejected)
 
     CValidationState state;
     BOOST_CHECK(!ValidateMineableCoinbaseClaims(coinbase, h, passets, *pmineabledb, state));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_issue_script_roundtrip)
+{
+    CIssueMineable issue;
+    issue.strRootAsset = "ROUNDROOT";
+    issue.strMineableAsset = MineableAssetNameFromRoot(issue.strRootAsset);
+    issue.nTotalQty = 1000 * COIN;
+    issue.nPerBlock = 100 * COIN;
+    issue.nNthBlock = 10;
+    issue.nUnits = 0;
+
+    CScript dest = GetScriptForDestination(DecodeDestination(GetParams().GlobalBurnAddress()));
+    issue.ConstructTransaction(dest);
+    BOOST_CHECK(dest.IsIssueMineableAsset());
+
+    CIssueMineable issue2 = issue;
+    CKey key;
+    key.MakeNewKey(true);
+    CScript miner = MinerScript(key);
+    issue2.ConstructTransaction(miner);
+    BOOST_CHECK(miner.IsIssueMineableAsset());
+
+    CIssueMineable parsed;
+    std::string address;
+    BOOST_CHECK(IssueMineableFromScript(dest, parsed, address));
+    BOOST_CHECK_EQUAL(parsed.strRootAsset, issue.strRootAsset);
+    BOOST_CHECK_EQUAL(parsed.nTotalQty, issue.nTotalQty);
 }
 
 BOOST_AUTO_TEST_CASE(mineable_reissue_script_roundtrip)
@@ -534,7 +569,7 @@ BOOST_AUTO_TEST_CASE(mineable_issue_fixed_cap_default)
 
 BOOST_AUTO_TEST_CASE(mineable_issue_burn_validation)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     SelectParams(CBaseChainParams::REGTEST);
 
     CIssueMineable issue;
@@ -569,7 +604,7 @@ BOOST_AUTO_TEST_CASE(mineable_issue_burn_validation)
 
 BOOST_AUTO_TEST_CASE(mineable_reissue_burn_validation)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     CMineableSchedule s = MakeSchedule("BURNEXT", 500 * COIN, 50 * COIN, 7, 10, true, 1000 * COIN);
     RegisterScheduleOnChain(s);
 
@@ -579,7 +614,7 @@ BOOST_AUTO_TEST_CASE(mineable_reissue_burn_validation)
     const CAmount burn = CalculateMineableExtensionCost(s, reissue.nAddQty, 0);
 
     CScript dest = GetScriptForDestination(DecodeDestination(GetParams().GlobalBurnAddress()));
-    CMutableTransaction tx = BuildReissueMineableTx(reissue, burn, dest);
+    CMutableTransaction tx = BuildReissueMineableTx(reissue, burn, dest, s.strRootAsset);
     CTransaction ctx(tx);
     std::string err;
     BOOST_CHECK(ctx.VerifyReissueMineable(err));
@@ -595,7 +630,7 @@ BOOST_FIXTURE_TEST_SUITE(mineable_chain_tests, TestChain100Setup)
 
 BOOST_AUTO_TEST_CASE(mineable_chain_mine_and_claim)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     const int base = chainActive.Height();
     CMineableSchedule s = MakeSchedule("CHAIN1", 400 * COIN, 100 * COIN, 4, base + 1);
     RegisterScheduleOnChain(s);
@@ -611,7 +646,8 @@ BOOST_AUTO_TEST_CASE(mineable_chain_mine_and_claim)
     BOOST_CHECK(accrued >= 100 * COIN);
 
     std::map<std::string, CAmount> claims;
-    claims[s.strMineableAsset] = accrued;
+    live.UpdateMaturity(chainActive.Height() + 1);
+    claims[s.strMineableAsset] = live.GetAccruedAmount();
     CreateAndProcessBlockWithMineableClaims({}, miner, claims);
 
     CMineableSchedule claimed;
@@ -622,7 +658,7 @@ BOOST_AUTO_TEST_CASE(mineable_chain_mine_and_claim)
 
 BOOST_AUTO_TEST_CASE(mineable_chain_delayed_claim_full_accrual)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     const int base = chainActive.Height();
     CMineableSchedule s = MakeSchedule("CHAIN2", 600 * COIN, 100 * COIN, 3, base + 1);
     RegisterScheduleOnChain(s);
@@ -639,7 +675,10 @@ BOOST_AUTO_TEST_CASE(mineable_chain_delayed_claim_full_accrual)
 
     CreateAndProcessBlock({}, miner);
     std::map<std::string, CAmount> claims;
-    claims[s.strMineableAsset] = fullAccrued;
+    CMineableSchedule preClaim;
+    pmineabledb->ReadSchedule(s.strMineableAsset, preClaim);
+    preClaim.UpdateMaturity(chainActive.Height() + 1);
+    claims[s.strMineableAsset] = preClaim.GetAccruedAmount();
     CreateAndProcessBlockWithMineableClaims({}, miner, claims);
 
     CMineableSchedule claimed;
@@ -649,7 +688,7 @@ BOOST_AUTO_TEST_CASE(mineable_chain_delayed_claim_full_accrual)
 
 BOOST_AUTO_TEST_CASE(mineable_chain_spend_after_claim)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     const int base = chainActive.Height();
     CMineableSchedule s = MakeSchedule("CHAIN3", 200 * COIN, 100 * COIN, 2, base + 1);
     RegisterScheduleOnChain(s);
@@ -664,12 +703,9 @@ BOOST_AUTO_TEST_CASE(mineable_chain_spend_after_claim)
     const CAmount accrued = live.GetAccruedAmount();
 
     std::map<std::string, CAmount> claims;
-    claims[s.strMineableAsset] = accrued;
+    live.UpdateMaturity(chainActive.Height() + 1);
+    claims[s.strMineableAsset] = live.GetAccruedAmount();
     CreateAndProcessBlockWithMineableClaims({}, miner, claims);
-
-    passets->Clear();
-    CValidationState state;
-    ActivateBestChain(state, GetParams());
 
     CMineableSchedule after;
     pmineabledb->ReadSchedule(s.strMineableAsset, after);
@@ -678,7 +714,7 @@ BOOST_AUTO_TEST_CASE(mineable_chain_spend_after_claim)
 
 BOOST_AUTO_TEST_CASE(mineable_chain_many_assets_one_block)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     const int base = chainActive.Height();
     const char* roots[] = {"MULTI1", "MULTI2", "MULTI3", "MULTI4", "MULTI5"};
     std::map<std::string, CAmount> claims;
@@ -696,7 +732,7 @@ BOOST_AUTO_TEST_CASE(mineable_chain_many_assets_one_block)
         const std::string asset = MineableAssetNameFromRoot(root);
         CMineableSchedule live;
         pmineabledb->ReadSchedule(asset, live);
-        live.UpdateMaturity(chainActive.Height());
+        live.UpdateMaturity(chainActive.Height() + 1);
         claims[asset] = live.GetAccruedAmount();
     }
 
@@ -711,7 +747,7 @@ BOOST_AUTO_TEST_CASE(mineable_chain_many_assets_one_block)
 
 BOOST_AUTO_TEST_CASE(mineable_chain_extend_schedule_on_chain)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const std::string root = H.IssueRootAndMineableOnChain(500 * COIN, 50 * COIN, 10, true, 1000 * COIN);
     const std::string asset = MineableAssetNameFromRoot(root);
@@ -730,7 +766,7 @@ BOOST_AUTO_TEST_CASE(mineable_chain_extend_schedule_on_chain)
 
 BOOST_AUTO_TEST_CASE(mineable_chain_extend_prime_nth_one_recost)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const std::string root = H.IssueRootAndMineableOnChain(700 * COIN, 100 * COIN, 7, true, 1400 * COIN);
     const std::string asset = MineableAssetNameFromRoot(root);
@@ -748,7 +784,7 @@ BOOST_AUTO_TEST_CASE(mineable_chain_extend_prime_nth_one_recost)
 
 BOOST_AUTO_TEST_CASE(mineable_chain_reject_extend_when_fixed)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     CMineableSchedule s = MakeSchedule("FIXED1", 300 * COIN, 50 * COIN, 5, chainActive.Height() + 1);
     RegisterScheduleOnChain(s);
 
@@ -763,7 +799,7 @@ BOOST_AUTO_TEST_CASE(mineable_chain_reject_extend_when_fixed)
 
 BOOST_AUTO_TEST_CASE(mineable_reissue_requires_owner_token)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     CMineableSchedule s = MakeSchedule("OWNCHK", 500 * COIN, 50 * COIN, 5, 10, true, 1000 * COIN);
     RegisterScheduleOnChain(s);
 
@@ -781,7 +817,7 @@ BOOST_AUTO_TEST_CASE(mineable_reissue_requires_owner_token)
 
 BOOST_AUTO_TEST_CASE(mineable_stress_many_schedules_maturity)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     const int base = chainActive.Height();
     const int count = 20;
     CScript miner = MinerScript(coinbaseKey);
@@ -815,7 +851,7 @@ BOOST_FIXTURE_TEST_SUITE(mineable_e2e_tests, TestChain100Setup)
 
 BOOST_AUTO_TEST_CASE(mineable_e2e_issue_root_and_mineable_on_chain)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const std::string root = H.NextRootName();
     H.IssueRootOnChain(root);
@@ -830,7 +866,7 @@ BOOST_AUTO_TEST_CASE(mineable_e2e_issue_root_and_mineable_on_chain)
 
 BOOST_AUTO_TEST_CASE(mineable_e2e_full_mint_mine_claim)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const std::string root = H.IssueRootAndMineableOnChain(400 * COIN, 100 * COIN, 4);
     const std::string asset = MineableAssetNameFromRoot(root);
@@ -847,7 +883,7 @@ BOOST_AUTO_TEST_CASE(mineable_e2e_full_mint_mine_claim)
 
 BOOST_AUTO_TEST_CASE(mineable_e2e_enumerated_assets_sequential_mint)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const int count = 8;
     std::vector<std::string> assets;
@@ -860,7 +896,7 @@ BOOST_AUTO_TEST_CASE(mineable_e2e_enumerated_assets_sequential_mint)
     H.MineBlocks(6);
     std::map<std::string, CAmount> claims;
     for (const auto& asset : assets) {
-        const CAmount amt = H.AccruedForAsset(asset);
+        const CAmount amt = H.AccruedForAsset(asset, chainActive.Height() + 1);
         if (amt > 0)
             claims[asset] = amt;
     }
@@ -876,7 +912,7 @@ BOOST_AUTO_TEST_CASE(mineable_e2e_enumerated_assets_sequential_mint)
 
 BOOST_AUTO_TEST_CASE(mineable_e2e_payg_extend_while_mining)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const std::string root = H.IssueRootAndMineableOnChain(300 * COIN, 50 * COIN, 5, true, 800 * COIN);
     const std::string asset = MineableAssetNameFromRoot(root);
@@ -899,7 +935,7 @@ BOOST_AUTO_TEST_CASE(mineable_e2e_payg_extend_while_mining)
 
 BOOST_AUTO_TEST_CASE(mineable_e2e_reissue_owner_signed_on_chain)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const std::string root = H.IssueRootAndMineableOnChain(500 * COIN, 50 * COIN, 10, true, 1000 * COIN);
     const std::string asset = MineableAssetNameFromRoot(root);
@@ -918,7 +954,7 @@ BOOST_AUTO_TEST_CASE(mineable_e2e_reissue_owner_signed_on_chain)
 
 BOOST_AUTO_TEST_CASE(mineable_e2e_prime_nth_one_with_owner_burn)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const std::string root = H.IssueRootAndMineableOnChain(700 * COIN, 100 * COIN, 7, true, 1400 * COIN);
     const std::string asset = MineableAssetNameFromRoot(root);
@@ -935,7 +971,7 @@ BOOST_AUTO_TEST_CASE(mineable_e2e_prime_nth_one_with_owner_burn)
 
 BOOST_AUTO_TEST_CASE(mineable_e2e_reject_reissue_non_owner)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const std::string root = H.IssueRootAndMineableOnChain(300 * COIN, 50 * COIN, 5, true, 600 * COIN);
     const std::string asset = MineableAssetNameFromRoot(root);
@@ -951,7 +987,7 @@ BOOST_AUTO_TEST_CASE(mineable_e2e_reject_reissue_non_owner)
 
 BOOST_AUTO_TEST_CASE(mineable_e2e_multi_extend_up_to_cap)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const std::string root = H.IssueRootAndMineableOnChain(200 * COIN, 50 * COIN, 4, true, 500 * COIN);
     const std::string asset = MineableAssetNameFromRoot(root);
@@ -977,7 +1013,7 @@ BOOST_AUTO_TEST_CASE(mineable_e2e_multi_extend_up_to_cap)
 
 BOOST_AUTO_TEST_CASE(mineable_e2e_stress_enumerated_mine_loop)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const int rounds = 5;
     const int perRound = 4;
@@ -1012,15 +1048,16 @@ BOOST_AUTO_TEST_CASE(mineable_e2e_stress_enumerated_mine_loop)
 
 BOOST_AUTO_TEST_CASE(mineable_e2e_verify_issue_tx_before_block)
 {
-    SetMineableAssetsActive(true);
+    ActivateAllAssetFeaturesForTest();
     MineableChainHelper H(*this);
     const std::string root = H.NextRootName();
     H.IssueRootOnChain(root);
     CIssueMineable issue = H.DefaultIssueParams(root, 1000 * COIN, 100 * COIN, 10);
     CMutableTransaction mtx = H.BuildIssueMineableTx(issue);
+    BOOST_CHECK(mtx.vout.back().scriptPubKey.IsIssueMineableAsset());
     CTransaction tx(mtx);
     std::string err;
-    BOOST_CHECK(tx.VerifyIssueMineable(err));
+    BOOST_CHECK_MESSAGE(tx.VerifyIssueMineable(err), err);
     H.IssueMineableOnChain(issue);
     CMineableSchedule sched;
     BOOST_CHECK(pmineabledb->ReadSchedule(issue.strMineableAsset, sched));

--- a/src/test/assets/mineable_tests.cpp
+++ b/src/test/assets/mineable_tests.cpp
@@ -1,0 +1,1029 @@
+// Copyright (c) 2026 The Ravencoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <assets/assets.h>
+#include <assets/mineable.h>
+#include <assets/mineabledb.h>
+
+#include <test/test_raven.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <amount.h>
+#include <base58.h>
+#include <consensus/tx_verify.h>
+#include <consensus/validation.h>
+#include <script/standard.h>
+#include <validation.h>
+#include <key.h>
+#include <script/sign.h>
+#include <keystore.h>
+#include <util.h>
+
+#include <map>
+#include <vector>
+
+namespace {
+
+CMineableSchedule MakeSchedule(const std::string& root, CAmount total, CAmount perBlock, int nth,
+                               int startHeight = 100, bool allowExt = false, CAmount maxQty = 0)
+{
+    CMineableSchedule s;
+    s.strRootAsset = root;
+    s.strMineableAsset = MineableAssetNameFromRoot(root);
+    s.nTotalQty = total;
+    s.nPerBlock = perBlock;
+    s.nNthBlock = nth;
+    s.nFundAmt = 0;
+    s.nUnits = 0;
+    s.nHasIPFS = 0;
+    s.nStartHeight = startHeight;
+    s.nMaturedPeriods = 0;
+    s.nClaimedPeriods = 0;
+    s.nTotalMinted = 0;
+    s.fActive = true;
+    s.fAllowExtension = allowExt;
+    s.nMaxTotalQty = maxQty > 0 ? maxQty : total;
+    return s;
+}
+
+CScript MinerScript(const CKey& key)
+{
+    return CScript() << ToByteVector(key.GetPubKey()) << OP_CHECKSIG;
+}
+
+CScript IssueBurnScript()
+{
+    return GetScriptForDestination(DecodeDestination(GetParams().IssueAssetBurnAddress()));
+}
+
+/** End-to-end chain helper: coinbase -> self, enumerate assets, sign txs. */
+struct MineableChainHelper
+{
+    TestChain100Setup& chain;
+    CScript miner;
+    CBasicKeyStore keystore;
+    int nextCoinbase;
+    int assetSerial;
+    std::map<std::string, COutPoint> ownerOutpoints;
+    std::map<std::string, CMutableTransaction> rootIssueTxs;
+
+    explicit MineableChainHelper(TestChain100Setup& setup)
+        : chain(setup), miner(MinerScript(setup.coinbaseKey)), nextCoinbase(0), assetSerial(0)
+    {
+        keystore.AddKey(setup.coinbaseKey);
+    }
+
+    std::string NextRootName()
+    {
+        return strprintf("MINE%04d", assetSerial++);
+    }
+
+    void SignPrevout(CMutableTransaction& tx, unsigned int nIn, const CTransaction& prevTx) const
+    {
+        const CAmount amount = prevTx.vout[tx.vin[nIn].prevout.n].nValue;
+        BOOST_REQUIRE(SignSignature(keystore, prevTx, tx, nIn, amount, SIGHASH_ALL));
+    }
+
+    void AppendCoinbaseInput(CMutableTransaction& tx)
+    {
+        BOOST_REQUIRE(nextCoinbase < static_cast<int>(chain.coinbaseTxns.size()));
+        tx.vin.emplace_back(COutPoint(chain.coinbaseTxns[nextCoinbase].GetHash(), 0));
+        ++nextCoinbase;
+    }
+
+    CMutableTransaction BuildIssueRootAssetTx(const std::string& rootName, CAmount qty = COIN)
+    {
+        CMutableTransaction tx;
+        AppendCoinbaseInput(tx);
+        CNewAsset asset(rootName, qty, 0, 1, 0, "");
+        tx.vout.emplace_back(GetIssueAssetBurnAmount(), IssueBurnScript());
+        CScript ownerScript = miner;
+        asset.ConstructOwnerTransaction(ownerScript);
+        tx.vout.emplace_back(0, ownerScript);
+        CScript assetScript = miner;
+        asset.ConstructTransaction(assetScript);
+        tx.vout.emplace_back(0, assetScript);
+        tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    uint256 IssueRootOnChain(const std::string& rootName, CAmount qty = COIN)
+    {
+        CMutableTransaction tx = BuildIssueRootAssetTx(rootName, qty);
+        chain.CreateAndProcessBlock({tx}, miner);
+        ownerOutpoints[rootName] = COutPoint(tx.GetHash(), 1);
+        rootIssueTxs[rootName] = tx;
+        return tx.GetHash();
+    }
+
+    CMutableTransaction BuildIssueMineableTx(const CIssueMineable& issue)
+    {
+        CMutableTransaction tx;
+        AppendCoinbaseInput(tx);
+        const CAmount burn = CalculateMineableIssuanceCost(issue);
+        tx.vout.emplace_back(burn, IssueBurnScript());
+        CScript mineScript = miner;
+        issue.ConstructTransaction(mineScript);
+        tx.vout.emplace_back(0, mineScript);
+        tx.vout.emplace_back(50 * COIN, miner);
+        SignPrevout(tx, 0, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    CIssueMineable DefaultIssueParams(const std::string& root, CAmount total, CAmount perBlock, int nth,
+                                      bool allowExt = false, CAmount maxQty = 0)
+    {
+        CIssueMineable issue;
+        issue.strRootAsset = root;
+        issue.strMineableAsset = MineableAssetNameFromRoot(root);
+        issue.nTotalQty = total;
+        issue.nPerBlock = perBlock;
+        issue.nNthBlock = nth;
+        issue.nFundAmt = 0;
+        issue.nUnits = 0;
+        issue.nHasIPFS = 0;
+        issue.fAllowExtension = allowExt;
+        issue.nMaxTotalQty = maxQty;
+        return issue;
+    }
+
+    uint256 IssueMineableOnChain(const CIssueMineable& issue)
+    {
+        CMutableTransaction tx = BuildIssueMineableTx(issue);
+        chain.CreateAndProcessBlock({tx}, miner);
+        return tx.GetHash();
+    }
+
+    std::string IssueRootAndMineableOnChain(CAmount total = 400 * COIN, CAmount perBlock = 100 * COIN,
+                                            int nth = 4, bool allowExt = false, CAmount maxQty = 0)
+    {
+        const std::string root = NextRootName();
+        IssueRootOnChain(root);
+        CIssueMineable issue = DefaultIssueParams(root, total, perBlock, nth, allowExt, maxQty);
+        IssueMineableOnChain(issue);
+        return root;
+    }
+
+    CMutableTransaction BuildReissueMineableTx(const CReissueMineableSchedule& reissue,
+                                               const CMineableSchedule& schedule)
+    {
+        const COutPoint ownerOut = ownerOutpoints.at(schedule.strRootAsset);
+        CMutableTransaction tx;
+        tx.vin.emplace_back(ownerOut);
+        const CAmount burn = CalculateMineableExtensionCost(schedule, reissue.nAddQty, reissue.nNewNthBlock);
+        unsigned int coinbaseVin = 0;
+        if (burn > 0) {
+            AppendCoinbaseInput(tx);
+            coinbaseVin = 1;
+            tx.vout.emplace_back(burn, IssueBurnScript());
+        }
+        CAssetTransfer ownerReturn(schedule.strRootAsset + OWNER_TAG, OWNER_ASSET_AMOUNT);
+        CScript ownerScript = miner;
+        ownerReturn.ConstructTransaction(ownerScript);
+        tx.vout.emplace_back(0, ownerScript);
+        CScript reissueScript = miner;
+        reissue.ConstructTransaction(reissueScript);
+        tx.vout.emplace_back(0, reissueScript);
+        if (burn > 0)
+            tx.vout.emplace_back(50 * COIN, miner);
+
+        SignPrevout(tx, 0, rootIssueTxs.at(schedule.strRootAsset));
+        if (burn > 0)
+            SignPrevout(tx, coinbaseVin, chain.coinbaseTxns[nextCoinbase - 1]);
+        return tx;
+    }
+
+    void ReissueOnChain(const std::string& root, const CReissueMineableSchedule& reissue)
+    {
+        CMineableSchedule schedule;
+        pmineabledb->ReadSchedule(MineableAssetNameFromRoot(root), schedule);
+        CMutableTransaction tx = BuildReissueMineableTx(reissue, schedule);
+        chain.CreateAndProcessBlock({tx}, miner);
+    }
+
+    void MineBlocks(int n)
+    {
+        for (int i = 0; i < n; ++i)
+            chain.CreateAndProcessBlock({}, miner);
+    }
+
+    CAmount AccruedForAsset(const std::string& mineableAsset) const
+    {
+        CMineableSchedule live;
+        pmineabledb->ReadSchedule(mineableAsset, live);
+        live.UpdateMaturity(chainActive.Height());
+        return live.GetAccruedAmount();
+    }
+
+    void ClaimAsset(const std::string& mineableAsset)
+    {
+        const CAmount amt = AccruedForAsset(mineableAsset);
+        BOOST_REQUIRE(amt > 0);
+        std::map<std::string, CAmount> claims;
+        claims[mineableAsset] = amt;
+        chain.CreateAndProcessBlockWithMineableClaims({}, miner, claims);
+    }
+
+    CMutableTransaction BuildTransferTx(const COutPoint& assetIn, const std::string& assetName,
+                                        CAmount amount, const CScript& fromScript)
+    {
+        CMutableTransaction tx;
+        tx.vin.emplace_back(assetIn);
+        CAssetTransfer xfer(assetName, amount);
+        CScript dest = miner;
+        xfer.ConstructTransaction(dest);
+        tx.vout.emplace_back(0, dest);
+        CMutableTransaction fakePrev;
+        fakePrev.vin.emplace_back(COutPoint(uint256S("0"), 0));
+        CScript prevOut = fromScript;
+        CAssetTransfer inXfer(assetName, amount);
+        inXfer.ConstructTransaction(prevOut);
+        fakePrev.vout.emplace_back(0, prevOut);
+        SignPrevout(tx, 0, fakePrev);
+        return tx;
+    }
+};
+
+CMutableTransaction BuildReissueMineableTx(const CReissueMineableSchedule& reissue, CAmount burn,
+                                           const CScript& destScript)
+{
+    CMutableTransaction tx;
+    if (burn > 0) {
+        tx.vout.emplace_back(burn, GetScriptForDestination(
+            DecodeDestination(GetParams().IssueAssetBurnAddress())));
+    }
+    CScript script = destScript;
+    reissue.ConstructTransaction(script);
+    tx.vout.emplace_back(0, script);
+    return tx;
+}
+
+void RegisterScheduleOnChain(CMineableSchedule schedule)
+{
+    BOOST_REQUIRE(pmineabledb != nullptr);
+    BOOST_REQUIRE(pmineabledb->WriteSchedule(schedule));
+    CNewAsset asset(schedule.strMineableAsset, 0, schedule.nUnits, 0, schedule.nHasIPFS, schedule.strIPFSHash);
+    if (!passets->CheckIfAssetExists(schedule.strMineableAsset)) {
+        BOOST_REQUIRE(passets->AddNewAsset(asset, GetParams().GlobalBurnAddress(), schedule.nStartHeight, uint256()));
+    }
+}
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(mineable_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(mineable_accrual_math)
+{
+    SetMineableAssetsActive(true);
+    CMineableSchedule s = MakeSchedule("ROOTA", 1000 * COIN, 100 * COIN, 10, 100);
+    s.UpdateMaturity(110);
+    BOOST_CHECK_EQUAL(s.nMaturedPeriods, 1);
+    BOOST_CHECK_EQUAL(s.GetAccruedAmount(), 100 * COIN);
+
+    s.UpdateMaturity(130);
+    BOOST_CHECK_EQUAL(s.nMaturedPeriods, 3);
+    BOOST_CHECK_EQUAL(s.GetAccruedAmount(), 300 * COIN);
+
+    s.nClaimedPeriods = 1;
+    BOOST_CHECK_EQUAL(s.GetAccruedAmount(), 200 * COIN);
+
+    s.nTotalMinted = 900 * COIN;
+    BOOST_CHECK_EQUAL(s.GetAccruedAmount(), 100 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_delayed_claim_accrual)
+{
+    SetMineableAssetsActive(true);
+    CMineableSchedule s = MakeSchedule("ROOTB", 500 * COIN, 50 * COIN, 5, 200);
+    s.UpdateMaturity(220);
+    BOOST_CHECK_EQUAL(s.nMaturedPeriods, 4);
+    s.UpdateMaturity(235);
+    BOOST_CHECK_EQUAL(s.nMaturedPeriods, 7);
+    BOOST_CHECK_EQUAL(s.GetAccruedAmount(), 7 * 50 * COIN);
+    s.nClaimedPeriods = 0;
+    BOOST_CHECK_EQUAL(s.GetAccruedAmount(), 350 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_nth_compatibility)
+{
+    BOOST_CHECK(IsNthBlockExtensionCompatible(10, 0));
+    BOOST_CHECK(IsNthBlockExtensionCompatible(10, 10));
+    BOOST_CHECK(IsNthBlockExtensionCompatible(10, 5));
+    BOOST_CHECK(IsNthBlockExtensionCompatible(10, 2));
+    BOOST_CHECK(!IsNthBlockExtensionCompatible(10, 3));
+    BOOST_CHECK(!IsNthBlockExtensionCompatible(10, 15));
+    BOOST_CHECK(IsNthBlockExtensionCompatible(7, 1));
+    BOOST_CHECK(!IsNthBlockExtensionCompatible(7, 2));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_extension_cost_add_qty)
+{
+    CMineableSchedule s = MakeSchedule("ROOTC", 1000 * COIN, 100 * COIN, 10);
+    const CAmount cost = CalculateMineableExtensionCost(s, 200 * COIN, 0);
+    BOOST_CHECK_EQUAL(cost, 2 * MINEABLE_COST_PER_PERIOD);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_extension_cost_prime_to_nth_one)
+{
+    CMineableSchedule s = MakeSchedule("ROOTD", 700 * COIN, 100 * COIN, 7);
+    s.nClaimedPeriods = 2;
+    const CAmount cost = CalculateMineableExtensionCost(s, 0, 1);
+    const int remaining = s.GetTotalPeriods() - s.nClaimedPeriods;
+    BOOST_CHECK_EQUAL(cost, static_cast<CAmount>(remaining) * 6 * MINEABLE_COST_PER_PERIOD);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_extension_cost_compatible_nth_free)
+{
+    CMineableSchedule s = MakeSchedule("ROOTE", 1000 * COIN, 100 * COIN, 10);
+    BOOST_CHECK_EQUAL(CalculateMineableExtensionCost(s, 0, 5), 0);
+    BOOST_CHECK_EQUAL(CalculateMineableExtensionCost(s, 100 * COIN, 5), MINEABLE_COST_PER_PERIOD);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_extension_reject_subtractive)
+{
+    CMineableSchedule s = MakeSchedule("ROOTF", 1000 * COIN, 100 * COIN, 10, 100, true, 2000 * COIN);
+    std::string err;
+    BOOST_CHECK(!ApplyScheduleExtension(s, 0, 20, err));
+    BOOST_CHECK_EQUAL(s.nTotalQty, 1000 * COIN);
+
+    CMineableSchedule capped = MakeSchedule("ROOTF2", 1000 * COIN, 100 * COIN, 10, 100, true, 1100 * COIN);
+    BOOST_CHECK(!ApplyScheduleExtension(capped, 200 * COIN, 0, err));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_extension_hard_cap)
+{
+    CMineableSchedule s = MakeSchedule("ROOTG", 500 * COIN, 50 * COIN, 5, 100, true, 600 * COIN);
+    std::string err;
+    BOOST_CHECK(ApplyScheduleExtension(s, 100 * COIN, 0, err));
+    BOOST_CHECK_EQUAL(s.nTotalQty, 600 * COIN);
+    BOOST_CHECK(!ApplyScheduleExtension(s, 50 * COIN, 0, err));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_extension_not_editable_by_default)
+{
+    CMineableSchedule s = MakeSchedule("ROOTH", 500 * COIN, 50 * COIN, 5);
+    BOOST_CHECK(!s.fAllowExtension);
+    CMineableAssetsDB db(1 << 16, true, true);
+    db.WriteSchedule(s);
+
+    CReissueMineableSchedule reissue;
+    reissue.strMineableAsset = s.strMineableAsset;
+    reissue.nAddQty = 50 * COIN;
+    std::string err;
+    BOOST_CHECK(!ContextualCheckReissueMineableSchedule(nullptr, db, reissue, "", err));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_extension_pay_as_you_go)
+{
+    CMineableSchedule s = MakeSchedule("ROOTI", 500 * COIN, 50 * COIN, 5, 100, true, 2000 * COIN);
+    CAmount first = CalculateMineableExtensionCost(s, 100 * COIN, 0);
+    std::string err;
+    ApplyScheduleExtension(s, 100 * COIN, 0, err);
+    CAmount second = CalculateMineableExtensionCost(s, 150 * COIN, 0);
+    BOOST_CHECK_EQUAL(first, 2 * MINEABLE_COST_PER_PERIOD);
+    BOOST_CHECK_EQUAL(second, 3 * MINEABLE_COST_PER_PERIOD);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_db_persistence_restart)
+{
+    CMineableSchedule s = MakeSchedule("ROOTJ", 800 * COIN, 80 * COIN, 8, 50, true, 1600 * COIN);
+    s.nMaturedPeriods = 3;
+    s.nClaimedPeriods = 1;
+
+    CMineableAssetsDB db(1 << 16, true, true);
+    BOOST_CHECK(db.WriteSchedule(s));
+    db.Flush();
+
+    CMineableSchedule loaded;
+    BOOST_CHECK(db.ReadSchedule(s.strMineableAsset, loaded));
+    BOOST_CHECK_EQUAL(loaded.nTotalQty, s.nTotalQty);
+    BOOST_CHECK_EQUAL(loaded.nMaturedPeriods, 3);
+    BOOST_CHECK_EQUAL(loaded.nClaimedPeriods, 1);
+    BOOST_CHECK(loaded.fAllowExtension);
+    BOOST_CHECK_EQUAL(loaded.nMaxTotalQty, 1600 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_coinbase_claim_validation)
+{
+    SetMineableAssetsActive(true);
+    CMineableSchedule s = MakeSchedule("ROOTK", 300 * COIN, 100 * COIN, 5, chainActive.Height());
+    RegisterScheduleOnChain(s);
+
+    const int h = chainActive.Height() + 1;
+    ProcessMineableMaturityAtHeight(h, *pmineabledb);
+
+    CMineableSchedule updated;
+    pmineabledb->ReadSchedule(s.strMineableAsset, updated);
+    updated.UpdateMaturity(h);
+    const CAmount accrued = updated.GetAccruedAmount();
+    BOOST_CHECK(accrued > 0);
+
+    CMutableTransaction coinbase;
+    coinbase.vin.emplace_back(COutPoint(uint256S("00"), 0));
+    CKey key;
+    key.MakeNewKey(true);
+    CScript miner = MinerScript(key);
+    CAssetTransfer claim(s.strMineableAsset, accrued);
+    CScript claimScript = miner;
+    claim.ConstructTransaction(claimScript);
+    coinbase.vout.emplace_back(0, claimScript);
+
+    CValidationState state;
+    BOOST_CHECK(ValidateMineableCoinbaseClaims(coinbase, h, passets, *pmineabledb, state));
+
+    CAssetTransfer badClaim(s.strMineableAsset, accrued - COIN);
+    CMutableTransaction badCoinbase;
+    badCoinbase.vin.emplace_back(COutPoint(uint256S("01"), 0));
+    CScript badScript = miner;
+    badClaim.ConstructTransaction(badScript);
+    badCoinbase.vout.emplace_back(0, badScript);
+    CValidationState badState;
+    BOOST_CHECK(!ValidateMineableCoinbaseClaims(badCoinbase, h, passets, *pmineabledb, badState));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_coinbase_duplicate_miner_claim)
+{
+    SetMineableAssetsActive(true);
+    CMineableSchedule s = MakeSchedule("DUPD", 200 * COIN, 100 * COIN, 2, chainActive.Height());
+    RegisterScheduleOnChain(s);
+    const int h = chainActive.Height() + 1;
+    ProcessMineableMaturityAtHeight(h, *pmineabledb);
+
+    CMineableSchedule updated;
+    pmineabledb->ReadSchedule(s.strMineableAsset, updated);
+    updated.UpdateMaturity(h);
+    const CAmount amt = updated.GetAccruedAmount();
+
+    CKey key;
+    key.MakeNewKey(true);
+    CScript miner = MinerScript(key);
+    CMutableTransaction coinbase;
+    coinbase.vin.emplace_back(COutPoint(uint256S("02"), 0));
+    for (int i = 0; i < 2; ++i) {
+        CAssetTransfer claim(s.strMineableAsset, amt / 2);
+        CScript claimScript = miner;
+        claim.ConstructTransaction(claimScript);
+        coinbase.vout.emplace_back(0, claimScript);
+    }
+    CValidationState state;
+    BOOST_CHECK(!ValidateMineableCoinbaseClaims(coinbase, h, passets, *pmineabledb, state));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_coinbase_zero_accrued_rejected)
+{
+    SetMineableAssetsActive(true);
+    CMineableSchedule s = MakeSchedule("ZERO", 100 * COIN, 50 * COIN, 50, chainActive.Height() + 100);
+    RegisterScheduleOnChain(s);
+    const int h = chainActive.Height() + 1;
+
+    CKey key;
+    key.MakeNewKey(true);
+    CScript miner = MinerScript(key);
+    CMutableTransaction coinbase;
+    coinbase.vin.emplace_back(COutPoint(uint256S("03"), 0));
+    CAssetTransfer claim(s.strMineableAsset, 50 * COIN);
+    CScript claimScript = miner;
+    claim.ConstructTransaction(claimScript);
+    coinbase.vout.emplace_back(0, claimScript);
+
+    CValidationState state;
+    BOOST_CHECK(!ValidateMineableCoinbaseClaims(coinbase, h, passets, *pmineabledb, state));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_reissue_script_roundtrip)
+{
+    CReissueMineableSchedule reissue;
+    reissue.strMineableAsset = "&ROUND";
+    reissue.nAddQty = 100 * COIN;
+    reissue.nNewNthBlock = 2;
+
+    CScript dest = GetScriptForDestination(DecodeDestination(GetParams().GlobalBurnAddress()));
+    reissue.ConstructTransaction(dest);
+    BOOST_CHECK(dest.IsReissueMineableAsset());
+
+    CReissueMineableSchedule parsed;
+    std::string address;
+    BOOST_CHECK(ReissueMineableFromScript(dest, parsed, address));
+    BOOST_CHECK_EQUAL(parsed.strMineableAsset, reissue.strMineableAsset);
+    BOOST_CHECK_EQUAL(parsed.nAddQty, reissue.nAddQty);
+    BOOST_CHECK_EQUAL(parsed.nNewNthBlock, reissue.nNewNthBlock);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_issue_fixed_cap_default)
+{
+    CIssueMineable issue;
+    issue.strRootAsset = "CAPROOT";
+    issue.strMineableAsset = MineableAssetNameFromRoot(issue.strRootAsset);
+    issue.nTotalQty = 500 * COIN;
+    issue.nPerBlock = 50 * COIN;
+    issue.nNthBlock = 5;
+    issue.nUnits = 0;
+    issue.fAllowExtension = false;
+    issue.nMaxTotalQty = 0;
+
+    std::string err;
+    BOOST_CHECK(CheckIssueMineable(issue, err));
+
+    CMineableSchedule sched;
+    sched.nMaxTotalQty = issue.nTotalQty;
+    BOOST_CHECK_EQUAL(sched.nMaxTotalQty, 500 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_issue_burn_validation)
+{
+    SetMineableAssetsActive(true);
+    SelectParams(CBaseChainParams::REGTEST);
+
+    CIssueMineable issue;
+    issue.strRootAsset = "BURNROOT";
+    issue.strMineableAsset = MineableAssetNameFromRoot(issue.strRootAsset);
+    issue.nTotalQty = 1000 * COIN;
+    issue.nPerBlock = 100 * COIN;
+    issue.nNthBlock = 10;
+    issue.nUnits = 0;
+
+    CNewAsset root(issue.strRootAsset, 1 * COIN, 0, 1, 0, "");
+    BOOST_REQUIRE(passets->AddNewAsset(root, GetParams().GlobalBurnAddress(), 1, uint256()));
+
+    std::string err;
+    BOOST_CHECK(CheckIssueMineable(issue, err));
+
+    CMutableTransaction tx;
+    const CAmount burn = CalculateMineableIssuanceCost(issue);
+    tx.vout.emplace_back(burn, GetScriptForDestination(
+        DecodeDestination(GetParams().IssueAssetBurnAddress())));
+    CScript dest = GetScriptForDestination(DecodeDestination(GetParams().GlobalBurnAddress()));
+    issue.ConstructTransaction(dest);
+    tx.vout.emplace_back(0, dest);
+
+    CTransaction ctx(tx);
+    BOOST_CHECK(ctx.VerifyIssueMineable(err));
+
+    tx.vout[0].nValue = burn - COIN;
+    CTransaction badTx(tx);
+    BOOST_CHECK(!badTx.VerifyIssueMineable(err));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_reissue_burn_validation)
+{
+    SetMineableAssetsActive(true);
+    CMineableSchedule s = MakeSchedule("BURNEXT", 500 * COIN, 50 * COIN, 7, 10, true, 1000 * COIN);
+    RegisterScheduleOnChain(s);
+
+    CReissueMineableSchedule reissue;
+    reissue.strMineableAsset = s.strMineableAsset;
+    reissue.nAddQty = 100 * COIN;
+    const CAmount burn = CalculateMineableExtensionCost(s, reissue.nAddQty, 0);
+
+    CScript dest = GetScriptForDestination(DecodeDestination(GetParams().GlobalBurnAddress()));
+    CMutableTransaction tx = BuildReissueMineableTx(reissue, burn, dest);
+    CTransaction ctx(tx);
+    std::string err;
+    BOOST_CHECK(ctx.VerifyReissueMineable(err));
+
+    tx.vout[0].nValue = burn + COIN;
+    CTransaction badTx(tx);
+    BOOST_CHECK(!badTx.VerifyReissueMineable(err));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(mineable_chain_tests, TestChain100Setup)
+
+BOOST_AUTO_TEST_CASE(mineable_chain_mine_and_claim)
+{
+    SetMineableAssetsActive(true);
+    const int base = chainActive.Height();
+    CMineableSchedule s = MakeSchedule("CHAIN1", 400 * COIN, 100 * COIN, 4, base + 1);
+    RegisterScheduleOnChain(s);
+
+    CScript miner = MinerScript(coinbaseKey);
+    for (int i = 0; i < 5; ++i)
+        CreateAndProcessBlock({}, miner);
+
+    CMineableSchedule live;
+    pmineabledb->ReadSchedule(s.strMineableAsset, live);
+    live.UpdateMaturity(chainActive.Height());
+    const CAmount accrued = live.GetAccruedAmount();
+    BOOST_CHECK(accrued >= 100 * COIN);
+
+    std::map<std::string, CAmount> claims;
+    claims[s.strMineableAsset] = accrued;
+    CreateAndProcessBlockWithMineableClaims({}, miner, claims);
+
+    CMineableSchedule claimed;
+    pmineabledb->ReadSchedule(s.strMineableAsset, claimed);
+    BOOST_CHECK(claimed.nClaimedPeriods > 0);
+    BOOST_CHECK(claimed.nTotalMinted >= accrued);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_chain_delayed_claim_full_accrual)
+{
+    SetMineableAssetsActive(true);
+    const int base = chainActive.Height();
+    CMineableSchedule s = MakeSchedule("CHAIN2", 600 * COIN, 100 * COIN, 3, base + 1);
+    RegisterScheduleOnChain(s);
+
+    CScript miner = MinerScript(coinbaseKey);
+    for (int i = 0; i < 8; ++i)
+        CreateAndProcessBlock({}, miner);
+
+    CMineableSchedule live;
+    pmineabledb->ReadSchedule(s.strMineableAsset, live);
+    live.UpdateMaturity(chainActive.Height());
+    const CAmount fullAccrued = live.GetAccruedAmount();
+    BOOST_CHECK(fullAccrued >= 200 * COIN);
+
+    CreateAndProcessBlock({}, miner);
+    std::map<std::string, CAmount> claims;
+    claims[s.strMineableAsset] = fullAccrued;
+    CreateAndProcessBlockWithMineableClaims({}, miner, claims);
+
+    CMineableSchedule claimed;
+    pmineabledb->ReadSchedule(s.strMineableAsset, claimed);
+    BOOST_CHECK_EQUAL(claimed.nClaimedPeriods, claimed.nMaturedPeriods);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_chain_spend_after_claim)
+{
+    SetMineableAssetsActive(true);
+    const int base = chainActive.Height();
+    CMineableSchedule s = MakeSchedule("CHAIN3", 200 * COIN, 100 * COIN, 2, base + 1);
+    RegisterScheduleOnChain(s);
+
+    CScript miner = MinerScript(coinbaseKey);
+    for (int i = 0; i < 4; ++i)
+        CreateAndProcessBlock({}, miner);
+
+    CMineableSchedule live;
+    pmineabledb->ReadSchedule(s.strMineableAsset, live);
+    live.UpdateMaturity(chainActive.Height());
+    const CAmount accrued = live.GetAccruedAmount();
+
+    std::map<std::string, CAmount> claims;
+    claims[s.strMineableAsset] = accrued;
+    CreateAndProcessBlockWithMineableClaims({}, miner, claims);
+
+    passets->Clear();
+    CValidationState state;
+    ActivateBestChain(state, GetParams());
+
+    CMineableSchedule after;
+    pmineabledb->ReadSchedule(s.strMineableAsset, after);
+    BOOST_CHECK(after.nTotalMinted >= accrued);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_chain_many_assets_one_block)
+{
+    SetMineableAssetsActive(true);
+    const int base = chainActive.Height();
+    const char* roots[] = {"MULTI1", "MULTI2", "MULTI3", "MULTI4", "MULTI5"};
+    std::map<std::string, CAmount> claims;
+    CScript miner = MinerScript(coinbaseKey);
+
+    for (const char* root : roots) {
+        CMineableSchedule s = MakeSchedule(root, 200 * COIN, 50 * COIN, 2, base + 1);
+        RegisterScheduleOnChain(s);
+    }
+
+    for (int i = 0; i < 6; ++i)
+        CreateAndProcessBlock({}, miner);
+
+    for (const char* root : roots) {
+        const std::string asset = MineableAssetNameFromRoot(root);
+        CMineableSchedule live;
+        pmineabledb->ReadSchedule(asset, live);
+        live.UpdateMaturity(chainActive.Height());
+        claims[asset] = live.GetAccruedAmount();
+    }
+
+    CreateAndProcessBlockWithMineableClaims({}, miner, claims);
+
+    for (const char* root : roots) {
+        CMineableSchedule claimed;
+        pmineabledb->ReadSchedule(MineableAssetNameFromRoot(root), claimed);
+        BOOST_CHECK(claimed.nTotalMinted > 0);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(mineable_chain_extend_schedule_on_chain)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const std::string root = H.IssueRootAndMineableOnChain(500 * COIN, 50 * COIN, 10, true, 1000 * COIN);
+    const std::string asset = MineableAssetNameFromRoot(root);
+
+    CReissueMineableSchedule reissue;
+    reissue.strMineableAsset = asset;
+    reissue.nAddQty = 150 * COIN;
+    reissue.nNewNthBlock = 5;
+    H.ReissueOnChain(root, reissue);
+
+    CMineableSchedule extended;
+    pmineabledb->ReadSchedule(asset, extended);
+    BOOST_CHECK_EQUAL(extended.nTotalQty, 650 * COIN);
+    BOOST_CHECK_EQUAL(extended.nNthBlock, 5);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_chain_extend_prime_nth_one_recost)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const std::string root = H.IssueRootAndMineableOnChain(700 * COIN, 100 * COIN, 7, true, 1400 * COIN);
+    const std::string asset = MineableAssetNameFromRoot(root);
+
+    CReissueMineableSchedule reissue;
+    reissue.strMineableAsset = asset;
+    reissue.nAddQty = 0;
+    reissue.nNewNthBlock = 1;
+    H.ReissueOnChain(root, reissue);
+
+    CMineableSchedule extended;
+    pmineabledb->ReadSchedule(asset, extended);
+    BOOST_CHECK_EQUAL(extended.nNthBlock, 1);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_chain_reject_extend_when_fixed)
+{
+    SetMineableAssetsActive(true);
+    CMineableSchedule s = MakeSchedule("FIXED1", 300 * COIN, 50 * COIN, 5, chainActive.Height() + 1);
+    RegisterScheduleOnChain(s);
+
+    CReissueMineableSchedule reissue;
+    reissue.strMineableAsset = s.strMineableAsset;
+    reissue.nAddQty = 50 * COIN;
+
+    std::string err;
+    BOOST_CHECK(!ContextualCheckReissueMineableSchedule(passets, *pmineabledb, reissue,
+        EncodeDestination(coinbaseKey.GetPubKey().GetID()), err));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_reissue_requires_owner_token)
+{
+    SetMineableAssetsActive(true);
+    CMineableSchedule s = MakeSchedule("OWNCHK", 500 * COIN, 50 * COIN, 5, 10, true, 1000 * COIN);
+    RegisterScheduleOnChain(s);
+
+    CReissueMineableSchedule reissue;
+    reissue.strMineableAsset = s.strMineableAsset;
+    reissue.nAddQty = 50 * COIN;
+
+    std::string err;
+    const std::string notOwner = GetParams().GlobalBurnAddress();
+    BOOST_CHECK(!ContextualCheckReissueMineableSchedule(passets, *pmineabledb, reissue, notOwner, err));
+
+    passets->mapAssetsAddressAmount[std::make_pair(s.strRootAsset + OWNER_TAG, notOwner)] = OWNER_ASSET_AMOUNT;
+    BOOST_CHECK(ContextualCheckReissueMineableSchedule(passets, *pmineabledb, reissue, notOwner, err));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_stress_many_schedules_maturity)
+{
+    SetMineableAssetsActive(true);
+    const int base = chainActive.Height();
+    const int count = 20;
+    CScript miner = MinerScript(coinbaseKey);
+
+    for (int i = 0; i < count; ++i) {
+        const std::string root = "STRESS" + std::to_string(i);
+        CMineableSchedule s = MakeSchedule(root, 100 * COIN, 10 * COIN, 2, base + 1, i % 2 == 0, 200 * COIN);
+        RegisterScheduleOnChain(s);
+    }
+
+    for (int i = 0; i < 10; ++i)
+        CreateAndProcessBlock({}, miner);
+
+    std::vector<CMineableSchedule> all;
+    pmineabledb->ListSchedules(all);
+    BOOST_CHECK(static_cast<int>(all.size()) >= count);
+
+    int matured = 0;
+    for (const auto& sch : all) {
+        CMineableSchedule copy = sch;
+        copy.UpdateMaturity(chainActive.Height());
+        if (copy.nMaturedPeriods > 0)
+            ++matured;
+    }
+    BOOST_CHECK(matured >= count / 2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_FIXTURE_TEST_SUITE(mineable_e2e_tests, TestChain100Setup)
+
+BOOST_AUTO_TEST_CASE(mineable_e2e_issue_root_and_mineable_on_chain)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const std::string root = H.NextRootName();
+    H.IssueRootOnChain(root);
+    CIssueMineable issue = H.DefaultIssueParams(root, 400 * COIN, 100 * COIN, 4);
+    H.IssueMineableOnChain(issue);
+
+    CMineableSchedule sched;
+    BOOST_CHECK(pmineabledb->ReadSchedule(MineableAssetNameFromRoot(root), sched));
+    BOOST_CHECK(sched.fActive);
+    BOOST_CHECK_EQUAL(sched.nTotalQty, 400 * COIN);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_e2e_full_mint_mine_claim)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const std::string root = H.IssueRootAndMineableOnChain(400 * COIN, 100 * COIN, 4);
+    const std::string asset = MineableAssetNameFromRoot(root);
+
+    H.MineBlocks(5);
+    BOOST_CHECK(H.AccruedForAsset(asset) >= 100 * COIN);
+    H.ClaimAsset(asset);
+
+    CMineableSchedule claimed;
+    pmineabledb->ReadSchedule(asset, claimed);
+    BOOST_CHECK(claimed.nTotalMinted >= 100 * COIN);
+    BOOST_CHECK(claimed.nClaimedPeriods > 0);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_e2e_enumerated_assets_sequential_mint)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const int count = 8;
+    std::vector<std::string> assets;
+
+    for (int i = 0; i < count; ++i) {
+        const std::string root = H.IssueRootAndMineableOnChain(200 * COIN, 50 * COIN, 2);
+        assets.push_back(MineableAssetNameFromRoot(root));
+    }
+
+    H.MineBlocks(6);
+    std::map<std::string, CAmount> claims;
+    for (const auto& asset : assets) {
+        const CAmount amt = H.AccruedForAsset(asset);
+        if (amt > 0)
+            claims[asset] = amt;
+    }
+    BOOST_CHECK(static_cast<int>(claims.size()) >= count - 1);
+    CreateAndProcessBlockWithMineableClaims({}, H.miner, claims);
+
+    for (const auto& asset : assets) {
+        CMineableSchedule s;
+        pmineabledb->ReadSchedule(asset, s);
+        BOOST_CHECK(s.nTotalMinted > 0);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(mineable_e2e_payg_extend_while_mining)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const std::string root = H.IssueRootAndMineableOnChain(300 * COIN, 50 * COIN, 5, true, 800 * COIN);
+    const std::string asset = MineableAssetNameFromRoot(root);
+
+    H.MineBlocks(3);
+    CReissueMineableSchedule ext;
+    ext.strMineableAsset = asset;
+    ext.nAddQty = 100 * COIN;
+    H.ReissueOnChain(root, ext);
+
+    CMineableSchedule extended;
+    pmineabledb->ReadSchedule(asset, extended);
+    BOOST_CHECK_EQUAL(extended.nTotalQty, 400 * COIN);
+
+    H.MineBlocks(4);
+    H.ClaimAsset(asset);
+    pmineabledb->ReadSchedule(asset, extended);
+    BOOST_CHECK(extended.nTotalMinted > 0);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_e2e_reissue_owner_signed_on_chain)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const std::string root = H.IssueRootAndMineableOnChain(500 * COIN, 50 * COIN, 10, true, 1000 * COIN);
+    const std::string asset = MineableAssetNameFromRoot(root);
+
+    CReissueMineableSchedule reissue;
+    reissue.strMineableAsset = asset;
+    reissue.nAddQty = 100 * COIN;
+    reissue.nNewNthBlock = 5;
+    H.ReissueOnChain(root, reissue);
+
+    CMineableSchedule s;
+    pmineabledb->ReadSchedule(asset, s);
+    BOOST_CHECK_EQUAL(s.nTotalQty, 600 * COIN);
+    BOOST_CHECK_EQUAL(s.nNthBlock, 5);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_e2e_prime_nth_one_with_owner_burn)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const std::string root = H.IssueRootAndMineableOnChain(700 * COIN, 100 * COIN, 7, true, 1400 * COIN);
+    const std::string asset = MineableAssetNameFromRoot(root);
+
+    CReissueMineableSchedule reissue;
+    reissue.strMineableAsset = asset;
+    reissue.nNewNthBlock = 1;
+    H.ReissueOnChain(root, reissue);
+
+    CMineableSchedule s;
+    pmineabledb->ReadSchedule(asset, s);
+    BOOST_CHECK_EQUAL(s.nNthBlock, 1);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_e2e_reject_reissue_non_owner)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const std::string root = H.IssueRootAndMineableOnChain(300 * COIN, 50 * COIN, 5, true, 600 * COIN);
+    const std::string asset = MineableAssetNameFromRoot(root);
+
+    CReissueMineableSchedule reissue;
+    reissue.strMineableAsset = asset;
+    reissue.nAddQty = 50 * COIN;
+
+    std::string err;
+    const std::string stranger = GetParams().GlobalBurnAddress();
+    BOOST_CHECK(!ContextualCheckReissueMineableSchedule(passets, *pmineabledb, reissue, stranger, err));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_e2e_multi_extend_up_to_cap)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const std::string root = H.IssueRootAndMineableOnChain(200 * COIN, 50 * COIN, 4, true, 500 * COIN);
+    const std::string asset = MineableAssetNameFromRoot(root);
+
+    for (int i = 0; i < 3; ++i) {
+        CReissueMineableSchedule ext;
+        ext.strMineableAsset = asset;
+        ext.nAddQty = 50 * COIN;
+        H.ReissueOnChain(root, ext);
+    }
+
+    CMineableSchedule s;
+    pmineabledb->ReadSchedule(asset, s);
+    BOOST_CHECK_EQUAL(s.nTotalQty, 350 * COIN);
+
+    CReissueMineableSchedule tooMuch;
+    tooMuch.strMineableAsset = asset;
+    tooMuch.nAddQty = 200 * COIN;
+    std::string err;
+    BOOST_CHECK(!ContextualCheckReissueMineableSchedule(passets, *pmineabledb, tooMuch,
+        EncodeDestination(coinbaseKey.GetPubKey().GetID()), err));
+}
+
+BOOST_AUTO_TEST_CASE(mineable_e2e_stress_enumerated_mine_loop)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const int rounds = 5;
+    const int perRound = 4;
+
+    for (int r = 0; r < rounds; ++r) {
+        std::vector<std::string> batch;
+        for (int i = 0; i < perRound; ++i)
+            batch.push_back(MineableAssetNameFromRoot(H.IssueRootAndMineableOnChain(100 * COIN, 25 * COIN, 2, r % 2 == 0, 300 * COIN)));
+
+        H.MineBlocks(3);
+        std::map<std::string, CAmount> claims;
+        for (const auto& asset : batch) {
+            const CAmount amt = H.AccruedForAsset(asset);
+            if (amt > 0)
+                claims[asset] = amt;
+        }
+        if (!claims.empty())
+            CreateAndProcessBlockWithMineableClaims({}, H.miner, claims);
+    }
+
+    std::vector<CMineableSchedule> all;
+    pmineabledb->ListSchedules(all);
+    BOOST_CHECK(static_cast<int>(all.size()) >= rounds * perRound);
+
+    int withMint = 0;
+    for (const auto& s : all) {
+        if (s.nTotalMinted > 0)
+            ++withMint;
+    }
+    BOOST_CHECK(withMint >= rounds);
+}
+
+BOOST_AUTO_TEST_CASE(mineable_e2e_verify_issue_tx_before_block)
+{
+    SetMineableAssetsActive(true);
+    MineableChainHelper H(*this);
+    const std::string root = H.NextRootName();
+    H.IssueRootOnChain(root);
+    CIssueMineable issue = H.DefaultIssueParams(root, 1000 * COIN, 100 * COIN, 10);
+    CMutableTransaction mtx = H.BuildIssueMineableTx(issue);
+    CTransaction tx(mtx);
+    std::string err;
+    BOOST_CHECK(tx.VerifyIssueMineable(err));
+    H.IssueMineableOnChain(issue);
+    CMineableSchedule sched;
+    BOOST_CHECK(pmineabledb->ReadSchedule(issue.strMineableAsset, sched));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_raven.cpp
+++ b/src/test/test_raven.cpp
@@ -11,6 +11,10 @@
 #include "fs.h"
 #include "key.h"
 #include "validation.h"
+#include "assets/mineabledb.h"
+#include "assets/assets.h"
+#include "assets/assetdb.h"
+#include "assets/restricteddb.h"
 #include "miner.h"
 #include "net_processing.h"
 #include "pubkey.h"
@@ -22,7 +26,9 @@
 #include "rpc/server.h"
 #include "rpc/register.h"
 #include "script/sigcache.h"
+#include "assets/mineable.h"
 
+#include <map>
 #include <memory>
 
 uint256 insecure_rand_seed = GetRandHash();
@@ -79,6 +85,9 @@ TestingSetup::TestingSetup(const std::string &chainName) : BasicTestingSetup(cha
     }
 
     passets = new CAssetsCache();
+    pmineabledb = new CMineableAssetsDB(1 << 20, true, true);
+    passetsdb = new CAssetsDB(1 << 20, true, true);
+    prestricteddb = new CRestrictedDB(1 << 20, true, true);
     {
         CValidationState state;
         if (!ActivateBestChain(state, chainparams))
@@ -107,6 +116,12 @@ TestingSetup::~TestingSetup()
     delete pcoinsdbview;
     delete pblocktree;
     delete passets;
+    delete pmineabledb;
+    pmineabledb = nullptr;
+    delete passetsdb;
+    passetsdb = nullptr;
+    delete prestricteddb;
+    prestricteddb = nullptr;
     fs::remove_all(pathTemp);
 }
 
@@ -151,6 +166,41 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction> 
 
     CBlock result = block;
     return result;
+}
+
+CBlock
+TestChain100Setup::CreateAndProcessBlockWithMineableClaims(const std::vector<CMutableTransaction> &txns,
+                                                           const CScript &scriptPubKey,
+                                                           const std::map<std::string, CAmount> &mineableClaims)
+{
+    const CChainParams &chainparams = GetParams();
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
+    CBlock &block = pblocktemplate->block;
+
+    block.vtx.resize(1);
+    for (const CMutableTransaction &tx : txns)
+        block.vtx.push_back(MakeTransactionRef(tx));
+
+    CMutableTransaction coinbase = *block.vtx[0];
+    for (const auto& claim : mineableClaims) {
+        CAssetTransfer transfer(claim.first, claim.second);
+        CScript claimScript = scriptPubKey;
+        transfer.ConstructTransaction(claimScript);
+        coinbase.vout.emplace_back(0, claimScript);
+    }
+    block.vtx[0] = MakeTransactionRef(coinbase);
+
+    unsigned int extraNonce = 0;
+    IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
+
+    uint256 mix_hash;
+    while (!CheckProofOfWork(block.GetHashFull(mix_hash), block.nBits, chainparams.GetConsensus())) { ++block.nNonce64; ++block.nNonce;};
+    block.mix_hash = mix_hash;
+
+    std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
+    ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+
+    return block;
 }
 
 TestChain100Setup::~TestChain100Setup()

--- a/src/test/test_raven.h
+++ b/src/test/test_raven.h
@@ -15,6 +15,7 @@
 #include "txdb.h"
 #include "txmempool.h"
 
+#include <map>
 #include <boost/thread.hpp>
 
 extern uint256 insecure_rand_seed;
@@ -98,6 +99,11 @@ struct TestChain100Setup : public TestingSetup
     // scriptPubKey, and try to add it to the current chain.
     CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction> &txns,
                                  const CScript &scriptPubKey);
+
+    /** Same as CreateAndProcessBlock but appends mineable asset claim outputs to coinbase. */
+    CBlock CreateAndProcessBlockWithMineableClaims(const std::vector<CMutableTransaction> &txns,
+                                                   const CScript &scriptPubKey,
+                                                   const std::map<std::string, CAmount> &mineableClaims);
 
     ~TestChain100Setup();
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4,6 +4,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "assets/mineable.h"
+#include "assets/mineabledb.h"
 #include "validation.h"
 
 #include "arith_uint256.h"
@@ -253,6 +255,9 @@ CLRUCache<std::string, int8_t> *passetsQualifierCache = nullptr;
 CLRUCache<std::string, int8_t> *passetsRestrictionCache = nullptr;
 CLRUCache<std::string, int8_t> *passetsGlobalRestrictionCache = nullptr;
 CRestrictedDB *prestricteddb = nullptr;
+CMineableAssetsDB *pmineabledb = nullptr;
+
+static bool fMineableAssetsIsActive = false;
 
 enum FlushStateMode {
     FLUSH_STATE_NONE,
@@ -2514,10 +2519,25 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
 
     std::set<CMessage> setMessages;
     std::vector<std::pair<std::string, CNullAssetTxData>> myNullAssetData;
+
+    if (IsMineableAssetsDeployed() && pmineabledb) {
+        if (!ProcessMineableMaturityAtHeight(pindex->nHeight, *pmineabledb)) {
+            return state.DoS(100, error("%s: failed to process mineable maturity", __func__),
+                             REJECT_INVALID, "bad-mineable-maturity");
+        }
+    }
+
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         const CTransaction &tx = *(block.vtx[i]);
         const uint256 txhash = tx.GetHash();
+
+        if (i == 0 && IsMineableAssetsDeployed() && pmineabledb && assetsCache) {
+            if (!ValidateMineableCoinbaseClaims(tx, pindex->nHeight, assetsCache, *pmineabledb, state)) {
+                return state.DoS(100, error("%s: invalid mineable coinbase claims", __func__),
+                                 REJECT_INVALID, "bad-mineable-coinbase");
+            }
+        }
 
         nInputs += tx.vin.size();
 
@@ -2725,6 +2745,13 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
         /** RVN END */
 
         UpdateCoins(tx, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight, block.GetHash(), assetsCache, undoAssetData);
+
+        if (i == 0 && IsMineableAssetsDeployed() && pmineabledb && assetsCache) {
+            if (!ApplyMineableCoinbaseClaims(tx, pindex->nHeight, assetsCache, *pmineabledb)) {
+                return state.DoS(100, error("%s: failed to apply mineable coinbase claims", __func__),
+                                 REJECT_INVALID, "bad-mineable-apply");
+            }
+        }
 
         /** RVN START */
         if (!undoAssetData->first.empty()) {
@@ -5801,6 +5828,21 @@ void SetTransferOverflow(bool value) {
     fCheckTransferOverflowIsActive = value;
 }
 
+void SetMineableAssetsActive(bool value)
+{
+    fMineableAssetsIsActive = value;
+}
+
+void SetAssetsActive(bool value)
+{
+    fAssetsIsActive = value;
+}
+
+void SetRip5AssetsActive(bool value)
+{
+    fRip5IsActive = value;
+}
+
 bool AreEnforcedValuesDeployed()
 {
     if (fEnforcedValuesIsActive)
@@ -5903,6 +5945,18 @@ bool IsTransferOverflowCheckDeployed()
         fCheckTransferOverflowIsActive = true;
 
     return fCheckTransferOverflowIsActive;
+}
+
+bool IsMineableAssetsDeployed()
+{
+    if (fMineableAssetsIsActive)
+        return true;
+
+    const ThresholdState thresholdState = VersionBitsTipState(GetParams().GetConsensus(), Consensus::DEPLOYMENT_MINEABLE_ASSETS);
+    if (thresholdState == THRESHOLD_ACTIVE)
+        fMineableAssetsIsActive = true;
+
+    return fMineableAssetsIsActive;
 }
 
 CAssetsCache* GetCurrentAssetCache()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5828,6 +5828,11 @@ void SetTransferOverflow(bool value) {
     fCheckTransferOverflowIsActive = value;
 }
 
+void SetTransferScriptsSizeActive(bool value)
+{
+    fTransferScriptIsActive = value;
+}
+
 void SetMineableAssetsActive(bool value)
 {
     fMineableAssetsIsActive = value;

--- a/src/validation.h
+++ b/src/validation.h
@@ -55,6 +55,7 @@ class CTxUndo;
 struct ChainTxData;
 
 class CAssetsDB;
+class CMineableAssetsDB;
 class CAssets;
 class CSnapshotRequestDB;
 
@@ -534,6 +535,9 @@ extern CMyRestrictedDB *pmyrestricteddb;
 
 /** Global variable that points to the active restricted asset database (protected by cs_main) */
 extern CRestrictedDB *prestricteddb;
+extern CMineableAssetsDB *pmineabledb;
+
+bool IsMineableAssetsDeployed();
 
 /** Global variable that points to the asset verifier LRU Cache (protected by cs_main) */
 extern CLRUCache<std::string, CNullAssetTxVerifierString> *passetsVerifierCache;
@@ -605,6 +609,9 @@ bool IsTransferOverflowCheckDeployed();
 void SetEnforcedValues(bool value);
 void SetEnforcedCoinbase(bool value);
 void SetTransferOverflow(bool value);
+void SetMineableAssetsActive(bool value);
+void SetAssetsActive(bool value);
+void SetRip5AssetsActive(bool value);
 
 bool IsRip5Active();
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -609,6 +609,7 @@ bool IsTransferOverflowCheckDeployed();
 void SetEnforcedValues(bool value);
 void SetEnforcedCoinbase(bool value);
 void SetTransferOverflow(bool value);
+void SetTransferScriptsSizeActive(bool value);
 void SetMineableAssetsActive(bool value);
 void SetAssetsActive(bool value);
 void SetRip5AssetsActive(bool value);

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -38,6 +38,10 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
     {
         /*.name =*/ "transfer_overflow",
         /*.gbt_force =*/ true,
+     },
+    {
+        /*.name =*/ "mineable_assets",
+        /*.gbt_force =*/ true,
      }
 };
 


### PR DESCRIPTION
## Summary

- Adds **mineable assets** (`&NAME`) with block-accrual schedules, coinbase claims, and BIP9 `mineable_assets` deployment (version bit 12).
- Adds **additive `reissuemineable`** (`RVNE`): extend total quantity and optionally tighten `nth_block` with pay-as-you-go recost rules; hard cap via `nMaxTotalQty`; owner-token gated.
- Adds unit and chain regression coverage: dedicated `mineable_*` stress suite plus `asset_regression_*` matrix across standard, restricted, and mineable transaction types.

## Design notes

- Script tags: `RVNM` (issue mineable), `RVNE` (reissue mineable).
- Accrual bucket: `matured_periods - claimed_periods`; claims may lag maturity.
- Incompatible `nth_block` changes require reset to `nth=1` with recost = `remaining_periods × (old_nth - 1) × 1 RVN`.
- RIP draft: `doc/rip-mineable-assets.md`.

## Test plan

- [ ] `./src/test/test_raven --run_test=mineable_*`
- [ ] `./src/test/test_raven --run_test=asset_regression_*`
- [ ] Regtest activation of BIP9 mineable_assets bit
- [ ] Manual RPC: `issuemineable`, `reissuemineable`, mine + claim flow


Made with [Cursor](https://cursor.com)